### PR TITLE
Fixed Deserialization bug on immutable collection storing workflows outputs

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaExecutor.java
@@ -155,7 +155,8 @@ public class CamundaExecutor implements JavaDelegate {
       Map<String, Object> innerMap = new HashMap<>(variables);
       String activityId = getActivity().getId();
 
-      Map<String, Object> outer = Map.of(ActivityExecutorContext.OUTPUTS, innerMap);
+      Map<String, Object> outer = new HashMap<>();
+      outer.put(ActivityExecutorContext.OUTPUTS, innerMap);
       ObjectValue objectValue = Variables.objectValue(outer)
           .serializationDataFormat(Variables.SerializationDataFormats.JSON)
           .create();

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/GetAttachmentIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/GetAttachmentIntegrationTest.java
@@ -7,9 +7,7 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.symphony.bdk.gen.api.model.V4AttachmentInfo;
 import com.symphony.bdk.gen.api.model.V4Message;
-import com.symphony.bdk.gen.api.model.V4Stream;
 import com.symphony.bdk.workflow.swadl.SwadlParser;
 import com.symphony.bdk.workflow.swadl.v1.Workflow;
 
@@ -17,8 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Paths;
-import java.util.Collections;
-import java.util.List;
 
 
 @Slf4j
@@ -90,18 +86,4 @@ class GetAttachmentIntegrationTest extends IntegrationTest {
     verify(messageService, never()).getAttachment(anyString(), anyString(), anyString());
   }
 
-  private V4Message createMessage(String msgId, String attachmentId, String attachmentName) {
-    final V4Message actualMessage = new V4Message();
-    actualMessage.setMessageId(msgId);
-
-    final V4Stream v4Stream = new V4Stream();
-    v4Stream.setStreamId("STREAM_ID");
-    actualMessage.setStream(v4Stream);
-
-    final List<V4AttachmentInfo> attachments =
-        Collections.singletonList(new V4AttachmentInfo().id(attachmentId).name(attachmentName));
-    actualMessage.setAttachments(attachments);
-
-    return actualMessage;
-  }
 }

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/IntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/IntegrationTest.java
@@ -17,6 +17,7 @@ import com.symphony.bdk.core.service.stream.StreamService;
 import com.symphony.bdk.core.service.user.UserService;
 import com.symphony.bdk.gen.api.model.Stream;
 import com.symphony.bdk.gen.api.model.UserConnection;
+import com.symphony.bdk.gen.api.model.V4AttachmentInfo;
 import com.symphony.bdk.gen.api.model.V4Initiator;
 import com.symphony.bdk.gen.api.model.V4Message;
 import com.symphony.bdk.gen.api.model.V4MessageSent;
@@ -46,6 +47,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -258,6 +260,25 @@ public abstract class IntegrationTest {
   // This method makes a thread sleep to make a workflow times out
   protected static void sleepToTimeout(long durationInMilliSeconds) throws InterruptedException {
     Thread.sleep(durationInMilliSeconds);
+  }
+
+  protected V4Message createMessage(String msgId) {
+    return createMessage(msgId, null, null);
+  }
+
+  protected V4Message createMessage(String msgId, String attachmentId, String attachmentName) {
+    final V4Message actualMessage = new V4Message();
+    actualMessage.setMessageId(msgId);
+
+    final V4Stream v4Stream = new V4Stream();
+    v4Stream.setStreamId("STREAM_ID");
+    actualMessage.setStream(v4Stream);
+
+    final List<V4AttachmentInfo> attachments =
+        Collections.singletonList(new V4AttachmentInfo().id(attachmentId).name(attachmentName));
+    actualMessage.setAttachments(attachments);
+
+    return actualMessage;
   }
 
 }

--- a/workflow-bot-app/src/test/resources/event/event-middle-using-outputs.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/event/event-middle-using-outputs.swadl.yaml
@@ -1,0 +1,17 @@
+id: event-middle-using-outputs-workflow
+activities:
+  - send-message:
+      id: one
+      on:
+        message-received:
+          content: /one
+      to:
+        stream-id: abc
+      content: One
+
+  - get-message:
+      id: two
+      message-id: ${one.outputs.msgId}
+      on:
+        message-received:
+          content: /two


### PR DESCRIPTION
In #69, we created the outputs outer map using Map.of() that creates an immutable map. This map was supposed to be read only as a new instance is created at the end of every activity, and we never update it. To update an output we create a new instance of the map.
This introduced a new bug in the ProcessEngine. When an event comes to the workflow, the ProcessEngine deserializes the context outputs, and this fails when the map storing context outputs is immutable. The error could not be found on basic workflows that have one event to start it, as at the beginning no immutable map is created in the context yet. However, with events in the middle of the workflows, an immutable map is already found in the context and outputs deserialization fails with org.camunda.bpm.engine.ProcessEngineException.
This has been fixed by creating the map using new hashmap().

The encountered error:
`org.camunda.bpm.engine.ProcessEngineException: Cannot deserialize object in variable 'pingPong': SPIN/JACKSON-JSON-01006 Cannot deserialize '{"outputs"...' to java type '[map type; class java.util.ImmutableCollections$Map1, [simple type, class java.lang.Object] -> [simple type, class java.lang.Object]]'`