### PR TITLE
PLAT-11535: Support timeout.

### DIFF
--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/EventTypesIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/EventTypesIntegrationTest.java
@@ -180,6 +180,26 @@ class EventTypesIntegrationTest extends IntegrationTest {
         .notExecuted("script", "sendMessageIfNotTimeoutSecond");
   }
 
+  @Test
+  void onActivityExpiredToNewBranch_timeout() throws IOException, ProcessingException, InterruptedException {
+    final Workflow workflow = SwadlParser.fromYaml(
+        getClass().getResourceAsStream("/event/timeout/activity-expired-leading-to-new-branch.swadl.yaml"));
+
+    when(messageService.send("123", "Expired")).thenReturn(new V4Message());
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/start"));
+
+    sleepToTimeout(500);
+
+    ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
+    verify(messageService, timeout(5000).times(1)).send(anyString(), messageArgumentCaptor.capture());
+
+    assertThat(messageArgumentCaptor.getValue().getContent()).isEqualTo("<messageML>Expired</messageML>");
+    assertThat(workflow).executed("firstActivity", "expirationActivity", "scriptActivityToBeExecuted")
+        .notExecuted("sendMessageWithTimeout", "scriptActivityNotToBeExecuted1", "scriptActivityNotToBeExecuted2");
+  }
+
   @SuppressWarnings("checkstyle:LineLength")
   @Test
   void firstActivity_timeout() throws IOException, ProcessingException {

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/SendMessageIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/SendMessageIntegrationTest.java
@@ -109,11 +109,12 @@ class SendMessageIntegrationTest extends IntegrationTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   void sendMessageWithUidsVariables() throws Exception {
     final Workflow workflow =
         SwadlParser.fromYaml(getClass().getResourceAsStream("/message/send-message-with-uids-variables.swadl.yaml"));
 
-    final List<Long> uids = Arrays.asList(123L);
+    final List<Long> uids = List.of(123L);
     final String streamId = "STREAM_ID";
     final String msgId = "MSG_ID";
     final String content = "<messageML>hello</messageML>";

--- a/workflow-bot-app/src/test/resources/event/timeout/activity-expired-leading-to-new-branch.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/event/timeout/activity-expired-leading-to-new-branch.swadl.yaml
@@ -1,0 +1,48 @@
+id: activity-expired-leading-to-new-branch
+activities:
+  - execute-script:
+      id: firstActivity
+      on:
+        message-received:
+          content: /start
+      script: |
+        assert true
+
+  - send-message:
+      id: sendMessageWithTimeout
+      content: Message to be sent if no timeout
+      to:
+         stream-id: "123"
+      on:
+        timeout: PT0.01S
+        message-received:
+          content: /continue
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted1
+      # workflow should fail if this script is executed
+      script: |
+        assert true == false
+
+  - send-message:
+      id: expirationActivity
+      content: Expired
+      to:
+        stream-id: "123"
+      on:
+        activity-expired:
+          activity-id: sendMessageWithTimeout
+
+  - execute-script:
+      id: scriptActivityToBeExecuted
+      script: |
+        assert true == true
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted2
+      # workflow should fail if this script is executed
+      script: |
+        assert true == false
+      on:
+        activity-completed:
+          activity-id: sendMessageWithTimeout


### PR DESCRIPTION
[PLAT-11535](https://perzoinc.atlassian.net/browse/PLAT-11535)
In a previous PR we added the support of timeouts with the main process and we added the possibility to connect the timed out activities to a dedicated activity. This latter is executed when the specified one/ones is/are timed out. However, this implementation did not allow to connect a branch (a part of workflow) to activities with time out. Only one acitivty could be connected.
The issue was that when we have an activity with on:acitivty-expired property, we move the builder backward to the specified activity having timeout property in order to connect the two activities, but we do not update the builder with the new one. Thus, the following activities are added to the end of the workflow.
With this implementation, having an activity ac1 with on:activity-expired property, if we define an activity ac2 just after it, then ac1 will be connected to ac2. In order to connect ac2 to the end of the workflow instead of the new branch, it needs to use on:activity-completed referring the activity with timeout.

to do:
- [] Update reference documentation
- [] Add examples for different cases
----
**Here is an example of SWADL with the generated BPMN**
<img width="1294" alt="Screenshot 2021-11-25 at 20 40 02" src="https://user-images.githubusercontent.com/52406574/143493883-cca32e3a-fd44-44eb-a9ea-92b3276ca35e.png">

----
_By adding an activity to the main branch of workflow_:
![x](https://user-images.githubusercontent.com/52406574/143495326-b1ad0cd2-045e-4ec3-8ea1-97163cce19e3.png)


