### PR TITLE
PLAT-11536 Fixed multipart content type.

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1874,7 +1874,8 @@ Key | Type | Required |
 [headers](#headers) | String | No |
 
 _nb: For multipart/form-data content type requests, the body should be provided as a key/value object. For other content types, it can be provided as String in JSON format._
-_nb: For a JSON api, the response can be processes in subsequent activities in SWADL using the utility function [json()](#utility-functions)
+
+_nb: For a JSON api, the response can be processed in subsequent activities in SWADL using the utility function [json()](#utility-functions)_
 
 Output | Type |
 ----|----|
@@ -1964,7 +1965,7 @@ activities:
 Script to execute (only [Groovy](https://groovy-lang.org/) is supported).
 
 ## Utility functions
-WDK provides some utility functions that can be used in SWADL to process data in SWADL.
+WDK provides some utility functions that can be used to process data in SWADL.
 
 ### Object json(String string)
 This method is used to convert a String in JSON format to an Object in order to be processed as a JSON.
@@ -1977,7 +1978,7 @@ ${json("This is a regular String")} == "This is a regular String"
 ```
 
 ### String text(String presentationMl)
-This method is used to convert a presentation ML String to a text.
+This method is used to convert a PresentationML String to a text.
 
 Example:
 ```java
@@ -1985,7 +1986,7 @@ ${text(<div data-format="PresentationML" data-version="2.0">started</div>)} == "
 ```
 
 ### String escape(String string)
-This method will escape text contents using JSON standard escaping, and return results as a String
+This method will escape text contents using JSON standard escaping, and return results as a String.
 
 Example:
 ```java

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1874,6 +1874,7 @@ Key | Type | Required |
 [headers](#headers) | String | No |
 
 _nb: For multipart/form-data content type requests, the body should be provided as a key/value object. For other content types, it can be provided as String in JSON format._
+_nb: For a JSON api, the response can be processes in subsequent activities in SWADL using the utility function [json()](#utility-functions)
 
 Output | Type |
 ----|----|
@@ -1961,3 +1962,32 @@ activities:
 #### script
 
 Script to execute (only [Groovy](https://groovy-lang.org/) is supported).
+
+## Utility functions
+WDK provides some utility functions that can be used in SWADL to process data in SWADL.
+
+### Object json(String string)
+This method is used to convert a String in JSON format to an Object in order to be processed as a JSON.
+It returns a String if the parameter is a simple String.
+
+Example:
+```java
+${json("{\"result\": {\"code\": 200, \"message\": \"success\"}}").result.code} == 200
+${json("This is a regular String")} == "This is a regular String"
+```
+
+### String text(String presentationMl)
+This method is used to convert a presentation ML String to a text.
+
+Example:
+```java
+${text(<div data-format="PresentationML" data-version="2.0">started</div>)} == "started"
+```
+
+### String escape(String string)
+This method will escape text contents using JSON standard escaping, and return results as a String
+
+Example:
+```java
+${escape("{"result": {"code": 200, "message": "success"}}")} == "{\"result\": {\"code\": 200, \"message\": \"success\"}}"
+```

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/RequestExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/RequestExecutor.java
@@ -6,6 +6,7 @@ import com.symphony.bdk.workflow.engine.executor.request.client.HttpClient;
 import com.symphony.bdk.workflow.engine.executor.request.client.Response;
 import com.symphony.bdk.workflow.swadl.v1.activity.request.ExecuteRequest;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -15,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 
 @Component
+@Slf4j
 public class RequestExecutor implements ActivityExecutor<ExecuteRequest> {
 
   private static final String OUTPUT_STATUS_KEY = "status";
@@ -29,11 +31,13 @@ public class RequestExecutor implements ActivityExecutor<ExecuteRequest> {
   @Override
   public void execute(ActivityExecutorContext<ExecuteRequest> execution) throws IOException {
     ExecuteRequest activity = execution.getActivity();
+    log.info("Executing request {} {}", activity.getMethod(), activity.getUrl());
 
     Response response =
         this.httpClient.execute(activity.getMethod(), activity.getUrl(), activity.getBody(),
             headersToString(activity.getHeaders()));
 
+    log.info("Received response {}", response.getContent());
     execution.setOutputVariable(OUTPUT_STATUS_KEY, response.getCode());
     execution.setOutputVariable(OUTPUT_BODY_KEY, response.getContent());
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/RequestExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/RequestExecutor.java
@@ -37,7 +37,7 @@ public class RequestExecutor implements ActivityExecutor<ExecuteRequest> {
         this.httpClient.execute(activity.getMethod(), activity.getUrl(), activity.getBody(),
             headersToString(activity.getHeaders()));
 
-    log.info("Received response {}", response.getContent());
+    log.info("Received response {}", response.getCode());
     execution.setOutputVariable(OUTPUT_STATUS_KEY, response.getCode());
     execution.setOutputVariable(OUTPUT_BODY_KEY, response.getContent());
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/client/HttpClient.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/client/HttpClient.java
@@ -1,7 +1,6 @@
 package com.symphony.bdk.workflow.engine.executor.request.client;
 
 import lombok.Generated;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
@@ -19,7 +18,6 @@ import java.util.Map;
 
 @Generated
 @Component
-@Slf4j
 public class HttpClient {
 
   public Response execute(String method, String url, Object body, Map<String, String> headers)

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/client/HttpClient.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/client/HttpClient.java
@@ -1,9 +1,10 @@
 package com.symphony.bdk.workflow.engine.executor.request.client;
 
 import lombok.Generated;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hc.client5.http.fluent.Form;
+import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.client5.http.fluent.Request;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.ContentType;
@@ -18,6 +19,7 @@ import java.util.Map;
 
 @Generated
 @Component
+@Slf4j
 public class HttpClient {
 
   public Response execute(String method, String url, Object body, Map<String, String> headers)
@@ -43,10 +45,18 @@ public class HttpClient {
     // set body
     String contentType = headers.get(HttpHeaders.CONTENT_TYPE);
     if (body != null && ContentType.MULTIPART_FORM_DATA.getMimeType().equals(contentType)) {
-      Form form = Form.form();
+
+      final MultipartEntityBuilder multipartEntityBuilder = MultipartEntityBuilder
+          .create();
+
       Map<String, Object> bodyAsMap = (LinkedHashMap<String, Object>) body;
-      bodyAsMap.forEach((key, value) -> form.add(key, value.toString()));
-      request.bodyForm(form.build());
+      bodyAsMap.forEach((key, value) -> multipartEntityBuilder.addTextBody(key, value.toString()));
+
+      request.body(multipartEntityBuilder.build());
+
+      // The content type with boundary is provided in the entity, otherwise it is overridden
+      headers.remove(HttpHeaders.CONTENT_TYPE);
+
     } else if (body != null && StringUtils.isNotEmpty(contentType)) {
       request.bodyString(body.toString(), ContentType.parse(contentType));
     } else if (body != null) { // if no content type is provided, we set application/json by default


### PR DESCRIPTION
When sending a multipart/form request, the content type should include the boundary. However, this is no something the user can set in SWADL.
In this commit, we changed the way we handle this content type request and we made use of MultipartEntityBuilder that sets the boundary along with the content type in body.
When the content type is provided in the header than it overrides the one set by MultipartEntityBuilder. For this reason, when we process a multipart/form request, we remove the content type from headers if the user has provided any in order to make use of the one set with boundary.