### PR TITLE
(WIP) PLAT-11328: Prevent stale workflows from running forever

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/CamundaBpmnBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/CamundaBpmnBuilder.java
@@ -122,7 +122,7 @@ public class CamundaBpmnBuilder {
     String lastActivity = "";
     Map<String, String> parentActivities = new HashMap<>();
 
-    Map<String, AbstractFlowNodeBuilder<?, ?>> formExpirations = new HashMap<>();
+    Map<String, AbstractFlowNodeBuilder<?, ?>> activityExpirations = new HashMap<>();
     Map<String, AbstractFlowNodeBuilder<?, ?>> gateways = new HashMap<>();
     Map<String, Pair<BaseActivity, Event>> flowsToCreate = new HashMap<>();
 
@@ -130,13 +130,20 @@ public class CamundaBpmnBuilder {
     for (Activity activityContainer : workflow.getActivities()) {
       BaseActivity activity = activityContainer.getActivity();
 
-      builder = addIntermediateEvents(eventsToConnect, builder, lastActivity, activity, workflow);
+
+      if (onFormRepliedEvent(activity) || !hasTimeOut(activity)) {
+        // no intermediate events for activities with timeout which creates a subprocess
+        builder = addIntermediateEvents(eventsToConnect, builder, lastActivity, activity, workflow);
+      } else {
+        // set timeouts, formRepliedEvent activities timeout will be handled later
+        builder = setTimeoutIfExists(builder, activity, activityExpirations, workflow);
+      }
 
       // process events starting the activity
       if (onFormRepliedEvent(activity) && activity.getOn() != null) {
         checkParentIsKnown(parentActivities, workflow.getId(), activity.getId(),
             activity.getOn().getFormReplied().getFormId());
-        builder = formReply(builder, activity, formExpirations);
+        builder = formReply(builder, activity, activityExpirations);
       }
 
       // activity-failed events are handled as boundary error events
@@ -157,10 +164,10 @@ public class CamundaBpmnBuilder {
       if (onActivityExpired(activity) && activity.getOn() != null) {
         // add the activity as a form expiration
         AbstractFlowNodeBuilder<?, ?> formExpirationBuilder =
-            formExpirations.get(activity.getOn().getActivityExpired().getActivityId());
+            activityExpirations.get(activity.getOn().getActivityExpired().getActivityId());
         formExpirationBuilder = addTask(formExpirationBuilder, activity);
         // update it for the next activities
-        formExpirations.put(activity.getOn().getActivityExpired().getActivityId(), formExpirationBuilder);
+        activityExpirations.put(activity.getOn().getActivityExpired().getActivityId(), formExpirationBuilder);
 
       } else {
         // add the activity in the normal flow
@@ -281,7 +288,7 @@ public class CamundaBpmnBuilder {
     }
 
     // finish all subprocesses handling form replies
-    for (AbstractFlowNodeBuilder<?, ?> subProcessBuilder : formExpirations.values()) {
+    for (AbstractFlowNodeBuilder<?, ?> subProcessBuilder : activityExpirations.values()) {
       subProcessBuilder.endEvent().subProcessDone();
     }
 
@@ -494,6 +501,36 @@ public class CamundaBpmnBuilder {
           .name("formReply");
     }
     return builder;
+  }
+
+  private AbstractFlowNodeBuilder<?, ?> setTimeoutIfExists(AbstractFlowNodeBuilder<?, ?> builder,
+      BaseActivity activity, Map<String, AbstractFlowNodeBuilder<?, ?>> map, Workflow workflow) {
+
+    if (activity.getOn() != null && activity.getOn().getTimeout() != null) {
+      SubProcessBuilder subProcess = builder.subProcess();
+
+      AbstractFlowNodeBuilder<?, ?> expirationBuilder = subProcess.embeddedSubProcess()
+          .startEvent()
+          .intermediateCatchEvent().timerWithDuration(activity.getOn().getTimeout());
+      map.put(activity.getId(), expirationBuilder);
+
+      Optional<String> signalPrefix = this.eventToMessage.toSignalName(activity.getOn(), workflow);
+
+      if (signalPrefix.isPresent()) {
+        builder = subProcess.embeddedSubProcess().eventSubProcess()
+            .startEvent()
+            .camundaAsyncBefore()
+            .interrupting(false)
+            .signal(signalPrefix.get())
+            .name(signalPrefix.get());
+      }
+    }
+    return builder;
+  }
+
+  private boolean hasTimeOut(BaseActivity activity) {
+    List<Event> events = activity.getEvents();
+    return events.stream().anyMatch(e -> e.getTimeout() != null && !e.getTimeout().isEmpty());
   }
 
   private AbstractFlowNodeBuilder<?, ?> addTask(AbstractFlowNodeBuilder<?, ?> eventBuilder, BaseActivity activity)

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/FormReplyIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/FormReplyIntegrationTest.java
@@ -72,7 +72,7 @@ class FormReplyIntegrationTest extends IntegrationTest {
     // user 1 replies to form
     engine.onEvent(form("msgId", "sendForm", Collections.singletonMap("aField", "My message")));
 
-    // bot should send my reply back
+    // bot should send back my reply
     verify(messageService, timeout(5000)).send(eq("123"), contains("First reply: My message"));
     verify(messageService, timeout(5000)).send(eq("123"), contains("Second reply: My message"));
   }

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/custom/assertion/WorkflowAssert.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/custom/assertion/WorkflowAssert.java
@@ -14,6 +14,7 @@ import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 
 import org.apache.commons.io.IOUtils;
 import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
 import org.camunda.bpm.engine.history.HistoricActivityInstance;
 import org.camunda.bpm.engine.history.HistoricDetail;
 import org.camunda.bpm.engine.history.HistoricProcessInstance;
@@ -21,8 +22,11 @@ import org.camunda.bpm.engine.impl.persistence.entity.HistoricDetailVariableInst
 import org.mockito.ArgumentMatcher;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class WorkflowAssert extends AbstractAssert<WorkflowAssert, Workflow> {
   public WorkflowAssert(Workflow workflow) {
@@ -80,6 +84,12 @@ public class WorkflowAssert extends AbstractAssert<WorkflowAssert, Workflow> {
   public WorkflowAssert executed(String... activities) {
     isNotNull();
     assertExecuted(activities);
+    return this;
+  }
+
+  public WorkflowAssert notExecuted(String... activities) {
+    isNotNull();
+    assertNotExecuted(activities);
     return this;
   }
 
@@ -155,7 +165,7 @@ public class WorkflowAssert extends AbstractAssert<WorkflowAssert, Workflow> {
         .containsExactly(activities.toArray(String[]::new));
   }
 
-  private static void assertExecuted(String... activityIds) {
+  private static List<String> listExecutedActivities() {
     String process = lastProcess().orElseThrow();
     await().atMost(5, SECONDS).until(() -> processIsCompleted(process));
 
@@ -166,13 +176,23 @@ public class WorkflowAssert extends AbstractAssert<WorkflowAssert, Workflow> {
             .orderByActivityName().asc()
             .list();
 
-    org.assertj.core.api.Assertions.assertThat(processes)
-        .filteredOn(p -> !p.getActivityType().equals("signalStartEvent"))
-        .filteredOn(p -> !p.getActivityType().equals("exclusiveGateway"))
-        .filteredOn(p -> !p.getActivityType().equals("boundaryError"))
-        .filteredOn(p -> !p.isCanceled())
-        .extracting(HistoricActivityInstance::getActivityName)
-        .containsExactly(activityIds);
+    return processes.stream()
+        .filter(p -> !p.getActivityType().equals("signalStartEvent") && !p.getActivityType().equals("exclusiveGateway")
+            && !p.getActivityType().equals("boundaryError") && !p.isCanceled())
+        .map(HistoricActivityInstance::getActivityName)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+  }
+
+  private static void assertExecuted(String... activityIds) {
+    Assertions.assertThat(listExecutedActivities()).containsExactly(activityIds);
+  }
+
+  private static void assertNotExecuted(String... activityIds) {
+
+    Assertions.assertThat(Arrays.stream(activityIds)
+            .anyMatch(listExecutedActivities()::contains))
+        .isFalse();
   }
 
 

--- a/workflow-bot-app/src/test/resources/event/send-message-timeout.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/event/send-message-timeout.swadl.yaml
@@ -1,0 +1,18 @@
+id: send-message-timeout
+activities:
+  - execute-script:
+      id: startWorkflow
+      on:
+        message-received:
+          content: /start
+      script: |
+
+  - send-message:
+      id: sendMessageIfNotTimeout
+      content: Message to be sent if no timeout
+      to:
+        stream-id: "123"
+      on:
+        timeout: PT2S
+        message-received:
+          content: /continue

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/Event.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/Event.java
@@ -29,7 +29,7 @@ import java.util.List;
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Event {
-  private String timeout = "PT24H";
+  private String timeout;
 
   private List<Event> oneOf;
 


### PR DESCRIPTION
### Description
Every event starting an activity can define a timeout property. It will not be executed if it timeouts. This prevent stale workflows from running forever.
It is the responsibility of the workflow developer to set the timeout for activities.
Previously, the default timeout was set to 24h, this has been changed in this PR and no default value is set. Actually, the bpmn builder checks for the timeout property to set duration in the bpmn. The default value was removed so as the builder finds a null value and does not handle it. Otherwise, it would create a subprocess for each activity with duration of 24h.

### Checklist
- [ ] Referenced a ticket in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
