### PR TITLE
Stagging release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+# Release any branch to Maven Central.
+# This workflow currently assumes that the target branch is ready to be release (i.e. version is correct)
+
+name: Release
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  build:
+    name: "Release"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Configure signing
+        run: |
+          printf "$GPG_KEY_BASE64" | base64 --decode > secring.gpg
+        env:
+          GPG_KEY_BASE64: ${{ secrets.GPG_KEY_BASE64 }}
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gralde/wrapper
+            key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      # TODO: Only staging for now, it will be updated to closeAndReleaseRepository later
+      - name: Build with Gradle
+        run: |
+          mkdir -p ~/.gnupg/
+          printf "$GPG_KEY_BASE64" | base64 --decode > ~/.gnupg/secring.gpg
+          ./gradlew -PmavenRepoUsername=${{ secrets.MAVEN_USERNAME }} -PmavenRepoPassword=${{ secrets.MAVEN_PASSWORD }} -Psigning.keyId=${{ secrets.GPG_KEY_ID }} -Psigning.secretKeyRingFile=${{ github.workspace }}/secring.gpg -Psigning.password=${{ secrets.GPG_KEY_PASSPHRASE }} publish
+
+      - name: Cleanup Gradle Cache
+        # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
+        # Restoring these files from a GitHub Actions cache might cause problems for future builds.
+        run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties


### PR DESCRIPTION
### Description
Added release.yml file to release WDK at stagging level when a Github tag/release is created. After tests, this should be switched to closeAndReleaseRepository in order to do a real release.