### PR TITLE
PLAT-11517: activity outputs are overridden

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -135,9 +135,11 @@ Checkout the [welcome bot example](./examples/welcome-bot.swadl.yaml) to see how
 
 #### timeout
 
-Timeout while waiting for `form-replied` events, expressed as
+Timeout while waiting for an event, expressed as
 an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations). Upon expiration, another activity can be
-triggered with an [activity-expired](#activity-expired) event. Default value is 24 hours.
+triggered with an [activity-expired](#activity-expired) event.
+
+Default value for [form-replied](#form-replied) is 24 hours. No default value for other events.
 
 Example: _PT60S_ for a 60 seconds timeout.
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaExecutor.java
@@ -20,6 +20,7 @@ import org.camunda.bpm.engine.delegate.BpmnError;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
 import org.camunda.bpm.engine.variable.Variables;
+import org.camunda.bpm.engine.variable.value.ObjectValue;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -31,7 +32,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 @Slf4j
@@ -124,27 +125,39 @@ public class CamundaExecutor implements JavaDelegate {
     }
 
     @Override
-    public void setOutputVariable(String name, Object value) {
-      Map<String, Object> innerMap = Collections.singletonMap(name, value);
-      Map<String, Object> outerMap = Collections.singletonMap(ActivityExecutorContext.OUTPUTS, innerMap);
+    public void setOutputVariables(Map<String, Object> variables) {
+      Map<String, Object> innerMap = new HashMap<>(variables);
       String activityId = getActivity().getId();
 
-      // value might not implement serializable or be a collection with non-serializable items, so we use JSON if needed
-      Object outerMapVar;
-      Object valueVar;
-      if (value instanceof Serializable && !(value instanceof Collection)) {
-        outerMapVar = outerMap;
-        valueVar = value;
-      } else {
-        outerMapVar =
-            Variables.objectValue(outerMap).serializationDataFormat(Variables.SerializationDataFormats.JSON).create();
-        valueVar =
-            Variables.objectValue(value).serializationDataFormat(Variables.SerializationDataFormats.JSON).create();
+      Map<String, Object> outer = Map.of(ActivityExecutorContext.OUTPUTS, innerMap);
+      ObjectValue objectValue = Variables.objectValue(outer)
+          .serializationDataFormat(Variables.SerializationDataFormats.JSON)
+          .create();
+
+      // flatten outputs for message correlation
+      Map<String, Object> flattenOutputs = new HashMap<>();
+
+      for (Map.Entry<String, Object> entry : innerMap.entrySet()) {
+        // value might not implement serializable or be a collection with non-serializable items, so we use JSON if needed
+        if (entry.getValue() instanceof Serializable && !(entry.getValue() instanceof Collection)) {
+          flattenOutputs.put(entry.getKey(), entry.getValue());
+        } else {
+          flattenOutputs.put(entry.getKey(), Variables.objectValue(entry.getValue())
+              .serializationDataFormat(Variables.SerializationDataFormats.JSON)
+              .create());
+        }
       }
 
-      execution.setVariable(activityId, outerMapVar);
-      // flatten it too for message correlation
-      execution.setVariable(String.format("%s.%s.%s", activityId, ActivityExecutorContext.OUTPUTS, name), valueVar);
+      execution.setVariable(activityId, objectValue);
+      flattenOutputs.forEach((key, value) -> execution.setVariable(
+          String.format("%s.%s.%s", activityId, ActivityExecutorContext.OUTPUTS, key), value));
+    }
+
+    @Override
+    public void setOutputVariable(String name, Object value) {
+      Map<String, Object> singletonMap = new HashMap<>();
+      singletonMap.put(name, value);
+      this.setOutputVariables(singletonMap);
     }
 
     @Override

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/SendMessageExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/SendMessageExecutor.java
@@ -23,7 +23,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -54,8 +56,10 @@ public class SendMessageExecutor implements ActivityExecutor<SendMessage> {
       message = response.getMessages().get(0); // assume at least one message has been sent
     }
 
-    execution.setOutputVariable(OUTPUT_MESSAGE_KEY, message);
-    execution.setOutputVariable(OUTPUT_MESSAGE_ID_KEY, message.getMessageId());
+    Map<String, Object> outputs = new HashMap<>();
+    outputs.put(OUTPUT_MESSAGE_KEY, message);
+    outputs.put(OUTPUT_MESSAGE_ID_KEY, message.getMessageId());
+    execution.setOutputVariables(outputs);
   }
 
   private List<String> resolveStreamId(ActivityExecutorContext<SendMessage> execution, SendMessage activity,

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/UpdateMessageExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/UpdateMessageExecutor.java
@@ -10,17 +10,21 @@ import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
 import com.symphony.bdk.workflow.swadl.v1.activity.message.UpdateMessage;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class UpdateMessageExecutor implements ActivityExecutor<UpdateMessage> {
 
   @Override
   public void execute(ActivityExecutorContext<UpdateMessage> execution) throws IOException {
     String messageId = execution.getActivity().getMessageId();
-    V4Message messageToUpdate =  execution.bdk().messages().getMessage(messageId);
+    V4Message messageToUpdate = execution.bdk().messages().getMessage(messageId);
     Message message = Message.builder().content(execution.getActivity().getContent()).build();
     V4Message updatedMessage = execution.bdk().messages().update(messageToUpdate, message);
 
-    execution.setOutputVariable(OUTPUT_MESSAGE_KEY, updatedMessage);
-    execution.setOutputVariable(OUTPUT_MESSAGE_ID_KEY, updatedMessage.getMessageId());
+    Map<String, Object> outputs = new HashMap<>();
+    outputs.put(OUTPUT_MESSAGE_KEY, updatedMessage);
+    outputs.put(OUTPUT_MESSAGE_ID_KEY, updatedMessage.getMessageId());
+    execution.setOutputVariables(outputs);
   }
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/RequestExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/RequestExecutor.java
@@ -39,7 +39,12 @@ public class RequestExecutor implements ActivityExecutor<ExecuteRequest> {
       statusCode = apiException.getCode();
 
       // we need to set the responseBody as a map instead of a string to allow processing it in subsequent activities
-      data = new ObjectMapper().readValue(apiException.getResponseBody(), Map.class);
+      try {
+        data = new ObjectMapper().readValue(apiException.getResponseBody(), Map.class);
+      } catch (JsonProcessingException e) {
+        data = new ObjectMapper().readValue(String.format("{\"message\": \"%s\"}", apiException.getResponseBody()),
+            Map.class);
+      }
       log.debug("This error happens when the request fails.", apiException);
     }
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/RequestExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/RequestExecutor.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 @Slf4j
@@ -48,7 +49,9 @@ public class RequestExecutor implements ActivityExecutor<ExecuteRequest> {
       log.debug("This error happens when the request fails.", apiException);
     }
 
-    execution.setOutputVariable(OUTPUT_STATUS_KEY, statusCode);
-    execution.setOutputVariable(OUTPUT_BODY_KEY, data);
+    Map<String, Object> outputs = new HashMap<>();
+    outputs.put(OUTPUT_STATUS_KEY, statusCode);
+    outputs.put(OUTPUT_BODY_KEY, data);
+    execution.setOutputVariables(outputs);
   }
 }

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/SendMessageIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/SendMessageIntegrationTest.java
@@ -2,7 +2,6 @@ package com.symphony.bdk.workflow;
 
 import static com.symphony.bdk.workflow.custom.assertion.Assertions.assertThat;
 import static com.symphony.bdk.workflow.custom.assertion.WorkflowAssert.assertMessage;
-import static com.symphony.bdk.workflow.custom.assertion.WorkflowAssert.content;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -36,43 +35,49 @@ import java.util.List;
 class SendMessageIntegrationTest extends IntegrationTest {
 
   private static final String OUTPUTS_MSG_KEY = "%s.outputs.message";
+  private static final String OUTPUTS_MSG_ID_KEY = "%s.outputs.msgId";
 
   @Test
-  @DisplayName(
-      "Given a send-message with a streamId, when the triggering message is received, "
-          + "then the provided message should be sent to the room")
   void sendMessageOnMessage() throws Exception {
     final Workflow workflow =
         SwadlParser.fromYaml(getClass().getResourceAsStream("/message/send-message-on-message.swadl.yaml"));
+    final V4Message message = message("Hello!");
 
     engine.deploy(workflow);
     engine.onEvent(messageReceived("/message"));
 
-    verify(messageService, timeout(5000)).send(eq("123"), content("Hello!"));
+    when(messageService.send(anyString(), any(Message.class))).thenReturn(message);
+    verify(messageService, timeout(5000)).send(anyString(), any(Message.class));
+
+    assertThat(workflow).isExecuted()
+        .hasOutput(String.format(OUTPUTS_MSG_KEY, "sendMessage1"), message)
+        .hasOutput(String.format(OUTPUTS_MSG_ID_KEY, "sendMessage1"), message.getMessageId());
   }
 
   @Test
-  @DisplayName(
-      "Given two activities: create-room and send-message, when the room is created, then a message is sent to it")
   void sendMessageToCreatedRoomOnMessage() throws Exception {
     final Workflow workflow =
         SwadlParser.fromYaml(getClass().getResourceAsStream("/room/create-room-and-send-message.swadl.yaml"));
     final List<Long> uids = Arrays.asList(1234L, 5678L);
     final Stream stream = new Stream().id("0000");
 
+    final V4Message message = message("Hello!");
+
     when(streamService.create(uids)).thenReturn(stream);
+    when(messageService.send(anyString(), any(Message.class))).thenReturn(message);
 
     engine.deploy(workflow);
     engine.onEvent(messageReceived("/create-room"));
 
     verify(streamService, timeout(5000).times(1)).create(uids);
-    verify(messageService, timeout(5000).times(1)).send(anyString(), content("<p>Hello!</p>"));
+    verify(messageService, timeout(5000).times(1)).send(anyString(), any(Message.class));
+
+    assertThat(workflow).isExecuted()
+        .hasOutput(String.format(OUTPUTS_MSG_KEY, "sendmessageid"), message)
+        .hasOutput(String.format(OUTPUTS_MSG_ID_KEY, "sendmessageid"), message.getMessageId());
   }
 
   @Test
-  @DisplayName(
-      "Given a list of user ids, when the workflow is executed, then a message is sent to their IM/MIM"
-  )
   void sendMessageWithUids() throws Exception {
     final Workflow workflow =
         SwadlParser.fromYaml(getClass().getResourceAsStream("/message/send-message-with-uids.swadl.yaml"));
@@ -103,7 +108,9 @@ class SendMessageIntegrationTest extends IntegrationTest {
     assertThat(stringArgumentCaptor.getValue()).isEqualTo(streamId);
     assertThat(messageArgumentCaptor.getValue().getContent()).isEqualTo(content);
 
-    assertThat(workflow).isExecuted().hasOutput(String.format(OUTPUTS_MSG_KEY, "sendMessageWithUserIds"), message);
+    assertThat(workflow).isExecuted()
+        .hasOutput(String.format(OUTPUTS_MSG_KEY, "sendMessageWithUserIds"), message)
+        .hasOutput(String.format(OUTPUTS_MSG_ID_KEY, "sendMessageWithUserIds"), message.getMessageId());
   }
 
   @Test
@@ -137,14 +144,12 @@ class SendMessageIntegrationTest extends IntegrationTest {
     assertThat(stringArgumentCaptor.getValue()).isEqualTo(streamId);
     assertThat(messageArgumentCaptor.getValue().getContent()).isEqualTo(content);
 
-    assertThat(workflow).isExecuted().hasOutput(String.format(OUTPUTS_MSG_KEY, "sendMessageWithUserIds"), message);
+    assertThat(workflow).isExecuted()
+        .hasOutput(String.format(OUTPUTS_MSG_KEY, "sendMessageWithUserIds"), message)
+        .hasOutput(String.format(OUTPUTS_MSG_ID_KEY, "sendMessageWithUserIds"), message.getMessageId());
   }
 
   @Test
-  @DisplayName(
-      "Given a message with attachments, "
-          + "when I send a new message with the attachment id, "
-          + "this specific file is sent in a new message")
   void sendMessageWithSpecificAttachment() throws Exception {
     final Workflow workflow =
         SwadlParser.fromYaml(getClass().getResourceAsStream(

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/engine/executor/ActivityExecutorContext.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/engine/executor/ActivityExecutorContext.java
@@ -3,6 +3,7 @@ package com.symphony.bdk.workflow.engine.executor;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.Map;
 
 public interface ActivityExecutorContext<T> {
 
@@ -28,9 +29,14 @@ public interface ActivityExecutorContext<T> {
   String INITIATOR = "initiator";
 
   /**
-   * Define an output variable that can be retrieved later with ${activityId.outputs.name}.
+   * Define output variables that can be retrieved later with ${activityId.outputs.name}.
    */
-  void setOutputVariable(String name, Object value);
+  void setOutputVariables(Map<String, Object> variables);
+
+  /**
+   * Define one output variable that can be retrieved later with ${activityId.outputs.name}.
+   */
+  void setOutputVariable(String name, Object variable);
 
   /**
    * @return Gateway to access the BDK services.


### PR DESCRIPTION
### Description
Related to [PLAT-11517](https://perzoinc.atlassian.net/browse/PLAT-11517)

Some activities have more than one output variable to store in the context. Outputs are stored in an outer map having one item key called outputs, and the value is an inner map storing the actual variables. The method setOutputVariable() that was used for that was handling one variable at a time. When it is called a second time to store the second variable, then it was creating a new outer map with outputs key before setting the actual variable which overrides the previosu output in the context. In this commit, we refactored that with a method that takes a map of outputs and store them in one shot.
An output might be null, so we use a Hashmap and update it by putting outputs one bye one instead of doing it in one line.
Some integration tests were updated to verify multiple outputs are stored in the context.
