### PR TITLE
Groups support

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 Symphony LLC
+   Copyright 2022 Symphony LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
 Symphony Workflow Developer Kit (WDK) - FINOS
-Copyright 2021 Symphony LLC
+Copyright 2022 Symphony LLC
 
 This product includes software developed at the Fintech Open Source Foundation (https://www.finos.org/).

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ Java (JDK) 11 is required and Gradle is used to build the project.
 ```
 
 ## Contributing
-In order to get in touch with the project team, please open a [GitHub Issue](https://github.com/SymphonyPlatformSolutions/symphony-wdk/issues).
+In order to get in touch with the project team, please open a [GitHub Issue](https://github.com/finos/symphony-wdk/issues).
 Alternatively, you can email/subscribe to [symphony@finos.org](https://groups.google.com/a/finos.org/g/symphony).
 
-1. Fork it (<https://github.com/SymphonyPlatformSolutions/symphony-wdk>)
+1. Fork it (<https://github.com/finos/symphony-wdk>)
 2. Create your feature branch (`git checkout -b feature/fooBar`)
 3. Read our [contribution guidelines](.github/CONTRIBUTING.md) and [Community Code of Conduct](https://www.finos.org/code-of-conduct)
 4. Check your code quality (`./gradlew check`)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Checkout the [open issues](https://github.com/finos/symphony-wdk/issues).
 
 ## License
 
-Copyright 2021 Symphony LLC
+Copyright 2022 Symphony LLC
 
 Distributed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.freefair.gradle:lombok-plugin:6.3.0'
+    implementation 'io.freefair.gradle:lombok-plugin:6.4.1'
     implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.3'
 }

--- a/docs/examples/groups.swadl.yaml
+++ b/docs/examples/groups.swadl.yaml
@@ -1,0 +1,39 @@
+# Using group (distribution list) activities
+id: groups
+activities:
+  - create-group:
+      id: create
+      on:
+        message-received:
+          content: /group
+      type: SDL
+      name: test-group
+      profile:
+        display-name: Test Group
+      owner:
+        id: 190 # To be changed with the tenant/pod id
+        type: TENANT
+      members:
+        - tenant-id: 190 # To be changed with the tenant/pod id
+          user-id: 13056700579841 # To be changed with a real user id
+  - get-group:
+      id: get
+      group-id: ${get.outputs.group.id}
+      on:
+        message-received:
+          content: /start
+  - update-group:
+      id: updateAvatar
+      group-id: ${get.outputs.group.id}
+      image-path: "/attachments/logo.png"
+  - add-group-member:
+      id: add
+      group-id: ${get.outputs.group.id}
+      members:
+        - user-id: 13056700581328
+          tenant-id: 190
+        - user-id: 13056700581174
+          tenant-id: 190
+  - get-groups:
+      id: gets
+      type: SDL

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,21 +1,21 @@
 # Getting started
 
 The tool of choice to get started writing and running workflows is
-the [Symphony generator](https://github.com/SymphonyPlatformSolutions/generator-symphony). Essentially we are going to
+the [Symphony generator](https://github.com/finos/generator-symphony). Essentially we are going to
 create a Symphony bot that is capable of running workflows.
 
 It can be installed with:
 
 ```
-npm install -g yo generator-symphony
+npm install -g yo @finos/generator-symphony
 ```
 
-Then in an empty folder, run the `yo symphony` command.
+Then in an empty folder, run the `yo @finos/symphony` command.
 
 You will be guided as shown below to configure your bot. Make sure to select _Workflow Application_.
 
 ```
-~/dist $ yo symphony
+~/dist $ yo @finos/symphony
  __   __     ___                 _
  \ \ / /__  / __|_  _ _ __  _ __| |_  ___ _ _ _  _
   \ V / _ \ \__ \ || | '  \| '_ \ ' \/ _ \ ' \ || |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -27,7 +27,8 @@ activities:
 
 ## id
 
-Workflow's id should start with a letter and should not contain empty spaces. It is required. The id will appear in logs and audit trails.
+Workflow's id should start with a letter and should not contain empty spaces. It is required. The id will appear in logs
+and audit trails.
 
 ## variables
 
@@ -268,7 +269,6 @@ event can be set to `true`. In that case, the activity is executed in the main p
 controls can be used as normal.
 
 _nb: Loops are only supported with forms that require only one reply._
-
 
 Key | Type | Required |
 ------------ | -------| --- | 
@@ -771,16 +771,16 @@ Content can
 be [MessageML](https://docs.developers.symphony.com/building-bots-on-symphony/messages/overview-of-messageml) with
 the `<messageML>` tags or can be simple text too (<messageML> are automatically added if needed).
 
-Content can either be set directly in the SWADL file as plain text (String) or it can be referenced from an external file (Object).
-When using an external file the content has to be defined as follows:
+Content can either be set directly in the SWADL file as plain text (String) or it can be referenced from an external
+file (Object). When using an external file the content has to be defined as follows:
 
 Key | Type | Required |
 ------------ | -------| --- | 
 template | String | Yes |
 
-Both [Freemarker](https://freemarker.apache.org/) (.ftl) and mml.xml format are accepted as external files in the template field. 
-By default, it will search for the file in the `./workflows` root folder. 
-When [Freemarker](https://freemarker.apache.org/) is used, any workflow variable can be referenced in the external file, 
+Both [Freemarker](https://freemarker.apache.org/) (.ftl) and mml.xml format are accepted as external files in the
+template field. By default, it will search for the file in the `./workflows` root folder.
+When [Freemarker](https://freemarker.apache.org/) is used, any workflow variable can be referenced in the external file,
 same format as it is for the any other activity in the SWADL file.
 
 In case the content to send is PresentationML. The `text` function might come handy, it uses
@@ -799,20 +799,24 @@ activities:
       content:
         ${text(event.source.message.message)}
 ```
+
 Example using Freemarker:
+
 ```yaml
 activities:
   variables:
     val: world
-  - send-message:
-      id: echo
-      on:
-        message-received:
-          content: /echo
-      content: 
-        template: message-with-params.ftl
+           - send-message:
+           id: echo
+           on:
+             message-received:
+               content: /echo
+           content:
+             template: message-with-params.ftl
 ```
-message-with-params.ftl 
+
+message-with-params.ftl
+
 ```
 <messageML>Hello ${variables.val}</messageML>
 ```
@@ -849,6 +853,7 @@ encoded urls are accepted.
 Path to the file to be attached to the message. The path is relative to the workflows folder.
 
 ### update-message
+
 Update an existing message into a stream. Returns the new updated message.
 
 Key | Type | Required |
@@ -866,6 +871,7 @@ msgId | String
 Message id of the message to be updated. Both url safe and base64 encoded urls are accepted
 
 ### pin-message
+
 Pin an existing message into the stream it belongs to. It works for both Instant Messages and Rooms.
 
 Key | Type | Required |
@@ -877,6 +883,7 @@ Depending on the stream type the activity will either call the
 [Update IM](https://developers.symphony.com/restapi/v20.13/reference#update-im) endpoint.
 
 ### unpin-message
+
 Unpin any message (if present) from an existing stream. It works for both Instant Messages and Rooms.
 
 Key | Type | Required |
@@ -928,7 +935,8 @@ Example: _2021-08-31T15:50:00Z_
 
 ### get-attachment
 
-Downloads an attachment to file system and returns its path. The stored file is suffixed with the executed activity id and stored under a folder with the executed process id.
+Downloads an attachment to file system and returns its path. The stored file is suffixed with the executed activity id
+and stored under a folder with the executed process id.
 
 An attachment named **_logo.png_** will be stored under _./workflows/**$PROCESS_ID**/**$ACTIVITY_ID**-logo.png_.
 
@@ -943,7 +951,8 @@ Output | Type |
 ----|----|
 attachmentPath | String
 
-[API reference](https://developers.symphony.com/restapi/reference#attachment) (Activity does not return the same outputs as the api response)
+[API reference](https://developers.symphony.com/restapi/reference#attachment) (Activity does not return the same outputs
+as the api response)
 
 ### create-room
 
@@ -1876,7 +1885,7 @@ user-id | String | Yes |
 
 ### get-connections
 
-Get one or multiple connections statuses
+Get one or multiple connections statuses.
 
 Key | Type | Required |
 ------------ | -------| --- |
@@ -1903,6 +1912,201 @@ Allowed values:
 - REJECTED
 - ALL
 
+### create-group
+
+Create a group (distribution list). _Distribution List Manager role_ is required to use this activity.
+
+Key | Type   | Required |
+------------ |--------|----------|
+[type](#group-type) | String | Yes      |
+[owner](#group-owner) | Map    | Yes      |
+name | String | Yes      |
+[sub-type](#group-sub-type) | String | No       |
+[referrer](#group-referrer) | String | No       |
+[members](#group-member) | List   | Yes      |
+[profile](#group-profile) | Map    | Yes      |
+
+Output | Type |
+----|----|
+group | [ReadGroup](https://javadoc.io/doc/org.finos.symphony.bdk.ext/symphony-group-extension/latest/com/symphony/bdk/ext/group/gen/api/model/ReadGroup.html)
+
+[API reference](https://developers.symphony.com/restapi/reference/insertgroup)
+
+#### <a name="group-type"></a>type
+
+Group type identifier (for instance SDL).
+
+#### <a name="group-owner"></a>owner
+
+Key | Type   | Required |
+------------ |--------| --- |
+[id](#owner-id) | String | Yes |
+[type](#owner-type) | String | Yes |
+
+##### <a name="owner-id"></a>id
+
+Owner id if the owner type is tenant (podId) or user (userId), otherwise null.
+
+##### <a name="owner-type"></a>type
+
+Owner type. Ony TENANT supported now.
+
+Allowed values:
+
+- TENANT
+- PLATFORM
+- USER
+
+#### <a name="group-sub-type"></a>sub-type
+
+The type of the company new groupType.
+
+Allowed values:
+
+- COMMUNITY
+- CHANNEL
+
+#### <a name="group-referrer"></a>referrer
+
+Symphony, referring company name, referring channel partner name.
+
+#### <a name="group-member"></a>members
+
+Key | Type    | Required |
+------------ |---------| --- |
+user-id | Integer  | Yes |
+tenant-id | Integer | Yes |
+
+#### <a name="group-profile"></a>profile
+
+See [API](https://developers.symphony.com/restapi/reference/insertgroup) for details.
+At least `display-name` should be set. Job properties are grouped under a `job` entry.
+
+### update-group
+
+Update a group (distribution list). _Distribution List Manager role_ is required to use this activity.
+
+Key | Type   | Required |
+------------ |--------|----------|
+group-id | String | Yes      |
+[status](#group-status) | String | Yes      |
+e-tag | String | Yes      |
+[image-path](#group-image-path) | String | No       |
+[type](#group-type) | String | No       |
+[owner](#group-owner) | Map    | Yes      |
+name | String | No       |
+[sub-type](#group-sub-type) | String | No       |
+[referrer](#group-referrer) | String | No       |
+[members](#group-member) | List   | Yes      |
+[profile](#group-profile) | Map    | Yes      |
+
+_Keys are similar to [group creation](#create-group)._
+
+E-tag must be passed and can be retrieved from a group with the [get-group](#get-group) activity. It is used to avoid
+concurrent updates.
+
+Output | Type |
+----|----|
+group | [ReadGroup](https://javadoc.io/doc/org.finos.symphony.bdk.ext/symphony-group-extension/latest/com/symphony/bdk/ext/group/gen/api/model/ReadGroup.html)
+
+[API reference](https://developers.symphony.com/restapi/reference/updategroup)
+
+#### <a name="group-status"></a>status
+
+Status flag to distinguish between active and deleted objects.
+
+Allowed values:
+
+- ACTIVE
+- DELETED
+
+#### <a name="group-image-path"></a>image-path
+
+Path to the image file to be used as the group's avatar. The path is relative to the workflows folder.
+
+### get-group
+
+Retrieve a group (distribution list). _Distribution List Manager role_ is required to use this activity.
+
+Key | Type   | Required |
+------------ |--------|----------|
+group-id | String | Yes      |
+
+Output | Type |
+----|----|
+group | [ReadGroup](https://javadoc.io/doc/org.finos.symphony.bdk.ext/symphony-group-extension/latest/com/symphony/bdk/ext/group/gen/api/model/ReadGroup.html)
+
+[API reference](https://developers.symphony.com/restapi/reference/getgroup)
+
+### get-groups
+
+Retrieve groups of specified type (distribution list). _Distribution List Manager role_ is required to use this activity.
+
+Key | Type   | Required |
+------------ |--------|----------|
+[type](#group-type) | String | Yes      |
+[status](#group-status) | String | No       |
+[before](#group-before) | String | No       |
+[after](#group-after) | String | No       |
+[limit](#group-limit) | String | No       |
+[sort-order](#group-sort-order) | String | No       |
+
+Output | Type |
+----|----|
+groups | [GroupList](https://javadoc.io/doc/org.finos.symphony.bdk.ext/symphony-group-extension/latest/com/symphony/bdk/ext/group/gen/api/model/GroupList.html)
+
+[API reference](https://developers.symphony.com/restapi/reference/listgroups)
+
+#### <a name="group-type"></a>type
+
+Group type id.
+
+#### <a name="group-status"></a>status
+
+Filter by status, active or deleted. If not specified both are returned.
+
+Allowed values:
+
+- ACTIVE
+- DELETED
+
+#### <a name="group-before"></a>before
+
+Not supported yet, currently ignored. Cursor that points to the start of the current page of data. If not present, the
+current page is the first page.
+
+#### <a name="group-after"></a>after
+
+Cursor that points to the end of the current page of data. If not present, the current page is the last page.
+
+#### <a name="group-limit"></a>limit
+
+Numbers of items to return.
+
+#### <a name="group-sort-order"></a>sort-order
+
+Items sorting direction (ordered by creation date).
+
+Allowed values:
+
+- ASC
+- DESC
+
+### add-group-member
+
+Add members to a group (distribution list). _Distribution List Manager role_ is required to use this activity.
+
+Key | Type   | Required |
+------------ |--------|----------|
+group-id | String | Yes      |
+[members](#group-member) | List   | Yes      |
+
+Output | Type |
+----|----|
+group | [ReadGroup](https://javadoc.io/doc/org.finos.symphony.bdk.ext/symphony-group-extension/latest/com/symphony/bdk/ext/group/gen/api/model/ReadGroup.html)
+
+[API reference](https://developers.symphony.com/restapi/reference/addmembertogroup)
+
 ### execute-request
 
 Executes an HTTP request.
@@ -1914,17 +2118,17 @@ Key | Type | Required |
 [body](#body) | Object/String | No |
 [headers](#headers) | String | No |
 
-
 Output | Type |
 ----|----|
 body | Object/String
 status | Integer
 
-If the response body has a `application/json` content type then the `body` output is parsed into a
-JSON object (if possible) otherwise it will a string. Please note that this approach comes with limitations
-and that the `execute-request` activity should not be used to download large payloads.
+If the response body has a `application/json` content type then the `body` output is parsed into a JSON object (if
+possible) otherwise it will a string. Please note that this approach comes with limitations and that
+the `execute-request` activity should not be used to download large payloads.
 
 Example:
+
 ```yaml
 activities:
   - execute-request:
@@ -1942,16 +2146,19 @@ activities:
       to:
         stream-id: A_STREAM
       content: ${myRequest.outputs.body.message} # Send a message with content "Hello Bob"
-      
+
 ```
 
 #### url
+
 String that contains the host and the path to be targeted.
 
 #### method
+
 HTTP method to perform. GET is the default one.
 
 Supported methods are:
+
 - DELETE
 - GET
 - HEAD
@@ -1961,14 +2168,16 @@ Supported methods are:
 - PUT
 
 #### body
-HTTP request body.
-It can be provided as an object (for `application/json` or `multiplart/form content` type) or as a string.
+
+HTTP request body. It can be provided as an object (for `application/json` or `multiplart/form content` type) or as a
+string.
 
 When `multipart/form` content type is used, only key/value object is supported.
 
 #### headers
-HTTP request headers. A map of key/value entries is expected. Simple types
-such as numbers, string and booleans as well as lists and maps are supported.
+
+HTTP request headers. A map of key/value entries is expected. Simple types such as numbers, string and booleans as well
+as lists and maps are supported.
 
 Unless set explicitly the `Content-Type` header will be `application/json` by default.
 
@@ -2000,14 +2209,17 @@ activities:
 Script to execute (only [Groovy](https://groovy-lang.org/) is supported).
 
 ## Utility functions
+
 WDK provides some utility functions that can be used to process data in SWADL.
 
 ### Object json(String string)
-This method is used to convert a String in JSON format to an Object in order to be processed as a JSON.
-It returns a String if the parameter is a simple String.
+
+This method is used to convert a String in JSON format to an Object in order to be processed as a JSON. It returns a
+String if the parameter is a simple String.
 
 Example:
 in [send-message](#send-message)
+
 ```yaml
 variables:
   aJson: "{\"result\": { \"code\": 200, \"message\": \"success\" } }"
@@ -2023,6 +2235,7 @@ activities:
 ```
 
 in [execute-script](#execute-script)
+
 ````yaml
 activities:
   - execute-script:
@@ -2033,11 +2246,13 @@ activities:
 ````
 
 ### String text(String presentationMl)
+
 This method is used to convert a PresentationML String to a text.
 
 Example:
 
 in [send-message](#send-message)
+
 ```yaml
 variables:
   presentationML: "<div data-format=\"PresentationML\" data-version=\"2.0\">started</div>"
@@ -2048,6 +2263,7 @@ activities:
 ```
 
 in [execute-script](#execute-script)
+
 ````yaml
 activities:
   - execute-script:
@@ -2057,11 +2273,13 @@ activities:
 ````
 
 ### String escape(String string)
+
 This method will escape text contents using JSON standard escaping, and return results as a String.
 
 Example:
 
 in [send-message](#send-message)
+
 ```yaml
 activities:
   - send-message:
@@ -2070,6 +2288,7 @@ activities:
 ```
 
 in [execute-script](#execute-script)
+
 ````yaml
 activities:
   - execute-script:

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1918,13 +1918,13 @@ Create a group (distribution list). _Distribution List Manager role_ is required
 
 Key | Type   | Required |
 ------------ |--------|----------|
+name | String | Yes      |
 [type](#group-type) | String | Yes      |
 [owner](#group-owner) | Map    | Yes      |
-name | String | Yes      |
+[profile](#group-profile) | Map    | Yes      |
+[members](#group-member) | List   | Yes      |
 [sub-type](#group-sub-type) | String | No       |
 [referrer](#group-referrer) | String | No       |
-[members](#group-member) | List   | Yes      |
-[profile](#group-profile) | Map    | Yes      |
 
 Output | Type |
 ----|----|
@@ -1949,7 +1949,7 @@ Owner id if the owner type is tenant (podId) or user (userId), otherwise null.
 
 ##### <a name="owner-type"></a>type
 
-Owner type. Ony TENANT supported now.
+Owner type. Only TENANT supported now.
 
 Allowed values:
 
@@ -1989,16 +1989,16 @@ Update a group (distribution list). _Distribution List Manager role_ is required
 Key | Type   | Required |
 ------------ |--------|----------|
 group-id | String | Yes      |
-[status](#group-status) | String | Yes      |
 e-tag | String | Yes      |
+[status](#group-status) | String | Yes      |
+[owner](#group-owner) | Map    | Yes      |
+[profile](#group-profile) | Map    | Yes      |
+[members](#group-member) | List   | Yes      |
+name | String | No       |
 [image-path](#group-image-path) | String | No       |
 [type](#group-type) | String | No       |
-[owner](#group-owner) | Map    | Yes      |
-name | String | No       |
 [sub-type](#group-sub-type) | String | No       |
 [referrer](#group-referrer) | String | No       |
-[members](#group-member) | List   | Yes      |
-[profile](#group-profile) | Map    | Yes      |
 
 _Keys are similar to [group creation](#create-group)._
 

--- a/workflow-bot-app/build.gradle
+++ b/workflow-bot-app/build.gradle
@@ -14,9 +14,10 @@ dependencies {
     implementation platform('com.fasterxml.jackson:jackson-bom:2.13.2')
     implementation platform('org.springframework.boot:spring-boot-dependencies:2.6.4')
 
-    implementation 'org.apache.httpcomponents.client5:httpclient5-fluent:5.1.2'
+    implementation 'org.apache.httpcomponents.client5:httpclient5-fluent:5.1.3'
 
     implementation 'org.finos.symphony.bdk:symphony-bdk-core-spring-boot-starter'
+    implementation 'org.finos.symphony.bdk.ext:symphony-group-extension'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
@@ -33,11 +34,11 @@ dependencies {
     implementation 'org.camunda.spin:camunda-spin-core'
     implementation 'org.camunda.spin:camunda-spin-dataformat-json-jackson'
 
-    implementation 'org.codehaus.groovy:groovy-all:3.0.9'
+    implementation 'org.codehaus.groovy:groovy-all:3.0.10'
 
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
     implementation 'com.github.java-json-tools:json-schema-validator:2.2.14'
-    implementation 'org.mozilla:rhino:1.7.12' // SNYK-JAVA-ORGMOZILLA-1314295
+    implementation 'org.mozilla:rhino:1.7.14' // SNYK-JAVA-ORGMOZILLA-1314295
 
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'commons-io:commons-io:2.11.0'

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/configuration/WorkflowBotConfiguration.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/configuration/WorkflowBotConfiguration.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.workflow.configuration;
 
+import com.symphony.bdk.ext.group.SymphonyGroupBdkExtension;
 import com.symphony.bdk.workflow.engine.ResourceProvider;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -15,5 +16,10 @@ public class WorkflowBotConfiguration {
   public ResourceProvider workflowResourcesProvider(@Value("${workflows.folder}") String resourcesFolder) {
     // ./workflows folder is used both to load workflows and local resources
     return new WorkflowResourcesProvider(resourcesFolder);
+  }
+
+  @Bean
+  public SymphonyGroupBdkExtension groupExtension() {
+    return new SymphonyGroupBdkExtension();
   }
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/SpringBdkGateway.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/SpringBdkGateway.java
@@ -4,9 +4,11 @@ import com.symphony.bdk.core.service.connection.ConnectionService;
 import com.symphony.bdk.core.service.message.MessageService;
 import com.symphony.bdk.core.service.stream.StreamService;
 import com.symphony.bdk.core.service.user.UserService;
+import com.symphony.bdk.ext.group.SymphonyGroupService;
 import com.symphony.bdk.workflow.engine.executor.BdkGateway;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -16,15 +18,17 @@ public class SpringBdkGateway implements BdkGateway {
   private final StreamService streamService;
   private final UserService userService;
   private final ConnectionService connectionService;
+  private final SymphonyGroupService groupService;
 
   @Autowired
   public SpringBdkGateway(MessageService messageService,
       StreamService streamService, UserService userService,
-      ConnectionService connectionService) {
+      ConnectionService connectionService, @Lazy SymphonyGroupService groupService) {
     this.messageService = messageService;
     this.streamService = streamService;
     this.userService = userService;
     this.connectionService = connectionService;
+    this.groupService = groupService;
   }
 
   @Override
@@ -45,5 +49,10 @@ public class SpringBdkGateway implements BdkGateway {
   @Override
   public ConnectionService connections() {
     return connectionService;
+  }
+
+  @Override
+  public SymphonyGroupService groups() {
+    return groupService;
   }
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaExecutor.java
@@ -84,6 +84,7 @@ public class CamundaExecutor implements JavaDelegate {
     this.applicationContext = applicationContext;
   }
 
+  @SuppressWarnings({"unchecked", "rawtypes"})
   @Override
   public void execute(DelegateExecution execution) throws Exception {
     Class<?> implClass = Class.forName((String) execution.getVariable(EXECUTOR));

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/WorkflowEventToCamundaEvent.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/WorkflowEventToCamundaEvent.java
@@ -144,6 +144,7 @@ public class WorkflowEventToCamundaEvent {
     return Optional.empty();
   }
 
+  @SuppressWarnings("unchecked")
   public <T> void dispatch(RealTimeEvent<T> event)
       throws PresentationMLParserException {
 
@@ -226,6 +227,7 @@ public class WorkflowEventToCamundaEvent {
     }
   }
 
+  @SuppressWarnings("unchecked")
   private <T> void formReplyToMessage(RealTimeEvent<T> event,
       Map<String, Object> processVariables) {
     // we expect the activity id to be the same as the form id to work

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/group/AddGroupMemberExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/group/AddGroupMemberExecutor.java
@@ -1,0 +1,35 @@
+package com.symphony.bdk.workflow.engine.executor.group;
+
+import com.symphony.bdk.ext.group.gen.api.model.AddMember;
+import com.symphony.bdk.ext.group.gen.api.model.Member;
+import com.symphony.bdk.ext.group.gen.api.model.ReadGroup;
+import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
+import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
+import com.symphony.bdk.workflow.swadl.v1.activity.group.AddGroupMember;
+import com.symphony.bdk.workflow.swadl.v1.activity.group.CreateGroup;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class AddGroupMemberExecutor implements ActivityExecutor<AddGroupMember> {
+
+  private static final String OUTPUTS_GROUP_KEY = "group";
+
+  @Override
+  public void execute(ActivityExecutorContext<AddGroupMember> execution) {
+    String groupId = execution.getActivity().getGroupId();
+
+    ReadGroup group = null;
+    for (CreateGroup.GroupMember user : execution.getActivity().getMembers()) {
+      log.debug("Add member {}/{} to group {}", user.getUserId(), user.getTenantId(), groupId);
+      AddMember member = new AddMember().member(
+          new Member().memberId(user.getUserId()).memberTenant(user.getTenantId()));
+      group = execution.bdk().groups().addMemberToGroup(groupId, member);
+    }
+
+    if (group != null) {
+      execution.setOutputVariable(OUTPUTS_GROUP_KEY, group);
+    }
+  }
+
+}

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/group/CreateGroupExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/group/CreateGroupExecutor.java
@@ -1,0 +1,119 @@
+package com.symphony.bdk.workflow.engine.executor.group;
+
+import com.symphony.bdk.ext.group.gen.api.model.BaseProfile;
+import com.symphony.bdk.ext.group.gen.api.model.GroupImplicitConnection;
+import com.symphony.bdk.ext.group.gen.api.model.GroupInteractionTransfer;
+import com.symphony.bdk.ext.group.gen.api.model.GroupVisibilityRestriction;
+import com.symphony.bdk.ext.group.gen.api.model.Member;
+import com.symphony.bdk.ext.group.gen.api.model.Owner;
+import com.symphony.bdk.ext.group.gen.api.model.ReadGroup;
+import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
+import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
+import com.symphony.bdk.workflow.swadl.v1.activity.group.CreateGroup;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class CreateGroupExecutor implements ActivityExecutor<CreateGroup> {
+
+  private static final String OUTPUTS_GROUP_KEY = "group";
+
+  @Override
+  public void execute(ActivityExecutorContext<CreateGroup> execution) {
+
+    com.symphony.bdk.ext.group.gen.api.model.CreateGroup group = toCreateGroup(execution.getActivity());
+    ReadGroup createdGroup = execution.bdk().groups().insertGroup(group);
+
+    log.debug("Group created with id {}", createdGroup.getId());
+    execution.setOutputVariable(OUTPUTS_GROUP_KEY, createdGroup);
+  }
+
+  private com.symphony.bdk.ext.group.gen.api.model.CreateGroup toCreateGroup(CreateGroup createGroup) {
+    return new com.symphony.bdk.ext.group.gen.api.model.CreateGroup().type(createGroup.getType())
+        .ownerId(createGroup.getOwner().getId())
+        .ownerType(Owner.fromValue(createGroup.getOwner().getType()))
+        .name(createGroup.getName())
+        .subType(toSubType(createGroup))
+        .referrer(createGroup.getReferrer())
+        .members(toMembers(createGroup.getMembers()))
+        .profile(toProfile(createGroup.getProfile()))
+        .visibilityRestriction(toVisibilityRestriction(createGroup.getVisibilityRestriction()))
+        .implicitConnection(toImplicitConnection(createGroup.getImplicitConnection()))
+        .interactionTransfer(toInteractionTransfer(createGroup.getInteractionTransfer()));
+  }
+
+  private com.symphony.bdk.ext.group.gen.api.model.CreateGroup.SubTypeEnum toSubType(CreateGroup createGroup) {
+    if (createGroup.getSubType() == null) {
+      return null;
+    } else {
+      return com.symphony.bdk.ext.group.gen.api.model.CreateGroup.SubTypeEnum.valueOf(createGroup.getSubType());
+    }
+  }
+
+  static List<Member> toMembers(List<CreateGroup.GroupMember> members) {
+    if (members == null) {
+      return null;
+    }
+    return members.stream()
+        .map(m -> new Member().memberId(m.getUserId()).memberTenant(m.getTenantId()))
+        .collect(Collectors.toList());
+  }
+
+  static BaseProfile toProfile(CreateGroup.Profile profile) {
+    if (profile == null) {
+      return null;
+    } else {
+      BaseProfile baseProfile = new BaseProfile().displayName(profile.getDisplayName())
+          .companyName(profile.getCompanyName())
+          .email(profile.getEmail())
+          .mobile(profile.getMobile())
+          .industryOfInterest(profile.getIndustries())
+          .assetClassesOfInterest(profile.getIndustries())
+          .marketCoverage((profile.getMarketCoverages()))
+          .responsibility((profile.getResponsibilities()))
+          .function((profile.getFunctions()))
+          .instrument((profile.getInstruments()));
+      if (profile.getJob() != null) {
+        baseProfile.jobTitle(profile.getJob().getTitle())
+            .jobRole(profile.getJob().getRole())
+            .jobDepartment(profile.getJob().getDepartment())
+            .jobDivision(profile.getJob().getDivision())
+            .jobPhone(profile.getJob().getDivision())
+            .jobCity(profile.getJob().getCity());
+      }
+      return baseProfile;
+    }
+  }
+
+  static GroupVisibilityRestriction toVisibilityRestriction(CreateGroup.VisibilityRestriction visibilityRestriction) {
+    if (visibilityRestriction == null) {
+      return null;
+    } else {
+      return new GroupVisibilityRestriction().restrictedTenantsList(visibilityRestriction.getTenantIds())
+          .restrictedUsersList(visibilityRestriction.getUserIds());
+    }
+  }
+
+  static GroupImplicitConnection toImplicitConnection(CreateGroup.ImplicitConnection implicitConnection) {
+    if (implicitConnection == null) {
+      return null;
+    } else {
+      return new GroupImplicitConnection()
+          .connectedTenantsList(implicitConnection.getTenantIds())
+          .connectedUsersList(implicitConnection.getUserIds());
+    }
+  }
+
+  static GroupInteractionTransfer toInteractionTransfer(CreateGroup.InteractionTransfer interactionTransfer) {
+    if (interactionTransfer == null) {
+      return null;
+    } else {
+      return new GroupInteractionTransfer()
+          .restrictedTenantsList(interactionTransfer.getTenantIds())
+          .restrictedUsersList(interactionTransfer.getUserIds());
+    }
+  }
+}

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/group/CreateGroupExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/group/CreateGroupExecutor.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.workflow.engine.executor.group;
 
 import com.symphony.bdk.ext.group.gen.api.model.BaseProfile;
+import com.symphony.bdk.ext.group.gen.api.model.CreateGroup.SubTypeEnum;
 import com.symphony.bdk.ext.group.gen.api.model.GroupImplicitConnection;
 import com.symphony.bdk.ext.group.gen.api.model.GroupInteractionTransfer;
 import com.symphony.bdk.ext.group.gen.api.model.GroupVisibilityRestriction;
@@ -45,11 +46,11 @@ public class CreateGroupExecutor implements ActivityExecutor<CreateGroup> {
         .interactionTransfer(toInteractionTransfer(createGroup.getInteractionTransfer()));
   }
 
-  private com.symphony.bdk.ext.group.gen.api.model.CreateGroup.SubTypeEnum toSubType(CreateGroup createGroup) {
+  private SubTypeEnum toSubType(CreateGroup createGroup) {
     if (createGroup.getSubType() == null) {
       return null;
     } else {
-      return com.symphony.bdk.ext.group.gen.api.model.CreateGroup.SubTypeEnum.valueOf(createGroup.getSubType());
+      return SubTypeEnum.valueOf(createGroup.getSubType());
     }
   }
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/group/GetGroupExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/group/GetGroupExecutor.java
@@ -1,0 +1,23 @@
+package com.symphony.bdk.workflow.engine.executor.group;
+
+import com.symphony.bdk.ext.group.gen.api.model.ReadGroup;
+import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
+import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
+import com.symphony.bdk.workflow.swadl.v1.activity.group.GetGroup;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class GetGroupExecutor implements ActivityExecutor<GetGroup> {
+
+  private static final String OUTPUTS_GROUP_KEY = "group";
+
+  @Override
+  public void execute(ActivityExecutorContext<GetGroup> execution) {
+    String groupId = execution.getActivity().getGroupId();
+    log.debug("Getting group {}", groupId);
+    ReadGroup group = execution.bdk().groups().getGroup(groupId);
+    execution.setOutputVariable(OUTPUTS_GROUP_KEY, group);
+  }
+
+}

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/group/GetGroupsExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/group/GetGroupsExecutor.java
@@ -1,0 +1,49 @@
+package com.symphony.bdk.workflow.engine.executor.group;
+
+import com.symphony.bdk.ext.group.gen.api.model.GroupList;
+import com.symphony.bdk.ext.group.gen.api.model.SortOrder;
+import com.symphony.bdk.ext.group.gen.api.model.Status;
+import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
+import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
+import com.symphony.bdk.workflow.swadl.v1.activity.group.GetGroups;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class GetGroupsExecutor implements ActivityExecutor<GetGroups> {
+
+  private static final String OUTPUTS_GROUP_KEY = "groups";
+
+  @Override
+  public void execute(ActivityExecutorContext<GetGroups> execution) {
+    log.debug("Getting groups");
+
+    String typeId = execution.getActivity().getType();
+    Status status = toStatus(execution.getActivity().getStatus());
+    Integer limit = execution.getActivity().getLimit();
+    SortOrder sort = toSortOrder(execution.getActivity().getSortOrder());
+    String before = execution.getActivity().getBefore();
+    String after = execution.getActivity().getAfter();
+
+    GroupList groups = execution.bdk().groups().listGroups(typeId, status, before, after, limit, sort);
+
+    execution.setOutputVariable(OUTPUTS_GROUP_KEY, groups);
+  }
+
+  private Status toStatus(String status) {
+    if (status == null) {
+      return null;
+    } else {
+      return Status.fromValue(status);
+    }
+  }
+
+  private SortOrder toSortOrder(String sortOrder) {
+    if (sortOrder == null) {
+      return null;
+    } else {
+      return SortOrder.fromValue(sortOrder);
+    }
+  }
+
+}

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/group/UpdateGroupExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/group/UpdateGroupExecutor.java
@@ -1,0 +1,87 @@
+package com.symphony.bdk.workflow.engine.executor.group;
+
+import static com.symphony.bdk.workflow.engine.executor.group.CreateGroupExecutor.toImplicitConnection;
+import static com.symphony.bdk.workflow.engine.executor.group.CreateGroupExecutor.toInteractionTransfer;
+import static com.symphony.bdk.workflow.engine.executor.group.CreateGroupExecutor.toMembers;
+import static com.symphony.bdk.workflow.engine.executor.group.CreateGroupExecutor.toProfile;
+import static com.symphony.bdk.workflow.engine.executor.group.CreateGroupExecutor.toVisibilityRestriction;
+
+import com.symphony.bdk.ext.group.gen.api.model.Owner;
+import com.symphony.bdk.ext.group.gen.api.model.ReadGroup;
+import com.symphony.bdk.ext.group.gen.api.model.Status;
+import com.symphony.bdk.ext.group.gen.api.model.UploadAvatar;
+import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
+import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
+import com.symphony.bdk.workflow.swadl.v1.activity.group.CreateGroup;
+import com.symphony.bdk.workflow.swadl.v1.activity.group.UpdateGroup;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+@Slf4j
+public class UpdateGroupExecutor implements ActivityExecutor<UpdateGroup> {
+
+  private static final String OUTPUTS_GROUP_KEY = "group";
+
+  @Override
+  public void execute(ActivityExecutorContext<UpdateGroup> execution) throws IOException {
+
+    ReadGroup updatedGroup = null;
+    if (execution.getActivity().getImagePath() != null) {
+      try (InputStream image = execution.getResource(Path.of(execution.getActivity().getImagePath()))) {
+        updatedGroup = execution.bdk().groups().updateAvatar(execution.getActivity().getGroupId(),
+            new UploadAvatar().image(
+                IOUtils.toByteArray(image)));
+        // update etag in case we want to update other fields too
+        execution.getActivity().setEtag(updatedGroup.geteTag());
+      }
+      log.debug("Group avatar {} updated", execution.getActivity().getGroupId());
+    }
+
+    if (execution.getActivity().getStatus() != null) { // required field in case an update is performed
+      com.symphony.bdk.ext.group.gen.api.model.UpdateGroup group = toUpdateGroup(execution.getActivity());
+      updatedGroup = execution.bdk().groups().updateGroup(
+          execution.getActivity().getEtag(),
+          execution.getActivity().getGroupId(), group);
+      log.debug("Group {} updated", execution.getActivity().getGroupId());
+    }
+
+    if (updatedGroup != null) {
+      execution.setOutputVariable(OUTPUTS_GROUP_KEY, updatedGroup);
+    }
+  }
+
+  private com.symphony.bdk.ext.group.gen.api.model.UpdateGroup toUpdateGroup(UpdateGroup group) {
+    com.symphony.bdk.ext.group.gen.api.model.UpdateGroup updateGroup =
+        new com.symphony.bdk.ext.group.gen.api.model.UpdateGroup().type(group.getType())
+            .id(group.getGroupId())
+            .eTag(group.getEtag())
+            .name(group.getName())
+            .status(Status.valueOf(group.getStatus()))
+            .subType(toSubType(group))
+            .referrer(group.getReferrer())
+            .members(toMembers(group.getMembers()))
+            .profile(toProfile(group.getProfile()))
+            .visibilityRestriction(toVisibilityRestriction(group.getVisibilityRestriction()))
+            .implicitConnection(toImplicitConnection(group.getImplicitConnection()))
+            .interactionTransfer(toInteractionTransfer(group.getInteractionTransfer()));
+    if (group.getOwner() != null) {
+      updateGroup.ownerId(group.getOwner().getId())
+          .ownerType(Owner.fromValue(group.getOwner().getType()));
+    }
+    return updateGroup;
+  }
+
+  private com.symphony.bdk.ext.group.gen.api.model.UpdateGroup.SubTypeEnum toSubType(CreateGroup createGroup) {
+    if (createGroup.getSubType() == null) {
+      return null;
+    } else {
+      return com.symphony.bdk.ext.group.gen.api.model.UpdateGroup.SubTypeEnum.valueOf(createGroup.getSubType());
+    }
+  }
+
+}

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/GroupIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/GroupIntegrationTest.java
@@ -1,0 +1,40 @@
+package com.symphony.bdk.workflow;
+
+import static com.symphony.bdk.workflow.custom.assertion.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.symphony.bdk.ext.group.gen.api.model.GroupList;
+import com.symphony.bdk.ext.group.gen.api.model.ReadGroup;
+import com.symphony.bdk.workflow.swadl.SwadlParser;
+import com.symphony.bdk.workflow.swadl.v1.Workflow;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class GroupIntegrationTest extends IntegrationTest {
+
+  @Test
+  @DisplayName("Groups (SDL) basic operations")
+  void groupBasicOperations() throws Exception {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/group/group.swadl.yaml"));
+
+    when(groupService.insertGroup(any())).thenReturn(new ReadGroup().id("group-id-123").eTag("etag-123"));
+    when(groupService.updateGroup(eq("etag-123"), any(),
+        argThat(group -> "etag-123".equals(group.geteTag()) && "group-id-123".equals(group.getId()))))
+        .thenReturn(new ReadGroup().id("group-id-123"));
+    when(groupService.updateAvatar(any(), any())).thenReturn(new ReadGroup().id("group-id-123"));
+    when(groupService.getGroup("group-id-123")).thenReturn(new ReadGroup().id("group-id-123"));
+    when(groupService.listGroups(any(), any(), any(), any(), any(), any())).thenReturn(
+        new GroupList().addDataItem(new ReadGroup().id("group-id-123")));
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/start-group"));
+
+    assertThat(workflow).isExecuted();
+  }
+
+}

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/IntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/IntegrationTest.java
@@ -13,6 +13,7 @@ import com.symphony.bdk.core.service.message.model.Message;
 import com.symphony.bdk.core.service.session.SessionService;
 import com.symphony.bdk.core.service.stream.StreamService;
 import com.symphony.bdk.core.service.user.UserService;
+import com.symphony.bdk.ext.group.SymphonyGroupService;
 import com.symphony.bdk.gen.api.model.Stream;
 import com.symphony.bdk.gen.api.model.UserConnection;
 import com.symphony.bdk.gen.api.model.V4AttachmentInfo;
@@ -83,6 +84,9 @@ public abstract class IntegrationTest {
   @MockBean(name = "sessionService")
   SessionService sessionService;
 
+  @MockBean(name = "groupService")
+  SymphonyGroupService groupService;
+
   // BdkGateway is changed in setUpMocks method to return the beans above
   @MockBean(name = "springBdkGateway")
   BdkGateway bdkGateway;
@@ -126,6 +130,7 @@ public abstract class IntegrationTest {
     when(bdkGateway.streams()).thenReturn(this.streamService);
     when(bdkGateway.connections()).thenReturn(this.connectionService);
     when(bdkGateway.users()).thenReturn(this.userService);
+    when(bdkGateway.groups()).thenReturn(this.groupService);
   }
 
   // make sure we start the test with a clean engine to avoid the same /command to be registered

--- a/workflow-bot-app/src/test/resources/group/group.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/group/group.swadl.yaml
@@ -1,0 +1,61 @@
+id: group
+activities:
+  - create-group:
+      id: create
+      on:
+        message-received:
+          content: /start-group
+      type: SDL
+      name: test-group
+      profile:
+        display-name: Test
+      members:
+        - tenant-id: 190
+          user-id: 123
+      owner:
+        id: 123
+        type: TENANT
+  - update-group:
+      id: update
+      group-id: ${create.outputs.group.id}
+      e-tag: ${create.outputs.group.eTag}
+      name: test-group
+      status: ACTIVE
+      profile:
+        display-name: Test updated
+      owner:
+        id: 190
+        type: TENANT
+      members:
+        - tenant-id: 190
+          user-id: 123
+  - execute-script:
+      id: checkUpdate
+      script: |
+        assert create.outputs.group.id == update.outputs.group.id
+  - add-group-member:
+      id: add
+      group-id: ${create.outputs.group.id}
+      members:
+        - user-id: 123
+          tenant-id: 1
+        - user-id: 456
+          tenant-id: 2
+  - update-group:
+      id: updateAvatar
+      group-id: ${create.outputs.group.id}
+      image-path: "/attachments/logo.png"
+  - get-group:
+      id: get
+      group-id: ${create.outputs.group.id}
+  - execute-script:
+      id: checkGet
+      script: |
+        assert create.outputs.group.id == get.outputs.group.id
+  - get-groups:
+      id: gets
+      type: SDL
+  - execute-script:
+      id: checkGets
+      script: |
+        assert create.outputs.group.id == gets.outputs.groups.data[0].id

--- a/workflow-bot-app/src/test/resources/loop/loop-continue-activity.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/loop/loop-continue-activity.swadl.yaml
@@ -13,12 +13,15 @@ activities:
               if: ${variables.execution <= 1}
       script: |
         println "act1"
+        sleep 100 // make sure execution date differ
   - execute-script:
       id: act2
       script: |
         variables.execution++
+        sleep 100 // make sure execution date differ
   - execute-script:
       id: act3
       # = on/activity-completed: act2 without an if, i.e. the default flow after act2
       script: |
         println "act3"
+        sleep 100 // make sure execution date differ

--- a/workflow-bot-app/src/test/resources/loop/loop-more-activities.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/loop/loop-more-activities.swadl.yaml
@@ -13,11 +13,14 @@ activities:
               if: ${variables.execution <= 1}
       script: |
         println "act1"
+        sleep 100 // make sure execution date differ
   - execute-script:
       id: act2
       script: |
         variables.execution++
+        sleep 100 // make sure execution date differ
   - execute-script:
       id: act3
       script: |
         println "act3"
+        sleep 100 // make sure execution date differ

--- a/workflow-bot-app/src/test/resources/loop/loop.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/loop/loop.swadl.yaml
@@ -13,8 +13,10 @@ activities:
               if: ${variables.execution <= 1}
       script: |
         println "act1"
+        sleep 100 // make sure execution date differ
   - execute-script:
       id: act2
       script: |
         variables.execution++
-
+        sleep 100 // make sure execution date differ
+        

--- a/workflow-language/build.gradle
+++ b/workflow-language/build.gradle
@@ -8,9 +8,10 @@ javadoc {
 }
 
 dependencies {
-    api platform('org.finos.symphony.bdk:symphony-bdk-bom:2.5.0')
+    api platform('org.finos.symphony.bdk:symphony-bdk-bom:2.6.0')
 
     api 'org.finos.symphony.bdk:symphony-bdk-core'
+    api 'org.finos.symphony.bdk.ext:symphony-group-extension'
 
-    api 'com.fasterxml.jackson.core:jackson-annotations:2.13.1'
+    api 'com.fasterxml.jackson.core:jackson-annotations:2.13.2'
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/engine/executor/BdkGateway.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/engine/executor/BdkGateway.java
@@ -4,6 +4,7 @@ import com.symphony.bdk.core.service.connection.ConnectionService;
 import com.symphony.bdk.core.service.message.MessageService;
 import com.symphony.bdk.core.service.stream.StreamService;
 import com.symphony.bdk.core.service.user.UserService;
+import com.symphony.bdk.ext.group.SymphonyGroupService;
 
 /**
  * A gateway to access all the BDK services as the SymphonyBDK object is not exposed in the Spring Boot BDK starter.
@@ -28,4 +29,9 @@ public interface BdkGateway {
    * @return BDK service to manage connections.
    */
   ConnectionService connections();
+
+  /**
+   * @return BDK service to manage Symphony groups (aka SDLs).
+   */
+  SymphonyGroupService groups();
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/group/AddGroupMember.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/group/AddGroupMember.java
@@ -1,0 +1,18 @@
+package com.symphony.bdk.workflow.swadl.v1.activity.group;
+
+import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.List;
+
+/**
+ * @see <a href="https://developers.symphony.com/restapi/reference/addmembertogroup">Add member to group API</a>
+ */
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class AddGroupMember extends BaseActivity {
+  private String groupId;
+  private List<CreateGroup.GroupMember> members = List.of();
+}

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/group/CreateGroup.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/group/CreateGroup.java
@@ -1,0 +1,92 @@
+package com.symphony.bdk.workflow.swadl.v1.activity.group;
+
+import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * @see <a href="https://developers.symphony.com/restapi/reference/insertgroup">Add group API</a>
+ */
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class CreateGroup extends BaseActivity {
+  private String type = "SDL";
+  private Owner owner;
+  private String name;
+  @Nullable private String subType;
+  @Nullable private String referrer;
+  private List<GroupMember> members = List.of();
+
+  @Nullable private Profile profile;
+  @Nullable private VisibilityRestriction visibilityRestriction;
+  @Nullable private ImplicitConnection implicitConnection;
+  @Nullable private InteractionTransfer interactionTransfer;
+
+
+  @Data
+  public static class GroupMember {
+    private Long userId;
+    private Integer tenantId;
+  }
+
+
+  @Data
+  public static class Owner {
+    private Long id;
+    private String type;
+  }
+
+
+  @Data
+  public static class Profile {
+    @Nullable private String displayName;
+    @Nullable private String companyName;
+    @Nullable private String email;
+    @Nullable private String mobile;
+    @Nullable private Job job;
+
+    @Nullable private List<String> industries;
+    @Nullable private List<String> assetClasses;
+    @Nullable private Set<String> marketCoverages;
+    @Nullable private Set<String> responsibilities;
+    @Nullable private Set<String> functions;
+    @Nullable private Set<String> instruments;
+  }
+
+
+  @Data
+  public static class Job {
+    @Nullable private String title;
+    @Nullable private String role;
+    @Nullable private String department;
+    @Nullable private String division;
+    @Nullable private String phone;
+    @Nullable private String city;
+  }
+
+
+  @Data
+  public static class VisibilityRestriction {
+    @Nullable private List<Integer> tenantIds;
+    @Nullable private List<Long> userIds;
+  }
+
+
+  @Data
+  public static class ImplicitConnection {
+    @Nullable private List<Integer> tenantIds;
+    @Nullable private List<Long> userIds;
+  }
+
+
+  @Data
+  public static class InteractionTransfer {
+    @Nullable private List<Integer> tenantIds;
+    @Nullable private List<Long> userIds;
+  }
+}

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/group/GetGroup.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/group/GetGroup.java
@@ -1,0 +1,15 @@
+package com.symphony.bdk.workflow.swadl.v1.activity.group;
+
+import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * @see <a href="https://developers.symphony.com/restapi/reference/getgroup">Get group API</a>
+ */
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class GetGroup extends BaseActivity {
+  private String groupId;
+}

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/group/GetGroups.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/group/GetGroups.java
@@ -1,0 +1,22 @@
+package com.symphony.bdk.workflow.swadl.v1.activity.group;
+
+import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import javax.annotation.Nullable;
+
+/**
+ * @see <a href="https://developers.symphony.com/restapi/reference/listgroups">Get groups API</a>
+ */
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class GetGroups extends BaseActivity {
+  private String type = "SDL";
+  @Nullable private String status;
+  @Nullable private String before;
+  @Nullable private String after;
+  @Nullable private Integer limit = 100;
+  @Nullable private String sortOrder = "ASC"; // DESC
+}

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/group/UpdateGroup.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/group/UpdateGroup.java
@@ -1,0 +1,19 @@
+package com.symphony.bdk.workflow.swadl.v1.activity.group;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * @see <a href="https://developers.symphony.com/restapi/reference/updategroup">Update group API</a>
+ */
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class UpdateGroup extends CreateGroup {
+  private String groupId;
+  private String status;
+  @JsonProperty("e-tag")
+  private String etag;
+
+  private String imagePath;
+}

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/SendMessage.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/SendMessage.java
@@ -18,6 +18,7 @@ public class SendMessage extends BaseActivity {
   @Nullable private To to;
   @Nullable private List<Attachment> attachments;
 
+  @SuppressWarnings("unchecked")
   public void setContent(Object content) {
     if (content instanceof Map) {
       setTemplate(((Map<String, String>) content).get("template"));

--- a/workflow-language/src/main/resources/swadl-schema-1.0.json
+++ b/workflow-language/src/main/resources/swadl-schema-1.0.json
@@ -509,6 +509,81 @@
                                 "$ref": "#/definitions/get-connections-inner"
                             }
                         ]
+                    },
+                    "create-group": {
+                        "type": "object",
+                        "description": "Create a group (distribution list)",
+                        "x-intellij-html-description": "<html><p>Create a group (distribution list)</p><a href=\"https://developers.symphony.com/restapi/reference/insertgroup\">https://developers.symphony.com/restapi/reference/insertgroup</a></html>",
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/basic-activity-inner"
+                            },
+                            {
+                                "$ref": "#/definitions/create-group-inner"
+                            }
+                        ],
+                        "required": [
+                            "name",
+                            "owner",
+                            "members",
+                            "profile"
+                        ]
+                    },
+                    "update-group": {
+                        "type": "object",
+                        "description": "Update a group (distribution list)",
+                        "x-intellij-html-description": "<html><p>Update a group (distribution list)</p><a href=\"https://developers.symphony.com/restapi/reference/updategroup\">https://developers.symphony.com/restapi/reference/updategroup</a></html>",
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/basic-activity-inner"
+                            },
+                            {
+                                "$ref": "#/definitions/create-group-inner"
+                            },
+                            {
+                                "type": "object",
+                                "$ref": "#/definitions/update-group-inner"
+                            }
+                        ]
+                    },
+                    "get-group": {
+                        "type": "object",
+                        "description": "Retrieve a group (distribution list)",
+                        "x-intellij-html-description": "<html><p>Retrieve a group (distribution list)</p><a href=\"https://developers.symphony.com/restapi/reference/getgroup\">https://developers.symphony.com/restapi/reference/getgroup</a></html>",
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/basic-activity-inner"
+                            },
+                            {
+                                "$ref": "#/definitions/get-group-inner"
+                            }
+                        ]
+                    },
+                    "get-groups": {
+                        "type": "object",
+                        "description": "Retrieve groups of specified type (distribution list)",
+                        "x-intellij-html-description": "<html><p>Retrieve groups of specified type (distribution list)</p><a href=\"https://developers.symphony.com/restapi/reference/listgroups\">https://developers.symphony.com/restapi/reference/listgroups</a></html>",
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/basic-activity-inner"
+                            },
+                            {
+                                "$ref": "#/definitions/get-groups-inner"
+                            }
+                        ]
+                    },
+                    "add-group-member": {
+                        "type": "object",
+                        "description": "Add members to a group (distribution list)",
+                        "x-intellij-html-description": "<html><p>Add members to a group (distribution list)</p><a href=\"https://developers.symphony.com/restapi/reference/addmembertogroup\">https://developers.symphony.com/restapi/reference/addmembertogroup</a></html>",
+                        "allOf": [
+                            {
+                                "$ref": "#/definitions/basic-activity-inner"
+                            },
+                            {
+                                "$ref": "#/definitions/add-group-member-inner"
+                            }
+                        ]
                     }
                 },
                 "maxProperties": 1,
@@ -1507,7 +1582,7 @@
                     "description": "The recipient (conversation, IM, MIM or chatroom) in which the message should be posted.",
                     "$ref": "#/definitions/to"
                 },
-                "content" : {
+                "content": {
                     "$ref": "#/definitions/content-inner"
                 },
                 "attachments": {
@@ -1525,7 +1600,7 @@
         "update-message-inner": {
             "type": "object",
             "properties": {
-                "content" : {
+                "content": {
                     "$ref": "#/definitions/content-inner"
                 },
                 "message-id": {
@@ -2908,6 +2983,575 @@
                     ]
                 }
             }
+        },
+        "create-group-inner": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Group type identifier (for instance SDL).",
+                    "minLength": 1
+                },
+                "owner": {
+                    "type": "object",
+                    "$ref": "#/definitions/group-owner"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Group's name.",
+                    "minLength": 1
+                },
+                "sub-type": {
+                    "type": "string",
+                    "description": "The type of the company new groupType.",
+                    "enum": [
+                        "COMMUNITY",
+                        "CHANNEL"
+                    ]
+                },
+                "referrer": {
+                    "type": "string",
+                    "description": "Symphony, referring company name, referring channel partner name.",
+                    "minLength": 1
+                },
+                "members": {
+                    "type": "array",
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "$ref": "#/definitions/group-member"
+                            }
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^\\$\\{.*\\}$"
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ]
+                },
+                "profile": {
+                    "$ref": "#/definitions/group-profile"
+                }
+            }
+        },
+        "group-owner": {
+            "type": "object",
+            "required": [
+                "id",
+                "type"
+            ],
+            "properties": {
+                "id": {
+                    "anyOf": [
+                        {
+                            "type": [
+                                "string",
+                                "integer"
+                            ],
+                            "minLength": 1
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ],
+                    "description": "Owner id if the owner type is tenant (podId) or user (userId), otherwise null."
+                },
+                "type": {
+                    "type": "string",
+                    "default": "TENANT",
+                    "description": "Owner type. Ony TENANT supported now.",
+                    "enum": [
+                        "TENANT",
+                        "PLATFORM",
+                        "USER"
+                    ]
+                }
+            }
+        },
+        "group-member": {
+            "type": "object",
+            "required": [
+                "user-id",
+                "tenant-id"
+            ],
+            "properties": {
+                "user-id": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "minLength": 1,
+                    "minimum": 0,
+                    "description": "Member's user id."
+                },
+                "tenant-id": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "minLength": 1,
+                    "minimum": 0,
+                    "description": "Member's tenant id."
+                }
+            }
+        },
+        "group-profile": {
+            "type": "object",
+            "required": [
+                "display-name"
+            ],
+            "properties": {
+                "display-name": {
+                    "type": "string",
+                    "description": "The display name in Directory, it is expected to be the same as group name."
+                },
+                "company-name": {
+                    "type": "string",
+                    "description": "The company name is expected to be the same as group company owner."
+                },
+                "email": {
+                    "type": "string"
+                },
+                "mobile": {
+                    "type": "string"
+                },
+                "job": {
+                    "type": "object",
+                    "properties": {
+                        "title": {
+                            "type": "string"
+                        },
+                        "role": {
+                            "type": "string"
+                        },
+                        "department": {
+                            "type": "string"
+                        },
+                        "division": {
+                            "type": "string"
+                        },
+                        "phone": {
+                            "type": "string"
+                        },
+                        "city": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "asset-classes": {
+                    "description": "The group's asset classes (one or more).",
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "Equities",
+                                    "Cash Equities",
+                                    "Securities Lending",
+                                    "Fixed Income",
+                                    "Government Bonds",
+                                    "Prime Brokerage",
+                                    "Commodities",
+                                    "Municipal Bonds",
+                                    "Currencies",
+                                    "Corporate Bonds"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^\\$\\{.*\\}$"
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ]
+                },
+                "industries": {
+                    "description": "The group's job industries (one or more).",
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "Healthcare",
+                                    "Consumer Non-Cyclicals",
+                                    "Transportation",
+                                    "Technology",
+                                    "Real Estate",
+                                    "Basic Materials",
+                                    "Financials",
+                                    "Energy & Utilities",
+                                    "Conglomerates",
+                                    "Consumer Cyclicals",
+                                    "Services"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^\\$\\{.*\\}$"
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ]
+                },
+                "functions": {
+                    "description": "The group's job functions (one or more).",
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "Collateral",
+                                    "Confirmation",
+                                    "Trade Processing",
+                                    "Pre-Matching",
+                                    "Margin",
+                                    "Matching",
+                                    "Claims Processing",
+                                    "Middle Office",
+                                    "Liquidity Management",
+                                    "Allocation",
+                                    "Trade Management",
+                                    "Regulatory Outreach",
+                                    "Settlements",
+                                    "Post Trade Management"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^\\$\\{.*\\}$"
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ]
+                },
+                "market-coverages": {
+                    "description": "The group's market coverage (one or more).",
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "EMEA",
+                                    "NA",
+                                    "APAC",
+                                    "LATAM"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^\\$\\{.*\\}$"
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ]
+                },
+                "responsibilities": {
+                    "description": "The group's responsibilities (one or more).",
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "BAU",
+                                    "Escalation"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^\\$\\{.*\\}$"
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ]
+                },
+                "instruments": {
+                    "description": "The group's instruments (one or more).",
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "Securities",
+                                    "Fixed Income",
+                                    "Equities"
+                                ]
+                            }
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^\\$\\{.*\\}$"
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ]
+                },
+                "visibility-restriction": {
+                    "type": "object",
+                    "$ref": "#/definitions/tenants-users-list"
+                },
+                "implicit-connection": {
+                    "type": "object",
+                    "$ref": "#/definitions/tenants-users-list"
+                },
+                "interaction-transfer": {
+                    "type": "object",
+                    "$ref": "#/definitions/tenants-users-list"
+                }
+            }
+        },
+        "tenants-users-list": {
+            "type": "object",
+            "properties": {
+                "user-ids": {
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ],
+                                "minLength": 1,
+                                "minimum": 0
+                            }
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^\\$\\{.*\\}$"
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ]
+                },
+                "tenant-ids": {
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": [
+                                    "string",
+                                    "integer"
+                                ],
+                                "minLength": 1,
+                                "minimum": 0
+                            }
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^\\$\\{.*\\}$"
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "update-group-inner": {
+            "type": "object",
+            "required": [
+                "group-id"
+            ],
+            "properties": {
+                "group-id": {
+                    "$ref": "#/definitions/group-id"
+                },
+                "status": {
+                    "type": "string",
+                    "description": "Status flag to distinguish between active and deleted objects. Required to update group fields except the image-path.",
+                    "enum": [
+                        "ACTIVE",
+                        "DELETED"
+                    ]
+                },
+                "e-tag": {
+                    "type": "string",
+                    "description": "Required to update group fields except the image-path."
+                },
+                "image-path": {
+                    "description": "Path to the file to be uploaded as the group's avatar. The path is relative to the workflows folder.",
+                    "anyOf": [
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1
+                        }
+                    ]
+                }
+            }
+        },
+        "get-group-inner": {
+            "type": "object",
+            "required": [
+                "group-id"
+            ],
+            "properties": {
+                "group-id": {
+                    "$ref": "#/definitions/group-id"
+                }
+            }
+        },
+        "get-groups-inner": {
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "minLength": 1,
+                    "default": "SDL",
+                    "description": "Group type id."
+                },
+                "status": {
+                    "type": "string",
+                    "description": "Filter by status, active or deleted. If not specified both are returned.",
+                    "enum": [
+                        "ACTIVE",
+                        "DELETED"
+                    ]
+                },
+                "before": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "NOT SUPPORTED YET, currently ignored. Cursor that points to the start of the current page of data. If not present, the current page is the first page."
+                },
+                "after": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Cursor that points to the end of the current page of data. If not present, the current page is the last page."
+                },
+                "limit": {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "minLength": 1,
+                    "minimum": 0,
+                    "description": "Numbers of items to return.",
+                    "default": 100
+                },
+                "sort-order": {
+                    "type": "string",
+                    "enum": [
+                        "ASC",
+                        "DESC"
+                    ]
+                }
+            }
+        },
+        "add-group-member-inner": {
+            "type": "object",
+            "required": [
+                "group-id"
+            ],
+            "properties": {
+                "group-id": {
+                    "$ref": "#/definitions/group-id"
+                },
+                "members": {
+                    "type": "array",
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "$ref": "#/definitions/group-member"
+                            }
+                        },
+                        {
+                            "type": "string",
+                            "minLength": 1,
+                            "pattern": "^\\$\\{.*\\}$"
+                        },
+                        {
+                            "enum": [
+                                "${variables.VARIABLE_NAME}"
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "group-id": {
+            "anyOf": [
+                {
+                    "type": [
+                        "string",
+                        "integer"
+                    ],
+                    "minLength": 1
+                },
+                {
+                    "enum": [
+                        "${variables.VARIABLE_NAME}"
+                    ]
+                }
+            ],
+            "description": "Group's unique identifier."
         },
         "to": {
             "type": "object",

--- a/workflow-language/src/main/resources/swadl-schema-1.0.json
+++ b/workflow-language/src/main/resources/swadl-schema-1.0.json
@@ -3068,7 +3068,7 @@
                 "type": {
                     "type": "string",
                     "default": "TENANT",
-                    "description": "Owner type. Ony TENANT supported now.",
+                    "description": "Owner type. Only TENANT supported now.",
                     "enum": [
                         "TENANT",
                         "PLATFORM",


### PR DESCRIPTION
### Description
Groups (distribution lists) have recently been added in the BDK, we now
support them in the WDK too.

New activities:
- create-group
- update-group
- add-group-member
- get-group
- get-groups

Update avatar is supported through update-group to keep it simple.
The activities are pretty close to the APIs expect for some easy renames
to ease comprehension.

Also upgrade generator usage in doc.
Also upgrade dependencies.
Try to fix loop tests that are flaky because activities are executed too
fast so they have the same timestamp and are not properly ordered when
retrieved.

### Dependencies
N/A

### Checklist
- [X] Referenced a ticket in the PR title or description
- [X] Filled properly the description and dependencies, if any
- [X] Unit/Integration tests updated or added
- [X] Javadoc added or updated
- [X] Updated the documentation in [docs folder](../docs)
