### PR TITLE
Use closeAndReleaseRepository in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      # TODO: Only staging for now, it will be updated to closeAndReleaseRepository later
       - name: Build with Gradle
         run: |
           mkdir -p ~/.gnupg/
           printf "$GPG_KEY_BASE64" | base64 --decode > ~/.gnupg/secring.gpg
-          ./gradlew -PmavenRepoUsername=${{ secrets.MAVEN_USERNAME }} -PmavenRepoPassword=${{ secrets.MAVEN_PASSWORD }} -Psigning.keyId=${{ secrets.GPG_KEY_ID }} -Psigning.secretKeyRingFile=${{ github.workspace }}/secring.gpg -Psigning.password=${{ secrets.GPG_KEY_PASSPHRASE }} publish
+          ./gradlew -PmavenRepoUsername=${{ secrets.MAVEN_USERNAME }} -PmavenRepoPassword=${{ secrets.MAVEN_PASSWORD }} -Psigning.keyId=${{ secrets.GPG_KEY_ID }} -Psigning.secretKeyRingFile=${{ github.workspace }}/secring.gpg -Psigning.password=${{ secrets.GPG_KEY_PASSPHRASE }} publish closeAndReleaseRepository
 
       - name: Cleanup Gradle Cache
         # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.


### PR DESCRIPTION
release.yml was releasing on staging level for test. Now that it was tested, we put "closeAndReleaseRepository" for a closed release.

Staging Nexus Repository with 0.0.2-SNAPSHOT version used for test
![staging](https://user-images.githubusercontent.com/52406574/137336237-2f2fd5c5-f3f2-44e0-8dfc-55581cc17ea6.png)


