### PR TITLE
Support loop after form replies

### DIFF
--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/IntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/IntegrationTest.java
@@ -179,6 +179,7 @@ public abstract class IntegrationTest {
     elementsAction.setFormMessageId(messageId);
     elementsAction.setFormId(formId);
     elementsAction.setFormValues(formReplies);
+    elementsAction.setStream(new V4Stream());
     return new RealTimeEvent<>(initiator, elementsAction);
   }
 

--- a/workflow-bot-app/src/test/resources/form/send-form-continuation.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/form/send-form-continuation.swadl.yaml
@@ -1,0 +1,47 @@
+id: send-form-continuation
+activities:
+  - send-message:
+      id: sendForm
+      on:
+        one-of:
+          - message-received:
+              content: /message
+          - activity-completed:
+              activity-id: setVariables
+              if: ${variables.loop == true}
+      to:
+        stream-id: ABC
+      content: |
+        <messageML>
+          <form id="sendForm">
+            <button name="approve" type="action">Approve</button>
+            <button name="reject" type="action">Reject</button>
+          </form>
+        </messageML>
+
+
+  - send-message:
+      id: reply1
+      on:
+        timeout: PT1S
+        form-replied:
+          form-id: sendForm
+          unique: true
+      to:
+        stream-id: ABC
+      content: reply1
+
+  - send-message:
+      id: afterReply1
+      to:
+        stream-id: ABC
+      content: afterReply1
+
+  - send-message:
+      id: reply1Timeout
+      on:
+        activity-expired:
+          activity-id: sendForm
+      to:
+        stream-id: ABC
+      content: afterReply1

--- a/workflow-bot-app/src/test/resources/form/send-form-loop.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/form/send-form-loop.swadl.yaml
@@ -1,0 +1,31 @@
+id: send-form-loop
+activities:
+  - send-message:
+      id: sendForm
+      on:
+        one-of:
+          - message-received:
+              content: /message
+          - activity-completed:
+              activity-id: setVariables
+              if: ${variables.loop == true}
+      to:
+        stream-id: ABC
+      content: |
+        <messageML>
+          <form id="sendForm">
+            <button name="approve" type="action">Approve</button>
+            <button name="reject" type="action">Reject</button>
+          </form>
+        </messageML>
+
+
+  - execute-script:
+      id: setVariables
+      on:
+        form-replied:
+          form-id: sendForm
+          unique: true
+      # We go back to the first activity, resending the form
+      script: |
+        variables.loop = (sendForm.action == "reject" )

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/event/FormRepliedEvent.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/event/FormRepliedEvent.java
@@ -7,4 +7,7 @@ import lombok.Data;
 public class FormRepliedEvent {
   @JsonProperty
   private String formId;
+
+  @JsonProperty
+  private Boolean unique = false;
 }

--- a/workflow-language/src/main/resources/swadl-schema-1.0.json
+++ b/workflow-language/src/main/resources/swadl-schema-1.0.json
@@ -1027,6 +1027,11 @@
                 "form-id": {
                     "description": "Form's id. The id should be the same as activity's one that sent the form.",
                     "type": "string"
+                },
+                "unique": {
+                    "description": "True if only one reply is expected to the form. Default is false",
+                    "default": false,
+                    "type": "boolean"
                 }
             },
             "required": [


### PR DESCRIPTION
The main problem is that form replies start subprocesses each one having
its own life. But sometime in 1-1 or in specific case a form is meant to
be replied by only one user. Meaning we can avoid using the subprocess
and allow for loops to happen after the form is being replied to.

Introduce a flag in the form-reply event to decide wether subprocesses
are used or not. The timeouts are not yet handled.
