### PR TITLE
PLAT-11517: Activity outputs are overridden

### DIFF
--- a/buildSrc/src/main/groovy/workflow-bot.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/workflow-bot.java-conventions.gradle
@@ -29,6 +29,9 @@ javadoc.options.addStringOption('Xdoclint:none', '-quiet')
 
 test {
     useJUnitPlatform()
+    testLogging {
+        exceptionFormat = 'full'
+    }
 }
 
 jacocoTestCoverageVerification {

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/SendMessageExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/SendMessageExecutor.java
@@ -22,7 +22,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 public class SendMessageExecutor implements ActivityExecutor<SendMessage> {
@@ -52,8 +54,10 @@ public class SendMessageExecutor implements ActivityExecutor<SendMessage> {
       message = response.getMessages().get(0); // assume at least one message has been sent
     }
 
-    execution.setOutputVariable(OUTPUT_MESSAGE_KEY, message);
-    execution.setOutputVariable(OUTPUT_MESSAGE_ID_KEY, message.getMessageId());
+    Map<String, Object> outputs = new HashMap<>();
+    outputs.put(OUTPUT_MESSAGE_KEY, message);
+    outputs.put(OUTPUT_MESSAGE_ID_KEY, message.getMessageId());
+    execution.setOutputVariables(outputs);
   }
 
   private List<String> resolveStreamId(ActivityExecutorContext<SendMessage> execution, SendMessage activity,

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/UpdateMessageExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/UpdateMessageExecutor.java
@@ -10,17 +10,21 @@ import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
 import com.symphony.bdk.workflow.swadl.v1.activity.message.UpdateMessage;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class UpdateMessageExecutor implements ActivityExecutor<UpdateMessage> {
 
   @Override
   public void execute(ActivityExecutorContext<UpdateMessage> execution) throws IOException {
     String messageId = execution.getActivity().getMessageId();
-    V4Message messageToUpdate =  execution.bdk().messages().getMessage(messageId);
+    V4Message messageToUpdate = execution.bdk().messages().getMessage(messageId);
     Message message = Message.builder().content(execution.getActivity().getContent()).build();
     V4Message updatedMessage = execution.bdk().messages().update(messageToUpdate, message);
 
-    execution.setOutputVariable(OUTPUT_MESSAGE_KEY, updatedMessage);
-    execution.setOutputVariable(OUTPUT_MESSAGE_ID_KEY, updatedMessage.getMessageId());
+    Map<String, Object> outputs = new HashMap<>();
+    outputs.put(OUTPUT_MESSAGE_KEY, updatedMessage);
+    outputs.put(OUTPUT_MESSAGE_ID_KEY, updatedMessage.getMessageId());
+    execution.setOutputVariables(outputs);
   }
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/RequestExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/RequestExecutor.java
@@ -37,10 +37,15 @@ public class RequestExecutor implements ActivityExecutor<ExecuteRequest> {
         this.httpClient.execute(activity.getMethod(), activity.getUrl(), activity.getBody(),
             headersToString(activity.getHeaders()));
 
-    log.info("Received response {}", response.getCode());
-    execution.setOutputVariable(OUTPUT_STATUS_KEY, response.getCode());
-    execution.setOutputVariable(OUTPUT_BODY_KEY, response.getContent());
+    String data = response.getContent();
+    int statusCode = response.getCode();
 
+    log.info("Received response {}", response.getCode());
+
+    Map<String, Object> outputs = new HashMap<>();
+    outputs.put(OUTPUT_STATUS_KEY, statusCode);
+    outputs.put(OUTPUT_BODY_KEY, data);
+    execution.setOutputVariables(outputs);
   }
 
   private Map<String, String> headersToString(Map<String, Object> headers) {

--- a/workflow-bot-app/src/test/resources/com/symphony/bdk/workflow/configuration/workflow.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/com/symphony/bdk/workflow/configuration/workflow.swadl.yaml
@@ -1,4 +1,4 @@
-id: send-message-on-message
+id: send-message-workflow
 activities:
   - send-message:
       id: sendMessageId

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/engine/executor/ActivityExecutorContext.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/engine/executor/ActivityExecutorContext.java
@@ -3,6 +3,7 @@ package com.symphony.bdk.workflow.engine.executor;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.Map;
 
 public interface ActivityExecutorContext<T> {
 
@@ -28,9 +29,14 @@ public interface ActivityExecutorContext<T> {
   String INITIATOR = "initiator";
 
   /**
-   * Define an output variable that can be retrieved later with ${activityId.outputs.name}.
+   * Define output variables that can be retrieved later with ${activityId.outputs.name}.
    */
-  void setOutputVariable(String name, Object value);
+  void setOutputVariables(Map<String, Object> variables);
+
+  /**
+   * Define one output variable that can be retrieved later with ${activityId.outputs.name}.
+   */
+  void setOutputVariable(String name, Object variable);
 
   /**
    * @return Gateway to access the BDK services.


### PR DESCRIPTION
Related to [PLAT-11517](https://perzoinc.atlassian.net/browse/PLAT-11517)

Some activities have more than one output variable to store in the context. Outputs are stored in an outer map having one item key called outputs, and the value is an inner map storing the actual variables. The method setOutputVariable() that was used for that was handling one variable at a time. When it is called a second time to store the second variable, then it was creating a new outer map with outputs key before setting the actual variable which overrides the previosu output in the context. In this commit, we refactored that with a method that takes a map of outputs and store them in one shot.
An output might be null, so we use a Hashmap and update it by putting outputs one bye one instead of doing it in one line.
Some integration tests were updated to verify multiple outputs are stored in the context.