### PR TITLE
Fix flaky test sendMessageOnMessage

### DIFF
--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/custom/assertion/WorkflowAssert.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/custom/assertion/WorkflowAssert.java
@@ -205,15 +205,15 @@ public class WorkflowAssert extends AbstractAssert<WorkflowAssert, Workflow> {
     String process = lastProcess().orElseThrow();
     await().atMost(5, SECONDS).until(() -> processIsCompleted(process));
 
-    await().atMost(5, SECONDS).until(()
-        -> !IntegrationTest.historyService.createHistoricDetailQuery().processInstanceId(process).list().isEmpty());
-
-    final List<HistoricDetail> historicalDetails = IntegrationTest.historyService.createHistoricDetailQuery()
-        .processInstanceId(process).list();
-
-    Optional<HistoricDetail> historicalDetailOptional = historicalDetails.stream()
-        .filter(x -> ((HistoricDetailVariableInstanceUpdateEntity) x).getVariableName().equals(key))
-        .findFirst();
+    Optional<HistoricDetail> historicalDetailOptional = await().atMost(5, SECONDS).until(()
+        -> {
+      final List<HistoricDetail> details = IntegrationTest.historyService.createHistoricDetailQuery()
+          .processInstanceId(process).list();
+      Optional<HistoricDetail> detail = details.stream()
+          .filter(x -> ((HistoricDetailVariableInstanceUpdateEntity) x).getVariableName().equals(key))
+          .findFirst();
+      return detail;
+    }, Optional::isPresent);
 
     if (historicalDetailOptional.isEmpty()) {
       fail("No historical details found for the process.");

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/custom/assertion/WorkflowAssert.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/custom/assertion/WorkflowAssert.java
@@ -205,8 +205,11 @@ public class WorkflowAssert extends AbstractAssert<WorkflowAssert, Workflow> {
     String process = lastProcess().orElseThrow();
     await().atMost(5, SECONDS).until(() -> processIsCompleted(process));
 
-    final List<HistoricDetail> historicalDetails =
-        IntegrationTest.historyService.createHistoricDetailQuery().processInstanceId(process).list();
+    await().atMost(5, SECONDS).until(()
+        -> !IntegrationTest.historyService.createHistoricDetailQuery().processInstanceId(process).list().isEmpty());
+
+    final List<HistoricDetail> historicalDetails = IntegrationTest.historyService.createHistoricDetailQuery()
+        .processInstanceId(process).list();
 
     Optional<HistoricDetail> historicalDetailOptional = historicalDetails.stream()
         .filter(x -> ((HistoricDetailVariableInstanceUpdateEntity) x).getVariableName().equals(key))


### PR DESCRIPTION
PR checks are sometimes failing. I'm not 100% sure but maybe even if the
process is marked as completed all the historic details (like vars) have
not yet been written to the DB.

So we wait (actively) for that when checking variables.