### PR TITLE
Fix javadoc generation

### DIFF
--- a/buildSrc/src/main/groovy/workflow-bot.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/workflow-bot.java-conventions.gradle
@@ -25,6 +25,8 @@ java {
     withSourcesJar()
 }
 
+javadoc.options.addStringOption('Xdoclint:none', '-quiet')
+
 test {
     useJUnitPlatform()
 }
@@ -44,6 +46,7 @@ jacocoTestCoverageVerification {
 
 test.finalizedBy jacocoTestReport
 check.dependsOn jacocoTestCoverageVerification
+check.dependsOn javadoc
 
 checkstyle {
     configFile = rootProject.file("checkstyle.xml")

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/variable/BpmnToAndFromBaseActivityMixin.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/variable/BpmnToAndFromBaseActivityMixin.java
@@ -9,9 +9,9 @@ import java.util.Map;
 /**
  * Specify how we want to serialize/deserialize a {@link com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity}
  * to and from BPMN.
- * <p/>
- * We don't want the variableProperties to appear but instead to flatten out what inside (so it can be mapped back to
- * the real activity properties).
+ *
+ * <p>We don't want the variableProperties to appear but instead to flatten out what inside (so it can be mapped back to
+ * the real activity properties).</p>
  */
 public abstract class BpmnToAndFromBaseActivityMixin {
 

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/BaseActivity.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/BaseActivity.java
@@ -15,21 +15,21 @@ import javax.annotation.Nullable;
 
 /**
  * Base implementation of an activity providing data shared across all activities.
- * <p/>
- * This object is serialized/deserialized multiple times:
- * <p/>
- * 1. We read a SWADL file and built the Java model of it. At this stage the SWADL file might contain
+ *
+ * <p>This object is serialized/deserialized multiple times:</p>
+ *
+ * <p>1. We read a SWADL file and built the Java model of it. At this stage the SWADL file might contain
  * references to variables (${}). So we cannot properly map variable references to the properties of an activity
- * (when they are longs or lists for instance). Instead, we store those properties in variableProperties.
- * <p/>
- * 2. We use the Java model to build a BPMN model, as part of it we serialize the activities as JSON.
- * <p/>
- * 3. When a workflow is executed, the BPMN model is used and upon execution, variables will be replaced. In the
+ * (when they are longs or lists for instance). Instead, we store those properties in variableProperties.</p>
+ *
+ * <p>2. We use the Java model to build a BPMN model, as part of it we serialize the activities as JSON.</p>
+ *
+ * <p>3. When a workflow is executed, the BPMN model is used and upon execution, variables will be replaced. In the
  * CamundaExecutor we retrieve the JSON representation of an activity where variables have been replaced (by Camunda).
  * We then deserialize this JSON to the activity Java model, this time using the real properties and not
- * variableProperties as the variables have been replaced now.
- * <p/>
- * 4. In the activity executor we can access the activity's properties using proper types.
+ * variableProperties as the variables have been replaced now.</p>
+ *
+ * <p>4. In the activity executor we can access the activity's properties using proper types.</p>
  */
 @Data
 public abstract class BaseActivity {


### PR DESCRIPTION
Javadoc is currently failing and preventing deploying on Maven Central.

Fixed the issues (<p> tags) and made it run along the check tasks so we
avoid merging incorrect javadoc.

Also disabled Javadoc warnings as we don't need to address them
(sometimes we are better off with no @return/@throws if we have nothing
interesting to comment).