### PR TITLE
Support utility functions in templates

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -782,6 +782,29 @@ Both [Freemarker](https://freemarker.apache.org/) (.ftl) and mml.xml format are 
 template field. By default, it will search for the file in the `./workflows` root folder.
 When [Freemarker](https://freemarker.apache.org/) is used, any workflow variable can be referenced in the external file,
 same format as it is for the any other activity in the SWADL file.
+[Utility functions](#utility-functions) can also be used inside templates.
+
+Example using Freemarker:
+
+```yaml
+id: pingPong
+variables:
+  reply: pong
+activities:
+  - send-message:
+      id: pingPong
+      on:
+        message-received:
+          content: /ping {message}
+      content:
+        template: message-with-params.ftl
+```
+
+message-with-params.ftl
+
+```
+<messageML>${variables.reply}: ${wdk.text(event.source.message.message)}</messageML>
+```
 
 In case the content to send is PresentationML. The `text` function might come handy, it uses
 the [PresentationMLParser](https://javadoc.io/doc/org.finos.symphony.bdk/symphony-bdk-core/latest/com/symphony/bdk/core/service/message/util/PresentationMLParser.html)
@@ -798,27 +821,6 @@ activities:
           content: /echo
       content:
         ${text(event.source.message.message)}
-```
-
-Example using Freemarker:
-
-```yaml
-activities:
-  variables:
-    val: world
-           - send-message:
-           id: echo
-           on:
-             message-received:
-               content: /echo
-           content:
-             template: message-with-params.ftl
-```
-
-message-with-params.ftl
-
-```
-<messageML>Hello ${variables.val}</messageML>
 ```
 
 #### attachments
@@ -2210,7 +2212,7 @@ Script to execute (only [Groovy](https://groovy-lang.org/) is supported).
 
 ## Utility functions
 
-WDK provides some utility functions that can be used to process data in SWADL.
+WDK provides some utility functions that can be used to process data in SWADL or in [templates](#send-message-content).
 
 ### Object json(String string)
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaEngineConfiguration.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaEngineConfiguration.java
@@ -37,7 +37,7 @@ public class CamundaEngineConfiguration implements ProcessEnginePlugin {
 
   @Override
   public void postInit(ProcessEngineConfigurationImpl processEngineConfiguration) {
-    processEngineConfiguration.getBeans().put("wdk", new UtilityFunctionsMapper());
+    processEngineConfiguration.getBeans().put(UtilityFunctionsMapper.NAME, new UtilityFunctionsMapper());
     handleScriptExceptionsAsBpmnErrors(processEngineConfiguration);
   }
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/UtilityFunctionsMapper.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/UtilityFunctionsMapper.java
@@ -24,6 +24,12 @@ import java.util.Map;
  */
 public class UtilityFunctionsMapper extends FunctionMapper {
 
+  /**
+   * How to call those functions from script tasks or from Freemarker templates.
+   * Usage: wdk.text(...) from a script or ${wdk.text(...)} from a template.
+   */
+  public static final String NAME = "wdk";
+
   private static final Map<String, Method> FUNCTION_MAP;
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -38,16 +44,16 @@ public class UtilityFunctionsMapper extends FunctionMapper {
     FUNCTION_MAP.put("emojis", ReflectUtil.getMethod(UtilityFunctionsMapper.class, "emojis", Object.class));
   }
 
+  public Method resolveFunction(String prefix, String localName) {
+    return FUNCTION_MAP.get(localName);
+  }
+
   public static Object json(String string) {
     try {
       return objectMapper.readValue(string, Object.class);
     } catch (JsonProcessingException jsonProcessingException) {
       return string;
     }
-  }
-
-  public Method resolveFunction(String prefix, String localName) {
-    return FUNCTION_MAP.get(localName);
   }
 
   public static String text(String presentationMl) throws PresentationMLParserException {

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/SendMessageExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/SendMessageExecutor.java
@@ -11,6 +11,7 @@ import com.symphony.bdk.gen.api.model.V4Message;
 import com.symphony.bdk.gen.api.model.V4MessageBlastResponse;
 import com.symphony.bdk.gen.api.model.V4MessageSent;
 import com.symphony.bdk.gen.api.model.V4SymphonyElementsAction;
+import com.symphony.bdk.workflow.engine.camunda.UtilityFunctionsMapper;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
 import com.symphony.bdk.workflow.swadl.v1.activity.message.SendMessage;
@@ -114,11 +115,14 @@ public class SendMessageExecutor implements ActivityExecutor<SendMessage> {
     } else {
       String template = execution.getActivity().getTemplate();
       File file = execution.getResourceFile(Path.of(template));
+      Map<String, Object> templateVariables = new HashMap<>(execution.getVariables());
+      // also bind our utility functions so they can be used inside templates
+      templateVariables.put(UtilityFunctionsMapper.NAME, new UtilityFunctionsMapper());
       return execution.bdk()
           .messages()
           .templates()
           .newTemplateFromFile(file.getPath())
-          .process(execution.getVariables());
+          .process(templateVariables);
     }
   }
 

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/SendMessageIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/SendMessageIntegrationTest.java
@@ -158,19 +158,22 @@ class SendMessageIntegrationTest extends IntegrationTest {
   }
 
   @Test
-  void sendMessageWithTemplateSuccessfull() throws IOException, ProcessingException {
+  void sendMessageWithTemplateSuccessful() throws IOException, ProcessingException {
     final Workflow workflow =
         SwadlParser.fromYaml(getClass().getResourceAsStream("/message/send-message-with-freemarker.swadl.yaml"));
 
     TemplateEngine templateEngine = TemplateEngine.getDefaultImplementation();
     when(messageService.templates()).thenReturn(templateEngine);
+    when(messageService.send(eq("123"), any(Message.class))).thenReturn(message("MSG_ID"));
+
     engine.deploy(workflow);
     engine.onEvent(messageReceived("/send"));
 
     assertThat(workflow).isExecuted();
     ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
     verify(messageService, times(1)).send(eq("123"), messageArgumentCaptor.capture());
-    assertThat(messageArgumentCaptor.getValue().getContent()).isEqualTo("<messageML>Hello world!\n</messageML>");
+    assertThat(messageArgumentCaptor.getValue().getContent())
+        .isEqualTo("<messageML>Hello <presentationML>world</presentationML> world!\n</messageML>");
   }
 
   @Test

--- a/workflow-bot-app/src/test/resources/message/send-message-with-freemarker.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/send-message-with-freemarker.swadl.yaml
@@ -1,6 +1,6 @@
 id: sendMessageWithTemplate
 variables:
-  val: world
+  val: <presentationML>world</presentationML>
 activities:
   - send-message:
       id: sendMessageTemplateWithParams

--- a/workflow-bot-app/src/test/resources/message/templates/message-freemarker.ftl
+++ b/workflow-bot-app/src/test/resources/message/templates/message-freemarker.ftl
@@ -1,1 +1,1 @@
-Hello ${variables.val}!
+Hello ${variables.val} ${wdk.text(variables.val)}!


### PR DESCRIPTION
### Description
We can now use functions such as text,emojis,... im templates directly.
This is supported by adding a new 'wdk' object in the freemarker
variables on which methods can be called:

${wdk.text(...)}

Fixes #95

### Dependencies
N/A

### Checklist
- [X] Referenced a ticket in the PR title or description
- [X] Filled properly the description and dependencies, if any
- [X] Unit/Integration tests updated or added
- [X] Javadoc added or updated
- [X] Updated the documentation in [docs folder](../docs)
