### PR TITLE
PLAT-11470 Support pin/unpin messages

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -806,16 +806,43 @@ encoded urls are accepted.
 Path to the file to be attached to the message. The path is relative to the workflows folder.
 
 ### update-message
-Update an existing message into a stream.
+Update an existing message into a stream. Returns the new updated message.
 
 Key | Type | Required |
 ------------ | -------| --- |
 [message-id](#update-message-id) | String | Yes |
 [content](#content) | String | Yes |
 
+Output | Type |
+----|----|
+message | [V4Message](https://javadoc.io/doc/org.finos.symphony.bdk/symphony-bdk-core/latest/com/symphony/bdk/gen/api/model/V4Message.html)
+msgId | String
+
 #### <a name="update-message-id"></a> message-id
 
 Message id of the message to be updated. Both url safe and base64 encoded urls are accepted
+
+### pin-message
+Pin an existing message into the stream it belongs to. It works for both Instant Messages and Rooms.
+
+Key | Type | Required |
+------------ | -------| --- |
+message-id | String | Yes |
+
+Depending on the stream type the activity will either call the
+[Update Room](https://developers.symphony.com/restapi/reference#update-room-v3) or the
+[Update IM](https://developers.symphony.com/restapi/v20.13/reference#update-im) endpoint.
+
+### unpin-message
+Unpin any message (if present) from an existing stream. It works for both Instant Messages and Rooms.
+
+Key | Type | Required |
+------------ | -------| --- |
+stream-id | String | Yes |
+
+Depending on the stream type the activity will either call the
+[Update Room](https://developers.symphony.com/restapi/reference#update-room-v3) or the
+[Update IM](https://developers.symphony.com/restapi/v20.13/reference#update-im) endpoint.
 
 ### get-message
 
@@ -874,7 +901,6 @@ Output | Type |
 attachmentPath | String
 
 [API reference](https://developers.symphony.com/restapi/reference#attachment) (Activity does not return the same outputs as the api response)
-
 
 ### create-room
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/PinMessageExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/PinMessageExecutor.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.workflow.engine.executor.message;
 
 import com.symphony.bdk.core.util.IdUtil;
+import com.symphony.bdk.gen.api.model.StreamType;
 import com.symphony.bdk.gen.api.model.V1IMAttributes;
 import com.symphony.bdk.gen.api.model.V3RoomAttributes;
 import com.symphony.bdk.gen.api.model.V4Message;
@@ -15,11 +16,12 @@ import java.io.IOException;
 @Slf4j
 public class PinMessageExecutor implements ActivityExecutor<PinMessage> {
 
-  public static final String IM = "IM";
-  public static final String ROOM = "ROOM";
+  public static final String IM = StreamType.TypeEnum.IM.getValue();
+  public static final String ROOM = StreamType.TypeEnum.ROOM.getValue();
 
   @Override
   public void execute(ActivityExecutorContext<PinMessage> execution) throws IOException {
+    // temporary workaround until BDK 2.4.1 is released
     String messageId = IdUtil.toUrlSafeIdIfNeeded(execution.getActivity().getMessageId());
 
     V4Message messageToPin = execution.bdk().messages().getMessage(messageId);
@@ -39,7 +41,9 @@ public class PinMessageExecutor implements ActivityExecutor<PinMessage> {
       log.debug("Pin message {} in Room {}", messageId, streamId);
       execution.bdk().streams().updateRoom(streamId, roomAttributes);
     } else {
-      log.warn("Unable to pin message {} with stream type {}", messageId, streamType);
+      throw new IllegalArgumentException(
+          String.format("Unable to pin message in stream type %s in activity %s", streamType,
+              execution.getActivity().getId()));
     }
   }
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/PinMessageExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/PinMessageExecutor.java
@@ -1,0 +1,45 @@
+package com.symphony.bdk.workflow.engine.executor.message;
+
+import com.symphony.bdk.core.util.IdUtil;
+import com.symphony.bdk.gen.api.model.V1IMAttributes;
+import com.symphony.bdk.gen.api.model.V3RoomAttributes;
+import com.symphony.bdk.gen.api.model.V4Message;
+import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
+import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
+import com.symphony.bdk.workflow.swadl.v1.activity.message.PinMessage;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+@Slf4j
+public class PinMessageExecutor implements ActivityExecutor<PinMessage> {
+
+  public static final String IM = "IM";
+  public static final String ROOM = "ROOM";
+
+  @Override
+  public void execute(ActivityExecutorContext<PinMessage> execution) throws IOException {
+    String messageId = IdUtil.toUrlSafeIdIfNeeded(execution.getActivity().getMessageId());
+
+    V4Message messageToPin = execution.bdk().messages().getMessage(messageId);
+    String streamId = IdUtil.toUrlSafeIdIfNeeded(messageToPin.getStream().getStreamId());
+    String streamType = messageToPin.getStream().getStreamType();
+
+    if (IM.equals(streamType)) {
+      V1IMAttributes imAttributes = new V1IMAttributes();
+      imAttributes.setPinnedMessageId(messageId);
+
+      log.debug("Pin message {} in IM {}", messageId, streamId);
+      execution.bdk().streams().updateInstantMessage(streamId, imAttributes);
+    } else if (ROOM.equals(streamType)) {
+      V3RoomAttributes roomAttributes = new V3RoomAttributes();
+      roomAttributes.setPinnedMessageId(messageId);
+
+      log.debug("Pin message {} in Room {}", messageId, streamId);
+      execution.bdk().streams().updateRoom(streamId, roomAttributes);
+    } else {
+      log.warn("Unable to pin message {} with stream type {}", messageId, streamType);
+    }
+  }
+}

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/UnpinMessageExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/UnpinMessageExecutor.java
@@ -20,6 +20,7 @@ public class UnpinMessageExecutor implements ActivityExecutor<UnpinMessage> {
 
   @Override
   public void execute(ActivityExecutorContext<UnpinMessage> execution) throws IOException {
+    // temporary workaround until BDK 2.4.1 is released
     String streamId = IdUtil.toUrlSafeIdIfNeeded(execution.getActivity().getStreamId());
 
     V2StreamAttributes stream = execution.bdk().streams().getStream(streamId);
@@ -40,7 +41,9 @@ public class UnpinMessageExecutor implements ActivityExecutor<UnpinMessage> {
       log.debug("Unpin message in Room {}", streamId);
       execution.bdk().streams().updateRoom(streamId, roomAttributes);
     } else {
-      log.warn("Unable to unpin message in stream {} with type {}", streamId, streamType);
+      throw new IllegalArgumentException(
+          String.format("Unable to unpin message in stream type %s in activity %s", streamType,
+              execution.getActivity().getId()));
     }
   }
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/UnpinMessageExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/UnpinMessageExecutor.java
@@ -1,0 +1,46 @@
+package com.symphony.bdk.workflow.engine.executor.message;
+
+import static com.symphony.bdk.workflow.engine.executor.message.PinMessageExecutor.IM;
+import static com.symphony.bdk.workflow.engine.executor.message.PinMessageExecutor.ROOM;
+
+import com.symphony.bdk.core.util.IdUtil;
+import com.symphony.bdk.gen.api.model.V1IMAttributes;
+import com.symphony.bdk.gen.api.model.V2StreamAttributes;
+import com.symphony.bdk.gen.api.model.V3RoomAttributes;
+import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
+import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
+import com.symphony.bdk.workflow.swadl.v1.activity.message.UnpinMessage;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+@Slf4j
+public class UnpinMessageExecutor implements ActivityExecutor<UnpinMessage> {
+
+  @Override
+  public void execute(ActivityExecutorContext<UnpinMessage> execution) throws IOException {
+    String streamId = IdUtil.toUrlSafeIdIfNeeded(execution.getActivity().getStreamId());
+
+    V2StreamAttributes stream = execution.bdk().streams().getStream(streamId);
+    String streamType = stream.getStreamType().getType();
+
+    if (IM.equals(streamType)) {
+
+      V1IMAttributes imAttributes = new V1IMAttributes();
+      imAttributes.setPinnedMessageId("");
+
+      log.debug("Unpin message in IM {}", streamId);
+      execution.bdk().streams().updateInstantMessage(streamId, imAttributes);
+    } else if (ROOM.equals(streamType)) {
+
+      V3RoomAttributes roomAttributes = new V3RoomAttributes();
+      roomAttributes.setPinnedMessageId("");
+
+      log.debug("Unpin message in Room {}", streamId);
+      execution.bdk().streams().updateRoom(streamId, roomAttributes);
+    } else {
+      log.warn("Unable to unpin message in stream {} with type {}", streamId, streamType);
+    }
+  }
+}

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/UpdateMessageExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/UpdateMessageExecutor.java
@@ -1,5 +1,8 @@
 package com.symphony.bdk.workflow.engine.executor.message;
 
+import static com.symphony.bdk.workflow.engine.executor.message.SendMessageExecutor.OUTPUT_MESSAGE_ID_KEY;
+import static com.symphony.bdk.workflow.engine.executor.message.SendMessageExecutor.OUTPUT_MESSAGE_KEY;
+
 import com.symphony.bdk.core.service.message.model.Message;
 import com.symphony.bdk.gen.api.model.V4Message;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
@@ -7,9 +10,6 @@ import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
 import com.symphony.bdk.workflow.swadl.v1.activity.message.UpdateMessage;
 
 import java.io.IOException;
-
-import static com.symphony.bdk.workflow.engine.executor.message.SendMessageExecutor.OUTPUT_MESSAGE_ID_KEY;
-import static com.symphony.bdk.workflow.engine.executor.message.SendMessageExecutor.OUTPUT_MESSAGE_KEY;
 
 public class UpdateMessageExecutor implements ActivityExecutor<UpdateMessage> {
 

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/PinUnpinMessageIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/PinUnpinMessageIntegrationTest.java
@@ -1,0 +1,170 @@
+package com.symphony.bdk.workflow;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.symphony.bdk.gen.api.model.V1IMAttributes;
+import com.symphony.bdk.gen.api.model.V2StreamAttributes;
+import com.symphony.bdk.gen.api.model.V2StreamType;
+import com.symphony.bdk.gen.api.model.V3RoomAttributes;
+import com.symphony.bdk.gen.api.model.V4Message;
+import com.symphony.bdk.gen.api.model.V4Stream;
+import com.symphony.bdk.workflow.custom.assertion.Assertions;
+import com.symphony.bdk.workflow.swadl.SwadlParser;
+import com.symphony.bdk.workflow.swadl.v1.Workflow;
+
+import com.github.fge.jsonschema.core.exceptions.ProcessingException;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+public class PinUnpinMessageIntegrationTest extends IntegrationTest {
+  private static final String MSG_ID = "MSG_ID";
+  private static final String STREAM_ID = "STREAM_ID";
+  private static final V4Message message = message(MSG_ID);
+
+  @Test
+  void pinMessageInIm() throws IOException, ProcessingException {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/message/pin-message.swadl.yaml"));
+
+    V4Stream stream = new V4Stream();
+    stream.setStreamType("IM");
+    stream.setStreamId(STREAM_ID);
+    message.setStream(stream);
+    when(messageService.getMessage(eq(MSG_ID))).thenReturn(message);
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/pin-message"));
+
+    Assertions.assertThat(workflow).isExecuted();
+    verify(streamService, times(1)).updateInstantMessage(eq(STREAM_ID), any(V1IMAttributes.class));
+    verify(streamService, times(0)).updateRoom(any(String.class), any(V3RoomAttributes.class));
+  }
+
+  @Test
+  void pinMessageInRoom() throws IOException, ProcessingException {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/message/pin-message.swadl.yaml"));
+
+    V4Stream stream = new V4Stream();
+    stream.setStreamType("ROOM");
+    stream.setStreamId(STREAM_ID);
+    message.setStream(stream);
+    when(messageService.getMessage(eq(MSG_ID))).thenReturn(message);
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/pin-message"));
+
+    Assertions.assertThat(workflow).isExecuted();
+    verify(streamService, times(0)).updateInstantMessage(any(String.class), any(V1IMAttributes.class));
+    verify(streamService, times(1)).updateRoom(eq(STREAM_ID), any(V3RoomAttributes.class));
+  }
+
+  @Test
+  void unpinMessageInIm() throws IOException, ProcessingException {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/message/unpin-message.swadl.yaml"));
+
+    V2StreamAttributes streamAttributes = new V2StreamAttributes();
+    V2StreamType streamType = new V2StreamType();
+    streamType.setType("IM");
+    streamAttributes.setStreamType(streamType);
+    when(streamService.getStream(eq(STREAM_ID))).thenReturn(streamAttributes);
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/unpin-message"));
+
+    Assertions.assertThat(workflow).isExecuted();
+    verify(streamService, times(1)).updateInstantMessage(eq(STREAM_ID), any(V1IMAttributes.class));
+    verify(streamService, times(0)).updateRoom(any(String.class), any(V3RoomAttributes.class));
+  }
+
+  @Test
+  void unpinMessageInRoom() throws IOException, ProcessingException {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/message/unpin-message.swadl.yaml"));
+
+    V2StreamAttributes streamAttributes = new V2StreamAttributes();
+    V2StreamType streamType = new V2StreamType();
+    streamType.setType("ROOM");
+    streamAttributes.setStreamType(streamType);
+    when(streamService.getStream(eq(STREAM_ID))).thenReturn(streamAttributes);
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/unpin-message"));
+
+    Assertions.assertThat(workflow).isExecuted();
+    verify(streamService, times(0)).updateInstantMessage(any(String.class), any(V1IMAttributes.class));
+    verify(streamService, times(1)).updateRoom(eq(STREAM_ID), any(V3RoomAttributes.class));
+  }
+
+  @Test
+  void pinMessageFailOnMessageId() throws IOException, ProcessingException {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/message/pin-message.swadl.yaml"));
+    when(messageService.getMessage(eq(MSG_ID))).thenThrow(new RuntimeException("Failure"));
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/pin-message"));
+
+    Assertions.assertThat(workflow).isExecuted();
+    verify(streamService, times(0)).updateInstantMessage(any(String.class), any(V1IMAttributes.class));
+    verify(streamService, times(0)).updateRoom(any(String.class), any(V3RoomAttributes.class));
+  }
+
+  @Test
+  void unpinMessageFailOnStreamId() throws IOException, ProcessingException {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/message/unpin-message.swadl.yaml"));
+    when(streamService.getStream(eq(STREAM_ID))).thenThrow(new RuntimeException("Failure"));
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/unpin-message"));
+
+    Assertions.assertThat(workflow).isExecuted();
+    verify(streamService, times(0)).updateInstantMessage(any(String.class), any(V1IMAttributes.class));
+    verify(streamService, times(0)).updateRoom(any(String.class), any(V3RoomAttributes.class));
+  }
+
+  @Test
+  void pinMessageOnInvalidStreamType() throws IOException, ProcessingException {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/message/pin-message.swadl.yaml"));
+
+    V4Stream stream = new V4Stream();
+    stream.setStreamType("POST");
+    stream.setStreamId(STREAM_ID);
+    message.setStream(stream);
+    when(messageService.getMessage(eq(MSG_ID))).thenReturn(message);
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/pin-message"));
+
+    Assertions.assertThat(workflow).isExecuted();
+    verify(streamService, times(0)).updateInstantMessage(any(String.class), any(V1IMAttributes.class));
+    verify(streamService, times(0)).updateRoom(any(String.class), any(V3RoomAttributes.class));
+  }
+
+  @Test
+  void unpinMessageOnInvalidStreamType() throws IOException, ProcessingException {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/message/unpin-message.swadl.yaml"));
+
+    V2StreamAttributes streamAttributes = new V2StreamAttributes();
+    V2StreamType streamType = new V2StreamType();
+    streamType.setType("POST");
+    streamAttributes.setStreamType(streamType);
+    when(streamService.getStream(eq(STREAM_ID))).thenReturn(streamAttributes);
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/unpin-message"));
+
+    Assertions.assertThat(workflow).isExecuted();
+    verify(streamService, times(0)).updateInstantMessage(any(String.class), any(V1IMAttributes.class));
+    verify(streamService, times(0)).updateRoom(any(String.class), any(V3RoomAttributes.class));
+  }
+}

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/PinUnpinMessageIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/PinUnpinMessageIntegrationTest.java
@@ -2,6 +2,7 @@ package com.symphony.bdk.workflow;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -42,7 +43,7 @@ public class PinUnpinMessageIntegrationTest extends IntegrationTest {
 
     Assertions.assertThat(workflow).isExecuted();
     verify(streamService, times(1)).updateInstantMessage(eq(STREAM_ID), any(V1IMAttributes.class));
-    verify(streamService, times(0)).updateRoom(any(String.class), any(V3RoomAttributes.class));
+    verify(streamService, never()).updateRoom(any(String.class), any(V3RoomAttributes.class));
   }
 
   @Test
@@ -60,7 +61,7 @@ public class PinUnpinMessageIntegrationTest extends IntegrationTest {
     engine.onEvent(messageReceived("/pin-message"));
 
     Assertions.assertThat(workflow).isExecuted();
-    verify(streamService, times(0)).updateInstantMessage(any(String.class), any(V1IMAttributes.class));
+    verify(streamService, never()).updateInstantMessage(any(String.class), any(V1IMAttributes.class));
     verify(streamService, times(1)).updateRoom(eq(STREAM_ID), any(V3RoomAttributes.class));
   }
 
@@ -80,7 +81,7 @@ public class PinUnpinMessageIntegrationTest extends IntegrationTest {
 
     Assertions.assertThat(workflow).isExecuted();
     verify(streamService, times(1)).updateInstantMessage(eq(STREAM_ID), any(V1IMAttributes.class));
-    verify(streamService, times(0)).updateRoom(any(String.class), any(V3RoomAttributes.class));
+    verify(streamService, never()).updateRoom(any(String.class), any(V3RoomAttributes.class));
   }
 
   @Test
@@ -98,7 +99,7 @@ public class PinUnpinMessageIntegrationTest extends IntegrationTest {
     engine.onEvent(messageReceived("/unpin-message"));
 
     Assertions.assertThat(workflow).isExecuted();
-    verify(streamService, times(0)).updateInstantMessage(any(String.class), any(V1IMAttributes.class));
+    verify(streamService, never()).updateInstantMessage(any(String.class), any(V1IMAttributes.class));
     verify(streamService, times(1)).updateRoom(eq(STREAM_ID), any(V3RoomAttributes.class));
   }
 
@@ -112,8 +113,8 @@ public class PinUnpinMessageIntegrationTest extends IntegrationTest {
     engine.onEvent(messageReceived("/pin-message"));
 
     Assertions.assertThat(workflow).isExecuted();
-    verify(streamService, times(0)).updateInstantMessage(any(String.class), any(V1IMAttributes.class));
-    verify(streamService, times(0)).updateRoom(any(String.class), any(V3RoomAttributes.class));
+    verify(streamService, never()).updateInstantMessage(any(String.class), any(V1IMAttributes.class));
+    verify(streamService, never()).updateRoom(any(String.class), any(V3RoomAttributes.class));
   }
 
   @Test
@@ -126,8 +127,8 @@ public class PinUnpinMessageIntegrationTest extends IntegrationTest {
     engine.onEvent(messageReceived("/unpin-message"));
 
     Assertions.assertThat(workflow).isExecuted();
-    verify(streamService, times(0)).updateInstantMessage(any(String.class), any(V1IMAttributes.class));
-    verify(streamService, times(0)).updateRoom(any(String.class), any(V3RoomAttributes.class));
+    verify(streamService, never()).updateInstantMessage(any(String.class), any(V1IMAttributes.class));
+    verify(streamService, never()).updateRoom(any(String.class), any(V3RoomAttributes.class));
   }
 
   @Test
@@ -145,8 +146,8 @@ public class PinUnpinMessageIntegrationTest extends IntegrationTest {
     engine.onEvent(messageReceived("/pin-message"));
 
     Assertions.assertThat(workflow).isExecuted();
-    verify(streamService, times(0)).updateInstantMessage(any(String.class), any(V1IMAttributes.class));
-    verify(streamService, times(0)).updateRoom(any(String.class), any(V3RoomAttributes.class));
+    verify(streamService, never()).updateInstantMessage(any(String.class), any(V1IMAttributes.class));
+    verify(streamService, never()).updateRoom(any(String.class), any(V3RoomAttributes.class));
   }
 
   @Test
@@ -164,7 +165,7 @@ public class PinUnpinMessageIntegrationTest extends IntegrationTest {
     engine.onEvent(messageReceived("/unpin-message"));
 
     Assertions.assertThat(workflow).isExecuted();
-    verify(streamService, times(0)).updateInstantMessage(any(String.class), any(V1IMAttributes.class));
-    verify(streamService, times(0)).updateRoom(any(String.class), any(V3RoomAttributes.class));
+    verify(streamService, never()).updateInstantMessage(any(String.class), any(V1IMAttributes.class));
+    verify(streamService, never()).updateRoom(any(String.class), any(V3RoomAttributes.class));
   }
 }

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/UpdateMessageIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/UpdateMessageIntegrationTest.java
@@ -1,6 +1,11 @@
 package com.symphony.bdk.workflow;
 
-import com.github.fge.jsonschema.core.exceptions.ProcessingException;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.symphony.bdk.core.service.message.model.Message;
 import com.symphony.bdk.gen.api.model.V4Message;
@@ -8,17 +13,11 @@ import com.symphony.bdk.workflow.custom.assertion.Assertions;
 import com.symphony.bdk.workflow.swadl.SwadlParser;
 import com.symphony.bdk.workflow.swadl.v1.Workflow;
 
+import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class UpdateMessageIntegrationTest extends IntegrationTest {
 

--- a/workflow-bot-app/src/test/resources/message/pin-message.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/pin-message.swadl.yaml
@@ -1,0 +1,8 @@
+id: pin-message
+activities:
+  - pin-message:
+      id: pinMessage
+      on:
+        message-received:
+          content: /pin-message
+      message-id: MSG_ID

--- a/workflow-bot-app/src/test/resources/message/unpin-message.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/unpin-message.swadl.yaml
@@ -1,0 +1,8 @@
+id: unpin-message
+activities:
+  - unpin-message:
+      id: unpinMessage
+      on:
+        message-received:
+          content: /unpin-message
+      stream-id: STREAM_ID

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/PinMessage.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/PinMessage.java
@@ -1,0 +1,12 @@
+package com.symphony.bdk.workflow.swadl.v1.activity.message;
+
+import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class PinMessage extends BaseActivity {
+  private String messageId;
+}

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/UnpinMessage.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/UnpinMessage.java
@@ -1,0 +1,12 @@
+package com.symphony.bdk.workflow.swadl.v1.activity.message;
+
+import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class UnpinMessage extends BaseActivity {
+  private String streamId;
+}

--- a/workflow-language/src/main/resources/swadl-schema-1.0.json
+++ b/workflow-language/src/main/resources/swadl-schema-1.0.json
@@ -114,13 +114,37 @@
                     },
                     "update-message": {
                         "description": "Updates an existing message into a stream.",
-                        "x-intellij-html-description": "<html><p>Update an existing message into a stream.</p><a href=\"https://developers.symphony.com/restapi/reference#update-message-v4\">https://developers.symphony.com/restapi/reference#update-message-v4</a></html>",
+                        "x-intellij-html-description": "<html><p>Updates an existing message into a stream.</p><a href=\"https://developers.symphony.com/restapi/reference#update-message-v4\">https://developers.symphony.com/restapi/reference#update-message-v4</a></html>",
                         "allOf": [
                             {
                                 "$ref": "#/definitions/basic-activity-inner"
                             },
                             {
                                 "$ref": "#/definitions/update-message-inner"
+                            }
+                        ]
+                    },
+                    "pin-message": {
+                        "description": "Pin an existing message into the stream it belongs to.",
+                        "x-intellij-html-description": "<html><p>Pin an existing message into the stream it belongs to.<a href=\"https://developers.symphony.com/restapi/reference#update-room-v3\">https://developers.symphony.com/restapi/reference#update-room-v3</a><a href=\"https://developers.symphony.com/restapi/v20.13/reference#update-im\">(https://developers.symphony.com/restapi/v20.13/reference#update-im</a></html>",
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/basic-activity-inner"
+                            },
+                            {
+                                "$ref": "#/definitions/pin-message-inner"
+                            }
+                        ]
+                    },
+                    "unpin-message": {
+                        "description": "Unpin any message (if present) from an existing stream.",
+                        "x-intellij-html-description": "<html><p>Unpin any message (if present) from an existing stream.</p><a href=\"https://developers.symphony.com/restapi/reference#update-room-v3\">https://developers.symphony.com/restapi/reference#update-room-v3</a><a href=\"https://developers.symphony.com/restapi/v20.13/reference#update-im\">(https://developers.symphony.com/restapi/v20.13/reference#update-im</a></html>",
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/basic-activity-inner"
+                            },
+                            {
+                                "$ref": "#/definitions/unpin-message-inner"
                             }
                         ]
                     },
@@ -490,7 +514,7 @@
                 "maxProperties": 1,
                 "minProperties": 1,
                 "patternProperties": {
-                    "^(?!create-room|update-room|add-room-member|remove-room-member|promote-room-owner|demote-room-owner|send-message|update-message|execute-script|execute-request|create-user|create-system-user|create-connection|update-user|update-system-user|add-user-role|remove-user-role|remove-connection|reject-connection|accept-connection|get-user|get-users|get-stream|get-room|get-message|get-connection|get-stream-members|get-room-members|get-user-streams|get-streams|get-rooms|get-messages|get-connections)([a-z0-9-]+)$": {
+                    "^(?!create-room|update-room|add-room-member|remove-room-member|promote-room-owner|demote-room-owner|send-message|update-message|pin-message|unpin-message|execute-script|execute-request|create-user|create-system-user|create-connection|update-user|update-system-user|add-user-role|remove-user-role|remove-connection|reject-connection|accept-connection|get-user|get-users|get-stream|get-room|get-message|get-connection|get-stream-members|get-room-members|get-user-streams|get-streams|get-rooms|get-messages|get-connections)([a-z0-9-]+)$": {
                         "$comment": "Match everything that is not an already known activity to allow for custom activities to be used.",
                         "$ref": "#/definitions/basic-activity-inner"
                     }
@@ -1506,6 +1530,28 @@
             "required": [
                 "content",
                 "message-id"
+            ]
+        },
+        "pin-message-inner": {
+            "type": "object",
+            "properties": {
+                "message-id": {
+                    "$ref": "#/definitions/message-id-inner"
+                }
+            },
+            "required": [
+                "message-id"
+            ]
+        },
+        "unpin-message-inner": {
+            "type": "object",
+            "properties": {
+                "stream-id": {
+                    "$ref": "#/definitions/stream-id-inner"
+                }
+            },
+            "required": [
+                "stream-id"
             ]
         },
         "get-attachment-inner": {
@@ -2925,7 +2971,9 @@
                 {
                     "enum": [
                         "${variables.VARIABLE_NAME}",
-                        "${ACTIVITY_ID.outputs.msgId}"
+                        "${ACTIVITY_ID.outputs.msgId}",
+                        "${ACTIVITY_ID.outputs.message.messageId}",
+                        "${ACTIVITY_ID.outputs.message.initialMessageId}"
                     ]
                 },
                 {


### PR DESCRIPTION
### Description
Goal of this implementation is to add support for pin/unpin messages activities. The following activities have been implemented:
```
- pin-message:
     id: pinMessage
     message-id: messageId
```
```
- unpin-message:
     id: unpinMessage
     stream-id: streamId
```

Closes https://github.com/finos/symphony-wdk/issues/46