### PR TITLE
Upgrade dependencies

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.freefair.gradle:lombok-plugin:6.0.0-m2'
-    implementation 'gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.7.1'
+    implementation 'io.freefair.gradle:lombok-plugin:6.3.0'
+    implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.3'
 }

--- a/buildSrc/src/main/groovy/workflow-bot.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/workflow-bot.java-conventions.gradle
@@ -57,6 +57,7 @@ checkstyle {
 
 // Enable HTML report for spotbugs
 tasks.matching { task -> task.name.startsWith('spotbugs') }.forEach {
+    it.excludeFilter = rootProject.file("spotbugs.xml")
     it.reports {
         html.enabled = true
         xml.enabled = false

--- a/spotbugs.xml
+++ b/spotbugs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+    <Match>
+        <Bug code="EI,EI2,MS"/>
+    </Match>
+
+</FindBugsFilter>

--- a/workflow-bot-app/build.gradle
+++ b/workflow-bot-app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'workflow-bot.java-conventions'
-    id 'org.springframework.boot' version '2.5.4'
+    id 'org.springframework.boot' version '2.6.1'
 }
 
 javadoc {
@@ -10,9 +10,9 @@ javadoc {
 dependencies {
     implementation project(':workflow-language')
 
-    implementation platform('org.finos.symphony.bdk:symphony-bdk-bom:2.4.2')
+    implementation platform('org.finos.symphony.bdk:symphony-bdk-bom:2.4.3')
 
-    implementation 'org.apache.httpcomponents.client5:httpclient5-fluent:5.1.1'
+    implementation 'org.apache.httpcomponents.client5:httpclient5-fluent:5.1.2'
 
     implementation 'org.finos.symphony.bdk:symphony-bdk-core-spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -31,12 +31,12 @@ dependencies {
     implementation 'org.camunda.spin:camunda-spin-core'
     implementation 'org.camunda.spin:camunda-spin-dataformat-json-jackson'
 
-    implementation 'org.codehaus.groovy:groovy-all:3.0.8'
+    implementation 'org.codehaus.groovy:groovy-all:3.0.9'
 
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.4'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'com.github.java-json-tools:json-schema-validator:2.2.14'
 
-    implementation 'org.apache.commons:commons-lang3:3.12'
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'commons-io:commons-io:2.11.0'
     implementation('org.reflections:reflections:0.9.11') {
         version {
@@ -45,11 +45,11 @@ dependencies {
     }
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.7.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.2'
-    testImplementation 'org.assertj:assertj-core:3.20.2'
-    testImplementation 'org.awaitility:awaitility:4.1.0'
-    testImplementation 'com.github.tomakehurst:wiremock-jre8:2.31.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params'
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.awaitility:awaitility'
+    testImplementation 'com.github.tomakehurst:wiremock-jre8:2.32.0'
 }
 
 bootBuildImage {

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/PinMessageExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/PinMessageExecutor.java
@@ -1,6 +1,5 @@
 package com.symphony.bdk.workflow.engine.executor.message;
 
-import com.symphony.bdk.core.util.IdUtil;
 import com.symphony.bdk.gen.api.model.StreamType;
 import com.symphony.bdk.gen.api.model.V1IMAttributes;
 import com.symphony.bdk.gen.api.model.V3RoomAttributes;
@@ -21,11 +20,10 @@ public class PinMessageExecutor implements ActivityExecutor<PinMessage> {
 
   @Override
   public void execute(ActivityExecutorContext<PinMessage> execution) throws IOException {
-    // temporary workaround until BDK 2.4.1 is released
-    String messageId = IdUtil.toUrlSafeIdIfNeeded(execution.getActivity().getMessageId());
+    String messageId = execution.getActivity().getMessageId();
 
     V4Message messageToPin = execution.bdk().messages().getMessage(messageId);
-    String streamId = IdUtil.toUrlSafeIdIfNeeded(messageToPin.getStream().getStreamId());
+    String streamId = messageToPin.getStream().getStreamId();
     String streamType = messageToPin.getStream().getStreamType();
 
     if (IM.equals(streamType)) {

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/UnpinMessageExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/UnpinMessageExecutor.java
@@ -3,7 +3,6 @@ package com.symphony.bdk.workflow.engine.executor.message;
 import static com.symphony.bdk.workflow.engine.executor.message.PinMessageExecutor.IM;
 import static com.symphony.bdk.workflow.engine.executor.message.PinMessageExecutor.ROOM;
 
-import com.symphony.bdk.core.util.IdUtil;
 import com.symphony.bdk.gen.api.model.V1IMAttributes;
 import com.symphony.bdk.gen.api.model.V2StreamAttributes;
 import com.symphony.bdk.gen.api.model.V3RoomAttributes;
@@ -20,8 +19,7 @@ public class UnpinMessageExecutor implements ActivityExecutor<UnpinMessage> {
 
   @Override
   public void execute(ActivityExecutorContext<UnpinMessage> execution) throws IOException {
-    // temporary workaround until BDK 2.4.1 is released
-    String streamId = IdUtil.toUrlSafeIdIfNeeded(execution.getActivity().getStreamId());
+    String streamId = execution.getActivity().getStreamId();
 
     V2StreamAttributes stream = execution.bdk().streams().getStream(streamId);
     String streamType = stream.getStreamType().getType();

--- a/workflow-language/build.gradle
+++ b/workflow-language/build.gradle
@@ -8,9 +8,9 @@ javadoc {
 }
 
 dependencies {
-    api platform('org.finos.symphony.bdk:symphony-bdk-bom:2.4.2')
+    api platform('org.finos.symphony.bdk:symphony-bdk-bom:2.4.3')
 
     api 'org.finos.symphony.bdk:symphony-bdk-core'
 
-    api 'com.fasterxml.jackson.core:jackson-annotations:2.12.4'
+    api 'com.fasterxml.jackson.core:jackson-annotations'
 }


### PR DESCRIPTION
Java BDK 2.4.3 (using Spring Boot 2.6.1)
We can now remove escaping on message/thread ids.

Upgrade other dependencies too, sometime removing the number so we can
rely on the BDK/Spring Boot BOM.