### PR TITLE
Bug fix: activity outputs should be overridden when the activity is called multiple time

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaExecutor.java
@@ -1,7 +1,5 @@
 package com.symphony.bdk.workflow.engine.camunda;
 
-import com.google.common.collect.ImmutableMap;
-
 import com.symphony.bdk.workflow.engine.ResourceProvider;
 import com.symphony.bdk.workflow.engine.camunda.audit.AuditTrailLogger;
 import com.symphony.bdk.workflow.engine.camunda.variable.BpmnToAndFromBaseActivityMixin;
@@ -20,6 +18,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.google.common.collect.ImmutableMap;
 import lombok.extern.slf4j.Slf4j;
 import org.camunda.bpm.engine.delegate.BpmnError;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
@@ -43,7 +42,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -153,8 +151,6 @@ public class CamundaExecutor implements JavaDelegate {
 
     @Override
     public void setOutputVariables(Map<String, Object> variables) {
-      this.checkNoOutputsExist(activity.getId());
-
       Map<String, Object> innerMap = new HashMap<>(variables);
       String activityId = getActivity().getId();
 
@@ -185,7 +181,6 @@ public class CamundaExecutor implements JavaDelegate {
 
     @Override
     public void setOutputVariable(String name, Object value) {
-      this.checkNoOutputsExist(activity.getId());
       Map<String, Object> singletonMap = new HashMap<>();
       singletonMap.put(name, value);
       this.setOutputVariables(singletonMap);
@@ -236,17 +231,5 @@ public class CamundaExecutor implements JavaDelegate {
       return resourceLoader.saveResource(resourcePath, content);
     }
 
-    private void checkNoOutputsExist(String activityId) {
-      List<String> foundOutputs = this.execution.getVariables()
-          .keySet()
-          .stream()
-          .filter(o -> o.contains(String.format("%s.outputs", activityId)))
-          .collect(Collectors.toList());
-
-      if (!foundOutputs.isEmpty()) {
-        throw new RuntimeException(
-            String.format("Outputs %s already exist for activity %s", foundOutputs, activityId));
-      }
-    }
   }
 }

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/LoopIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/LoopIntegrationTest.java
@@ -4,13 +4,16 @@ import static com.symphony.bdk.workflow.custom.assertion.WorkflowAssert.assertTh
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.when;
 
 import com.symphony.bdk.core.service.message.model.Message;
+import com.symphony.bdk.gen.api.model.V4Message;
 import com.symphony.bdk.workflow.swadl.SwadlParser;
 import com.symphony.bdk.workflow.swadl.v1.Workflow;
 
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -41,6 +44,30 @@ class LoopIntegrationTest extends IntegrationTest {
     engine.onEvent(messageReceived("/execute"));
 
     assertThat(workflow).isExecutedWithProcessAndActivities(lastProcess(), activities);
+  }
+
+  @Test
+  void loopOverridesOutputsTest() throws IOException, ProcessingException {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/loop/loop-overrides-outputs.swadl.yaml"));
+
+    Message message0 = Message.builder().content("<messageML>0</messageML>").build();
+    Message message1 = Message.builder().content("<messageML>1</messageML>").build();
+
+    when(messageService.send(anyString(), refEq(message0, "data", "attachments", "previews", "version"))).thenReturn(
+        message("msgIdO"));
+    when(messageService.send(anyString(), refEq(message1, "data", "attachments", "previews", "version"))).thenReturn(
+        message("msgId1"));
+
+    engine.deploy(workflow);
+
+    engine.onEvent(messageReceived("/execute"));
+    V4Message expectedOutputs = new V4Message();
+    expectedOutputs.messageId("msgId1");
+
+    assertThat(workflow).executed("act0", "act1", "act2", "act0", "act1", "act2")
+        .hasOutput("act1.outputs.msgId", "msgId1")
+        .hasOutput("act1.outputs.message", expectedOutputs);
   }
 
 }

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/custom/assertion/WorkflowAssert.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/custom/assertion/WorkflowAssert.java
@@ -211,7 +211,7 @@ public class WorkflowAssert extends AbstractAssert<WorkflowAssert, Workflow> {
           .processInstanceId(process).list();
       Optional<HistoricDetail> detail = details.stream()
           .filter(x -> ((HistoricDetailVariableInstanceUpdateEntity) x).getVariableName().equals(key))
-          .findFirst();
+          .reduce((first, second) -> second);
       return detail;
     }, Optional::isPresent);
 

--- a/workflow-bot-app/src/test/resources/loop/loop-overrides-outputs.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/loop/loop-overrides-outputs.swadl.yaml
@@ -1,0 +1,27 @@
+id: loop-overrides-outputs
+variables:
+  execution: 0
+activities:
+  - execute-script:
+      id: act0
+      on:
+        one-of:
+          - message-received:
+              content: /execute
+          - activity-completed:
+              activity-id: act2
+              if: ${variables.execution <= 1}
+      script: |
+
+  - send-message:
+      id: act1
+      on:
+        activity-completed:
+          activity-id: ac0
+      content: ${variables.execution}
+
+  - execute-script:
+      id: act2
+      script: |
+        variables.execution++
+


### PR DESCRIPTION
In #69, we fixed a bug about activities outputs being overridden when an activity has multiple outputs to store. We implemented a sanity method called before writing outputs to check no outputs already exist  for that activity in the context. In this case, a runtime exception is thrown.
When we use loops, an activity is called multiple times and then, in the same process, the activity writes its outputs multiple times. This was not accepted anymore because of that sanity check. We removed it in this commit.

A small change is done in the WorkflowAssert: when an activity is executed multiple times, only the last execution outputs are kept in the context. But the method we use to test outputs use a history details which returns all outputs. We were getting the first occurence which does not correspond to the last execution. We replaced that with a reduce method to get the last one. This allowed to test the last written outputs for an activity.
