### PR TITLE
Avoid overwriting activity outputs with form replies

### DIFF
--- a/workflow-bot-app/build.gradle
+++ b/workflow-bot-app/build.gradle
@@ -10,9 +10,9 @@ javadoc {
 dependencies {
     implementation project(':workflow-language')
 
-    implementation platform('org.finos.symphony.bdk:symphony-bdk-bom:2.5.0')
-    implementation platform('com.fasterxml.jackson:jackson-bom:2.13.1')
-    implementation platform('org.springframework.boot:spring-boot-dependencies:2.6.3')
+    implementation platform('org.finos.symphony.bdk:symphony-bdk-bom:2.6.0')
+    implementation platform('com.fasterxml.jackson:jackson-bom:2.13.2')
+    implementation platform('org.springframework.boot:spring-boot-dependencies:2.6.4')
 
     implementation 'org.apache.httpcomponents.client5:httpclient5-fluent:5.1.2'
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/WorkflowEventToCamundaEvent.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/WorkflowEventToCamundaEvent.java
@@ -1,5 +1,7 @@
 package com.symphony.bdk.workflow.engine.camunda;
 
+import static java.util.Collections.singletonMap;
+
 import com.symphony.bdk.core.service.message.exception.PresentationMLParserException;
 import com.symphony.bdk.core.service.message.util.PresentationMLParser;
 import com.symphony.bdk.core.service.session.SessionService;
@@ -20,6 +22,7 @@ import com.symphony.bdk.gen.api.model.V4UserJoinedRoom;
 import com.symphony.bdk.gen.api.model.V4UserLeftRoom;
 import com.symphony.bdk.gen.api.model.V4UserRequestedToJoinRoom;
 import com.symphony.bdk.spring.events.RealTimeEvent;
+import com.symphony.bdk.workflow.engine.camunda.variable.FormVariableListener;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
 import com.symphony.bdk.workflow.engine.executor.EventHolder;
 import com.symphony.bdk.workflow.engine.executor.message.SendMessageExecutor;
@@ -226,11 +229,11 @@ public class WorkflowEventToCamundaEvent {
   private <T> void formReplyToMessage(RealTimeEvent<T> event,
       Map<String, Object> processVariables) {
     // we expect the activity id to be the same as the form id to work
-    // correlation across processes is based on the message id tha was created to send the form
+    // correlation across processes is based on the message id that was created to send the form
     V4SymphonyElementsAction implEvent = (V4SymphonyElementsAction) event.getSource();
     Map<String, Object> formReplies = (Map<String, Object>) implEvent.getFormValues();
     String formId = implEvent.getFormId();
-    processVariables.put(formId, formReplies);
+    processVariables.put(FormVariableListener.FORM_VARIABLES, singletonMap(formId, formReplies));
     runtimeService.createMessageCorrelation(WorkflowEventToCamundaEvent.FORM_REPLY_PREFIX + formId)
         .processInstanceVariableEquals(
             String.format("%s.%s.%s",

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/CamundaBpmnBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/CamundaBpmnBuilder.java
@@ -3,6 +3,7 @@ package com.symphony.bdk.workflow.engine.camunda.bpmn;
 import com.symphony.bdk.workflow.engine.camunda.CamundaExecutor;
 import com.symphony.bdk.workflow.engine.camunda.WorkflowEventToCamundaEvent;
 import com.symphony.bdk.workflow.engine.camunda.audit.ScriptTaskAuditListener;
+import com.symphony.bdk.workflow.engine.camunda.variable.FormVariableListener;
 import com.symphony.bdk.workflow.engine.camunda.variable.VariablesListener;
 import com.symphony.bdk.workflow.swadl.ActivityRegistry;
 import com.symphony.bdk.workflow.swadl.exception.ActivityNotFoundException;
@@ -358,7 +359,8 @@ public class CamundaBpmnBuilder {
                 builder.intermediateCatchEvent().camundaAsyncBefore().name(signalName.get());
 
             if (isExclusiveFormReply(activity)) {
-              intermediateCatchEventBuilder.message(signalName.get());
+              intermediateCatchEventBuilder.message(signalName.get())
+                  .camundaExecutionListenerClass(ExecutionListener.EVENTNAME_START, FormVariableListener.class);
             } else {
               intermediateCatchEventBuilder.signal(signalName.get());
             }
@@ -569,8 +571,10 @@ public class CamundaBpmnBuilder {
         formReplies.put(activity.getId(), formExpirationBuilder);
 
         // we add the form reply event sub process inside the subprocess
-        builder = subProcess.embeddedSubProcess().eventSubProcess()
+        builder = subProcess.embeddedSubProcess()
+            .eventSubProcess()
             .startEvent()
+            .camundaExecutionListenerClass(ExecutionListener.EVENTNAME_START, FormVariableListener.class)
             .camundaAsyncBefore()
             .interrupting(false) // run multiple instances of the sub process (i.e. multiple replies)
             .message(WorkflowEventToCamundaEvent.FORM_REPLY_PREFIX + activity.getOn().getFormReplied().getFormId())

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/variable/FormVariableListener.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/variable/FormVariableListener.java
@@ -1,0 +1,45 @@
+package com.symphony.bdk.workflow.engine.camunda.variable;
+
+import lombok.extern.slf4j.Slf4j;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.ExecutionListener;
+
+import java.util.Map;
+
+/**
+ * Merges form variables with activity variables.
+ * <p>When a form reply is received, the reply data is sent to a specific map named "form" and passed as a variable to
+ * the process. Here we take it and merge it with the existing variable ACTIVITY_ID
+ * (that contains the outputs for instance).
+ * </p>
+ * <p>We cannot set it directly when the message is sent because it overwrites the existing variable ACTIVITY_ID.</p>
+ * <p>This is executed when a correlation message for a form is received to merge the variables as soon as possible.</p>
+ */
+@Slf4j
+public class FormVariableListener implements ExecutionListener {
+
+  public static final String FORM_VARIABLES = "form";
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public void notify(DelegateExecution execution) {
+    Object formVariable = execution.getVariable(FORM_VARIABLES);
+    // do we have a form variable in the current process?
+    if (formVariable instanceof Map) {
+      Map<String, Map<String, Object>> form = (Map<String, Map<String, Object>>) formVariable;
+      // there should be only one form.FORM_ID entry
+      for (Map.Entry<String, Map<String, Object>> entry : form.entrySet()) {
+        Object activityVariable = execution.getVariable(entry.getKey());
+        if (activityVariable instanceof Map) {
+          // merge form.FORM_ID.FORM_REPLY_DATA into ACTIVITY_ID...
+          // FORM_ID = ACTIVITY_ID
+          // in the end we have ACTIVITY_ID.outputs... and ACTIVITY_ID.FORM_REPLY_DATA in the same variable
+          Map<String, Object> activity = (Map<String, Object>) activityVariable;
+          activity.putAll(entry.getValue());
+        }
+      }
+      execution.removeVariable(FORM_VARIABLES);
+    }
+  }
+
+}

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/custom/assertion/WorkflowAssert.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/custom/assertion/WorkflowAssert.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import com.symphony.bdk.core.service.message.model.Attachment;
 import com.symphony.bdk.core.service.message.model.Message;
 import com.symphony.bdk.workflow.IntegrationTest;
+import com.symphony.bdk.workflow.engine.camunda.WorkflowEventToCamundaEvent;
 import com.symphony.bdk.workflow.swadl.v1.Activity;
 import com.symphony.bdk.workflow.swadl.v1.Workflow;
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
@@ -188,6 +189,8 @@ public class WorkflowAssert extends AbstractAssert<WorkflowAssert, Workflow> {
 
     return processes.stream()
         .filter(p -> !ACTIVITY_TYPES_TO_IGNORE.contains(p.getActivityType()) && !p.isCanceled())
+        .filter(p -> p.getActivityName() != null
+            && !p.getActivityName().startsWith(WorkflowEventToCamundaEvent.FORM_REPLY_PREFIX))
         .map(HistoricActivityInstance::getActivityName)
         .filter(Objects::nonNull)
         .collect(Collectors.toList());

--- a/workflow-bot-app/src/test/resources/form/send-form-outputs-are-preserved.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/form/send-form-outputs-are-preserved.swadl.yaml
@@ -1,0 +1,21 @@
+id: send-form-outputs-are-preserved
+activities:
+  - send-message:
+      id: init
+      on:
+        message-received:
+          content: /run_form_outputs_preserved
+      to:
+        stream-id: ABC
+      content: <form id="init"><button type="action" name="one">One</button></form>
+
+  - execute-script:
+      id: check
+      on:
+        form-replied:
+          form-id: init
+          exclusive: true
+      # we have both the form reply data and the outputs accessible
+      script: |
+        assert init.action == "one"
+        assert init.outputs.msgId.length() > 0

--- a/workflow-bot-app/src/test/resources/form/send-form-reply-followup-activity-exclusive.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/form/send-form-reply-followup-activity-exclusive.swadl.yaml
@@ -1,0 +1,39 @@
+id: send-form-reply
+activities:
+  - send-message:
+      id: sendForm
+      on:
+        message-received:
+          content: "/message"
+      to:
+        stream-id: "123"
+      content: |
+        <messageML>
+          <form id="sendForm">
+            <text-field name="aField" placeholder="Anything you want to say" required="true"/>
+            <button name="send-answers" type="action">Send</button>
+            <button type="reset">Clear</button>
+          </form>
+        </messageML>
+
+  - send-message:
+      id: pongReply
+      on:
+        form-replied:
+          form-id: sendForm
+          exclusive: true
+      to:
+        stream-id: "123"
+      content: |
+        <messageML>
+          First reply: ${sendForm.aField}
+        </messageML>
+
+  - send-message:
+      id: pongReply2
+      to:
+        stream-id: "123"
+      content: |
+        <messageML>
+          Second reply: ${sendForm.aField}
+        </messageML>


### PR DESCRIPTION
### Description
Because we set the process variable under the same name (activity
id/form id) than the activity outputs for instance, we are overwriting
them when receiving a form reply.

Instead we now store them in a different name, just pass them with the
message that is triggering a form reply activity and with an execution
listener we properly merge them with existing variables like outputs.

This way we don't break the existing API.

### Dependencies
N/A

### Checklist
- [-] Referenced a ticket in the PR title or description
- [X] Filled properly the description and dependencies, if any
- [X] Unit/Integration tests updated or added
- [X] Javadoc added or updated
- [X] Updated the documentation in [docs folder](../docs)
