### PR TITLE
Added encodeRawQuery and decodeRawQuery to encode/decode url query parameters

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2119,7 +2119,7 @@ Key | Type | Required |
 [method](#method) | String | No |
 [body](#body) | Object/String | No |
 [headers](#headers) | String | No |
-
+[encode-query-params](#encode-query-params) | Boolean | No |
 Output | Type |
 ----|----|
 body | Object/String
@@ -2155,7 +2155,8 @@ activities:
 
 String that contains the host and the path to be targeted.
 
-The query parameters values are encoded with UTF-8 format by the activity.
+The query parameters values are, by default, encoded with UTF-8 format by the activity.
+The encoding can be disabled using [encode-query-params](#encode-query-params).
 
 #### method
 
@@ -2184,6 +2185,10 @@ HTTP request headers. A map of key/value entries is expected. Simple types such 
 as lists and maps are supported.
 
 Unless set explicitly the `Content-Type` header will be `application/json` by default.
+
+### encode-query-params
+If false, the url query parameters will not be encoded.
+It is set to true by default.
 
 ### execute-script
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -9,7 +9,7 @@ read about its syntax on [Wikipedia](https://en.wikipedia.org/wiki/YAML#Syntax).
 In SWADL, at the top level, you mainly define the activities part of the workflow.
 
 Key     | Type    | Required |
---------------|---------|----------| 
+--------------|---------|----------|
 [id](#id)            | String  | Yes    |
 [variables](#variables)     | Map     | No     |
 [activities](#activities)    | List   | Yes     |
@@ -67,7 +67,7 @@ events.
 Activities have common keys listed below:
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 [id](#activity-id) | String | Yes |
 [on](#on) | Map | No |
 [if](#if) | String | No |
@@ -100,7 +100,7 @@ Events that can trigger the activity execution. **The first activity of a workfl
 [List of real-time events](https://docs.developers.symphony.com/building-bots-on-symphony/datafeed/real-time-events)
 
 Key     | Type    | Required |
---------------|---------|----------| 
+--------------|---------|----------|
 [Typed Event](#events)    | Map   | No     |
 [one-of](#one-of)     | List     | No     |
 [timeout](#timeout)  | String  | No    |
@@ -192,7 +192,7 @@ Generated when a message is sent in an IM, MIM, or chatroom of which the workflo
 sent by the user him/herself.
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 [content](#content) | String | No |
 [requires-bot-mention](#requires-bot-mention) | Boolean | No |
 
@@ -271,7 +271,7 @@ controls can be used as normal.
 _nb: Loops are only supported with forms that require only one reply._
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 [form-id](#form-id) | String | Yes |
 [exclusive](#exclusive) | String | No |
 
@@ -448,7 +448,7 @@ This is usually used for forms when a specific activity is triggered upon expira
 longer valid or to collect results).
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 [activity-id](#expired-activity-id) | String | Yes |
 
 Example:
@@ -502,7 +502,7 @@ If no event are set for a given activity this is the default event that will be 
 previously declared activity (hence the sequential ordering by default).
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 [activity-id](#completed-activity-id) | String | Yes |
 [if](#completed-if) | String | No |
 
@@ -552,7 +552,7 @@ activities:
       id: start
       on:
         one-of:
-          # a slash command is used to trigger the workflow 
+          # a slash command is used to trigger the workflow
           - message-received:
               content: /execute
           # but this activity (once the workflow is running) can also start after the loop activity is executed
@@ -583,7 +583,7 @@ Generated when the given activity has failed. **Note this is not a Datafeed real
 Exceptions raised by activities will trigger this event. This gives a way to let the user know about a failure.
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 [activity-id](#failed-activity-id) | String | Yes |
 
 Example:
@@ -616,7 +616,7 @@ Timer based event. It is either triggered at a given point in time using the key
 keyword `repeat`. **Note this is not a Datafeed real-time event.**
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 [at](#at) | String | Yes |
 [repeat](#repeat) | String | Yes |
 
@@ -648,7 +648,7 @@ called by external users to manually trigger a workflow execution. This event ca
 a workflow.
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 [token](#token) | String | Yes |
 
 Example:
@@ -697,7 +697,7 @@ key. [Custom activities](./custom-activities.md) can be defined too.
 Posts a message to a stream. Probably the most commonly used activity to interact with end-users.
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 [to](#to) | Map | No |
 [content](#send-message-content) | String/Object | Yes |
 [attachments](#attachments) | List | No |
@@ -728,7 +728,7 @@ If not set, the stream associated with the latest received event is used. This m
 user easy.
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 [stream-id](#stream-id) | String | Yes |
 [stream-ids](#stream-ids) | String | Yes |
 [user-ids](#user-ids) | Map | Yes |
@@ -775,7 +775,7 @@ Content can either be set directly in the SWADL file as plain text (String) or i
 file (Object). When using an external file the content has to be defined as follows:
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 template | String | Yes |
 
 Both [Freemarker](https://freemarker.apache.org/) (.ftl) and mml.xml format are accepted as external files in the
@@ -829,7 +829,7 @@ One or more attachments to be sent along with the message. It can be either an e
 or a file local to the bot. Previews are not supported.
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 [message-id](#message-id) | String | Yes |
 [attachment-id](#attachment-id) | Map | No |
 
@@ -961,7 +961,7 @@ as the api response)
 Creates a new chatroom.
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 [room-name](#room-name) | String | Yes |
 [room-description](#room-description) | String | Yes |
 [user-ids](#create-room-user-ids) | List | Yes |
@@ -1019,7 +1019,7 @@ read-only and can’t be updated.
 Updates the attributes of an existing chat room.
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 [stream-id](#update-room-stream-id) | String | Yes |
 [room-name](#room-name) | String | Yes |
 [room-description](#room-description) | String | Yes |
@@ -1098,7 +1098,7 @@ If false, the room is not active anymore.
 Adds new members to an existing room.
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 stream-id | String | Yes |
 user-ids | List | Yes |
 
@@ -1121,7 +1121,7 @@ activities:
 Removes members from an existing room.
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 stream-id | String | Yes |
 user-ids | List | Yes |
 
@@ -1132,7 +1132,7 @@ user-ids | List | Yes |
 Promotes user to owner of the chat room.
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 stream-id | String | Yes |
 user-ids | List | Yes |
 
@@ -1143,7 +1143,7 @@ user-ids | List | Yes |
 Demotes room owner to a participant in the chat room.
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 stream-id | String | Yes |
 user-ids | List | Yes |
 
@@ -1381,7 +1381,7 @@ members | List of [MemberInfo](https://javadoc.io/doc/org.finos.symphony.bdk/sym
 Creates a new end user.
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 [email](#email) | String | Yes |
 [firstname](#firstname) | String | Yes |
 [lastname](#lastname) | String | Yes |
@@ -1433,7 +1433,7 @@ User's password. The password object is optional. For example, if your organizat
 specify the password.
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 hashed-password | String | Yes |
 hashed-salt | String | Yes |
 hashed-km-password | String | No |
@@ -1452,7 +1452,7 @@ Example: _en-US_
 Contact information.
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 work-phone-number | String | No |
 mobile-phone-number| String | No |
 two-factor-auth-number | String | No |
@@ -1463,7 +1463,7 @@ sms-number | String | No |
 Business information.
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 company-name | String | No |
 department | String | No |
 division | String | No |
@@ -1626,7 +1626,7 @@ User status: ENABLED or DISABLED.
 Updates an existing end user.
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 user-id | String | Yes |
 [email](#email) | String | No |
 [firstname](#firstname) | String | No |
@@ -1654,7 +1654,7 @@ user | [V2UserDetail](https://javadoc.io/doc/org.finos.symphony.bdk/symphony-bdk
 Creates a new service user.
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 [email](#email) | String | Yes |
 [display-name](#display-name) | String | Yes |
 [username](#username) | String | Yes |
@@ -1677,14 +1677,14 @@ Example: [create system user workflow](./examples/create-service-account.swadl.y
 For service users, to set up the RSA keys for authentication.
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 [current](#key) | String | Yes |
 [previous](#key) | String | Yes |
 
 ##### current / previous (key)
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 [action](#action) | String | Yes |
 [key](#key) | String | Yes |
 [expiration](#expiration) | String | No |
@@ -1717,7 +1717,7 @@ is only set for rotated keys.
 Updates an existing service user.
 
 Key | Type | Required |
------------- | -------| --- | 
+------------ | -------| --- |
 user-id | String | Yes |
 [email](#email) | String | No |
 [display-name](#display-name) | String | No |
@@ -2155,6 +2155,8 @@ activities:
 
 String that contains the host and the path to be targeted.
 
+The query parameters values are encoded with UTF-8 format by the activity.
+
 #### method
 
 HTTP method to perform. GET is the default one.
@@ -2233,7 +2235,7 @@ activities:
 
   - send-message: # will send the string content
       id: processJsonString
-      content: ${json(variables.aString)} 
+      content: ${json(variables.aString)}
 ```
 
 in [execute-script](#execute-script)

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/UtilityFunctionsMapper.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/UtilityFunctionsMapper.java
@@ -10,23 +10,14 @@ import com.symphony.bdk.workflow.engine.executor.EventHolder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang3.StringUtils;
 import org.camunda.bpm.engine.impl.javax.el.FunctionMapper;
 import org.camunda.bpm.engine.impl.util.ReflectUtil;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.util.UriComponents;
-import org.springframework.web.util.UriComponentsBuilder;
 
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
-import java.net.URLDecoder;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Utilities for EL evaluation by Camunda.
@@ -74,49 +65,6 @@ public class UtilityFunctionsMapper extends FunctionMapper {
       return null;
     }
     return new String(JsonStringEncoder.getInstance().quoteAsString(s));
-  }
-
-  public static String encodeRawQuery(String url) throws UnsupportedEncodingException {
-    return encodeRawQuery(url, StandardCharsets.UTF_8.name());
-  }
-
-  public static String encodeRawQuery(String url, String encoding)
-      throws UnsupportedEncodingException {
-    UriComponents uriComponents = UriComponentsBuilder.fromUriString(url).build();
-    MultiValueMap<String, String> queryParamsMap = uriComponents.getQueryParams();
-
-    String rawQuery = uriComponents.getQueryParams()
-        .keySet()
-        .stream()
-        .map(key ->
-            key + "=" + queryParamsMap.get(key).get(0))
-        .collect(Collectors.joining("&"));
-
-    rawQuery = URLEncoder.encode(rawQuery, encoding);
-
-    StringBuilder encodedBuilder = new StringBuilder(uriComponents.getScheme() + "://" + uriComponents.getHost());
-
-    if (uriComponents.getPort() != -1) {
-      encodedBuilder.append(":").append(uriComponents.getPort());
-    }
-
-    encodedBuilder.append(uriComponents.getPath());
-
-    if (StringUtils.isNotBlank(rawQuery)) {
-      encodedBuilder.append("?");
-    }
-
-    encodedBuilder.append(rawQuery);
-
-    return encodedBuilder.toString();
-  }
-
-  public static String decodeRawQuery(String url) throws UnsupportedEncodingException {
-    return URLDecoder.decode(url, StandardCharsets.UTF_8.name());
-  }
-
-  public static String decodeRawQuery(String url, String encoding) throws UnsupportedEncodingException {
-    return URLDecoder.decode(url, encoding);
   }
 
   @SuppressWarnings("rawtypes")

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/UtilityFunctionsMapper.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/UtilityFunctionsMapper.java
@@ -45,6 +45,8 @@ public class UtilityFunctionsMapper extends FunctionMapper {
     FUNCTION_MAP.put("text", ReflectUtil.getMethod(UtilityFunctionsMapper.class, "text", String.class));
     FUNCTION_MAP.put("json", ReflectUtil.getMethod(UtilityFunctionsMapper.class, "json", String.class));
     FUNCTION_MAP.put("escape", ReflectUtil.getMethod(UtilityFunctionsMapper.class, "escape", String.class));
+    FUNCTION_MAP.put("encodeQueryParameters",
+        ReflectUtil.getMethod(UtilityFunctionsMapper.class, "encodeQueryParameters", Object.class));
     FUNCTION_MAP.put("mentions", ReflectUtil.getMethod(UtilityFunctionsMapper.class, "mentions", Object.class));
     FUNCTION_MAP.put("hashTags", ReflectUtil.getMethod(UtilityFunctionsMapper.class, "hashTags", Object.class));
     FUNCTION_MAP.put("cashTags", ReflectUtil.getMethod(UtilityFunctionsMapper.class, "cashTags", Object.class));

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/UtilityFunctionsMapper.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/UtilityFunctionsMapper.java
@@ -10,6 +10,7 @@ import com.symphony.bdk.workflow.engine.executor.EventHolder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.StringUtils;
 import org.camunda.bpm.engine.impl.javax.el.FunctionMapper;
 import org.camunda.bpm.engine.impl.util.ReflectUtil;
 import org.springframework.util.MultiValueMap;
@@ -99,8 +100,10 @@ public class UtilityFunctionsMapper extends FunctionMapper {
       encodedBuilder.append(":").append(uriComponents.getPort());
     }
 
-    if (uriComponents.getPath() != null) {
-      encodedBuilder.append(uriComponents.getPath()).append("?");
+    encodedBuilder.append(uriComponents.getPath());
+
+    if (StringUtils.isNotBlank(rawQuery)) {
+      encodedBuilder.append("?");
     }
 
     encodedBuilder.append(rawQuery);

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/UtilityFunctionsMapper.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/UtilityFunctionsMapper.java
@@ -12,19 +12,12 @@ import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.camunda.bpm.engine.impl.javax.el.FunctionMapper;
 import org.camunda.bpm.engine.impl.util.ReflectUtil;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.util.UriComponentsBuilder;
 
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
-import java.net.URLDecoder;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Utilities for EL evaluation by Camunda.
@@ -45,8 +38,6 @@ public class UtilityFunctionsMapper extends FunctionMapper {
     FUNCTION_MAP.put("text", ReflectUtil.getMethod(UtilityFunctionsMapper.class, "text", String.class));
     FUNCTION_MAP.put("json", ReflectUtil.getMethod(UtilityFunctionsMapper.class, "json", String.class));
     FUNCTION_MAP.put("escape", ReflectUtil.getMethod(UtilityFunctionsMapper.class, "escape", String.class));
-    FUNCTION_MAP.put("encodeQueryParameters",
-        ReflectUtil.getMethod(UtilityFunctionsMapper.class, "encodeQueryParameters", Object.class));
     FUNCTION_MAP.put("mentions", ReflectUtil.getMethod(UtilityFunctionsMapper.class, "mentions", Object.class));
     FUNCTION_MAP.put("hashTags", ReflectUtil.getMethod(UtilityFunctionsMapper.class, "hashTags", Object.class));
     FUNCTION_MAP.put("cashTags", ReflectUtil.getMethod(UtilityFunctionsMapper.class, "cashTags", Object.class));
@@ -74,41 +65,6 @@ public class UtilityFunctionsMapper extends FunctionMapper {
       return null;
     }
     return new String(JsonStringEncoder.getInstance().quoteAsString(s));
-  }
-
-  public static String encodeQueryParameters(String fullUrl) {
-    MultiValueMap<String, String> queryParamsMap =
-        UriComponentsBuilder.fromUriString(fullUrl).build().getQueryParams();
-
-    UriComponentsBuilder uriComponentsBuilder =
-        UriComponentsBuilder.fromUriString(fullUrl);
-
-    queryParamsMap
-        .keySet()
-        .stream()
-        .filter(k -> !isAlreadyEncoded(queryParamsMap.get(k).get(0))).collect(Collectors.toList())
-        .forEach(
-            key -> {
-              try {
-                uriComponentsBuilder.replaceQueryParam(key,
-                    URLEncoder.encode(queryParamsMap.get(key).get(0), StandardCharsets.UTF_8.name()));
-              } catch (UnsupportedEncodingException e) {
-                e.printStackTrace();
-              }
-            });
-
-    return uriComponentsBuilder.build().toUriString();
-  }
-
-  private static boolean isAlreadyEncoded(String value) {
-    boolean isAlreadyEncoded = false;
-    try {
-      isAlreadyEncoded = !URLDecoder.decode(value, StandardCharsets.UTF_8.name()).equals(value);
-    } catch (UnsupportedEncodingException | IllegalArgumentException e) {
-      e.printStackTrace();
-    }
-
-    return isAlreadyEncoded;
   }
 
   @SuppressWarnings("rawtypes")

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/ExecuteRequestExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/ExecuteRequestExecutor.java
@@ -32,7 +32,10 @@ public class ExecuteRequestExecutor implements ActivityExecutor<ExecuteRequest> 
   @Override
   public void execute(ActivityExecutorContext<ExecuteRequest> execution) throws IOException {
     ExecuteRequest activity = execution.getActivity();
-    activity.setUrl(UtilityFunctionsMapper.encodeQueryParameters(activity.getUrl()));
+
+    if (activity.isEncodeQueryParams()) {
+      activity.setUrl(UtilityFunctionsMapper.encodeQueryParameters(activity.getUrl()));
+    }
 
     log.info("Executing request {} {}", activity.getMethod(), activity.getUrl());
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/ExecuteRequestExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/ExecuteRequestExecutor.java
@@ -60,8 +60,9 @@ public class ExecuteRequestExecutor implements ActivityExecutor<ExecuteRequest> 
     MultiValueMap<String, String> queryParamsMap =
         UriComponentsBuilder.fromUriString(fullUrl).build().getQueryParams();
 
-    if (splitUrl.length > 1) {
+    if (!queryParamsMap.isEmpty()) {
       log.info("Encoding query parameters with Standard UTF-8 format");
+
       String rawQuery = queryParamsMap
           .keySet()
           .stream()

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/ExecuteRequestExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/ExecuteRequestExecutor.java
@@ -1,6 +1,5 @@
 package com.symphony.bdk.workflow.engine.executor.request;
 
-import com.symphony.bdk.workflow.engine.camunda.UtilityFunctionsMapper;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
 import com.symphony.bdk.workflow.engine.executor.request.client.HttpClient;
@@ -34,7 +33,7 @@ public class ExecuteRequestExecutor implements ActivityExecutor<ExecuteRequest> 
     ExecuteRequest activity = execution.getActivity();
 
     if (activity.isEncodeQueryParams()) {
-      activity.setUrl(UtilityFunctionsMapper.encodeQueryParameters(activity.getUrl()));
+      activity.setUrl(ExecuteRequestUtils.encodeQueryParameters(activity.getUrl()));
     }
 
     log.info("Executing request {} {}", activity.getMethod(), activity.getUrl());

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/ExecuteRequestUtils.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/ExecuteRequestUtils.java
@@ -1,0 +1,45 @@
+package com.symphony.bdk.workflow.engine.executor.request;
+
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ExecuteRequestUtils {
+
+  ExecuteRequestUtils() {}
+
+  public static String encodeQueryParameters(String fullUrl) {
+    MultiValueMap<String, String> queryParamsMap =
+        UriComponentsBuilder.fromUriString(fullUrl).build().getQueryParams();
+
+    UriComponentsBuilder uriComponentsBuilder =
+        UriComponentsBuilder.fromUriString(fullUrl);
+
+    queryParamsMap
+        .keySet()
+        .forEach(
+            key -> {
+              List<String> encodedValues =
+                  queryParamsMap.get(key)
+                      .stream()
+                      .map(ExecuteRequestUtils::encode)
+                      .collect(Collectors.toList());
+              uriComponentsBuilder.replaceQueryParam(key, encodedValues);
+            });
+
+    return uriComponentsBuilder.build().toUriString();
+  }
+
+  private static String encode(String value) {
+    try {
+      return URLEncoder.encode(value, StandardCharsets.UTF_8.name());
+    } catch (UnsupportedEncodingException e) {
+      return value;
+    }
+  }
+}

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/ExecuteRequestUtils.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/ExecuteRequestUtils.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.workflow.engine.executor.request;
 
+import lombok.experimental.UtilityClass;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -9,9 +10,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@UtilityClass
 public class ExecuteRequestUtils {
-
-  ExecuteRequestUtils() {}
 
   public static String encodeQueryParameters(String fullUrl) {
     UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromUriString(fullUrl);

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/ExecuteRequestUtils.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/ExecuteRequestUtils.java
@@ -14,25 +14,22 @@ public class ExecuteRequestUtils {
   ExecuteRequestUtils() {}
 
   public static String encodeQueryParameters(String fullUrl) {
-    MultiValueMap<String, String> queryParamsMap =
-        UriComponentsBuilder.fromUriString(fullUrl).build().getQueryParams();
+    UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromUriString(fullUrl);
+    MultiValueMap<String, String> queryParamsMap = uriComponentsBuilder.build().getQueryParams();
 
-    UriComponentsBuilder uriComponentsBuilder =
-        UriComponentsBuilder.fromUriString(fullUrl);
-
+    UriComponentsBuilder clone = uriComponentsBuilder.cloneBuilder();
     queryParamsMap
         .keySet()
-        .forEach(
-            key -> {
-              List<String> encodedValues =
-                  queryParamsMap.get(key)
-                      .stream()
-                      .map(ExecuteRequestUtils::encode)
-                      .collect(Collectors.toList());
-              uriComponentsBuilder.replaceQueryParam(key, encodedValues);
-            });
+        .forEach(key -> {
+          List<String> encodedValues =
+              queryParamsMap.get(key)
+                  .stream()
+                  .map(ExecuteRequestUtils::encode)
+                  .collect(Collectors.toList());
+          clone.replaceQueryParam(key, encodedValues);
+        });
 
-    return uriComponentsBuilder.build().toUriString();
+    return clone.build().toUriString();
   }
 
   private static String encode(String value) {

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/ExecuteRequestIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/ExecuteRequestIntegrationTest.java
@@ -134,23 +134,6 @@ class ExecuteRequestIntegrationTest extends IntegrationTest {
     final Workflow workflow = SwadlParser.fromYaml(
         getClass().getResourceAsStream("/request/execute-request-encode-query-parameters.swadl.yaml"));
 
-    /*putFirstActivityUrl(workflow, wmRunTimeInfo.getHttpBaseUrl() + "/api");//?key1=value 1&key2=value@!$2&key3=value%3");
-
-
-    Map<String, StringValuePattern> stringStringValuePatternMap = new HashMap<>();
-    stringStringValuePatternMap.put("key1", equalTo("value+1"));
-    stringStringValuePatternMap.put("key2", equalTo("value%40%21%242"));
-    stringStringValuePatternMap.put("key3", equalTo("value%253"));
-    //.withQueryParams(stringStringValuePatternMap)
-    stubFor(post(UrlPattern.ANY)
-        .willReturn(ok().withHeader("Content-Type", "application/json").withBody("{\"response\": \"ok\"}")));
-
-    engine.deploy(workflow);
-
-    engine.onEvent(messageReceived("/execute"));
-
-    System.out.println("debug");*/
-
     putFirstActivityUrl(workflow, wmRuntimeInfo.getHttpBaseUrl() + "/api?key1=v 1&key2=value@!$2&key3=value%3");
 
     Map<String, StringValuePattern> stringStringValuePatternMap = new HashMap<>();

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/ExecuteRequestIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/ExecuteRequestIntegrationTest.java
@@ -11,6 +11,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.patch;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.symphony.bdk.workflow.custom.assertion.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -21,16 +22,13 @@ import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
-import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import com.github.tomakehurst.wiremock.matching.UrlPattern;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 
 @WireMockTest
@@ -136,13 +134,7 @@ class ExecuteRequestIntegrationTest extends IntegrationTest {
 
     putFirstActivityUrl(workflow, wmRuntimeInfo.getHttpBaseUrl() + "/api?key1=v 1&key2=value@!$2&key3=value%3");
 
-    Map<String, StringValuePattern> stringStringValuePatternMap = new HashMap<>();
-    stringStringValuePatternMap.put("key1", equalTo("v 1"));
-    stringStringValuePatternMap.put("key2", equalTo("value@!$2"));
-    stringStringValuePatternMap.put("key3", equalTo("value%3"));
-
-    stubFor(post(UrlPattern.ANY)
-        .withQueryParams(stringStringValuePatternMap)
+    stubFor(post("/api?key1=v+1&key2=value%40%21%242&key3=value%253")
         .willReturn(ok().withHeader("Content-Type", "application/json")
             .withBody("{\"message\": \"ok\"}")));
 
@@ -151,6 +143,42 @@ class ExecuteRequestIntegrationTest extends IntegrationTest {
     engine.onEvent(messageReceived("/execute"));
 
     assertThat(workflow).isExecuted().executed("executeRequestWithQueryParams", "assertionScript");
+  }
+
+  @Test
+  void executeRequestNotEncodeQueryParameters(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+    final Workflow workflow = SwadlParser.fromYaml(
+        getClass().getResourceAsStream("/request/execute-request-not-encode-query-parameters.swadl.yaml"));
+
+    putFirstActivityUrl(workflow, wmRuntimeInfo.getHttpBaseUrl() + "/api?key1=value%201&key2=value%402");
+
+    stubFor(post(urlEqualTo("/api?key1=value%201&key2=value%402"))
+        .willReturn(ok().withHeader("Content-Type", "application/json")
+            .withBody("{\"message\": \"ok\"}")));
+
+    engine.deploy(workflow);
+
+    engine.onEvent(messageReceived("/execute"));
+
+    assertThat(workflow).isExecuted().executed("executeRequestWithEncodedQueryParams", "assertionScript");
+  }
+
+  @Test
+  void executeRequestEncodeQueryParametersNotExecuted(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+    final Workflow workflow = SwadlParser.fromYaml(
+        getClass().getResourceAsStream("/request/execute-request-not-encode-query-parameters-no-response.swadl.yaml"));
+
+    putFirstActivityUrl(workflow, wmRuntimeInfo.getHttpBaseUrl() + "/api?key1=value%201&key2=value%402");
+
+    stubFor(post("/api?key1=v+1&key2=value%40%21%242")
+        .willReturn(ok().withHeader("Content-Type", "application/json")
+            .withBody("{\"message\": \"ok\"}")));
+
+    engine.deploy(workflow);
+
+    engine.onEvent(messageReceived("/execute"));
+
+    assertThat(workflow).isExecuted().executed("executeRequestWithEncodedQueryParams", "assertionScript");
   }
 
   private void putFirstActivityUrl(Workflow workflow, String url) {

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/custom/assertion/WorkflowAssert.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/custom/assertion/WorkflowAssert.java
@@ -177,7 +177,7 @@ public class WorkflowAssert extends AbstractAssert<WorkflowAssert, Workflow> {
 
   private static List<String> listExecutedActivities() {
     String process = lastProcess().orElseThrow();
-    await().atMost(5, SECONDS).until(() -> processIsCompleted(process));
+    await().atMost(20, SECONDS).until(() -> processIsCompleted(process));
 
     List<HistoricActivityInstance> processes =
         IntegrationTest.historyService.createHistoricActivityInstanceQuery()

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/utils/ExecuteRequestUtilsTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/utils/ExecuteRequestUtilsTest.java
@@ -1,0 +1,37 @@
+package com.symphony.bdk.workflow.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.symphony.bdk.workflow.engine.executor.request.ExecuteRequestUtils;
+
+import org.junit.jupiter.api.Test;
+
+class ExecuteRequestUtilsTest {
+
+  @Test
+  void encodeQueryParametersTest() {
+    String encodedUrl = ExecuteRequestUtils.encodeQueryParameters(
+        "https://www.wdk.symphony.com:8080/path1/path2?key1=value 1&key2=value@!$2&key3=value%3");
+
+    assertThat(encodedUrl).as("The parameters have been encoded").isEqualTo(
+        "https://www.wdk.symphony.com:8080/path1/path2?key1=value+1&key2=value%40%21%242&key3=value%253");
+  }
+
+
+  @Test
+  void encodeQueryParameters_sameParametersKeyTest() {
+    String encodedUrl = ExecuteRequestUtils.encodeQueryParameters(
+        "https://www.wdk.symphony.com:8080/path1/path2?key1=value 1&key1=value 2");
+
+    assertThat(encodedUrl).as("The parameters have been encoded").isEqualTo(
+        "https://www.wdk.symphony.com:8080/path1/path2?key1=value+1&key1=value+2");
+  }
+
+  @Test
+  void encodeQueryParameters_noParameters_Test() {
+    String fullUrl = "https://www.wdk.symphony.com:8080/path1/path2";
+    String encodedUrl = ExecuteRequestUtils.encodeQueryParameters(fullUrl);
+
+    assertThat(encodedUrl).isEqualTo(fullUrl);
+  }
+}

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/utils/ExecuteRequestUtilsTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/utils/ExecuteRequestUtilsTest.java
@@ -34,4 +34,13 @@ class ExecuteRequestUtilsTest {
 
     assertThat(encodedUrl).isEqualTo(fullUrl);
   }
+
+  @Test
+  void encodeQueryParameters_encodedParameters() {
+    String encodedUrl = ExecuteRequestUtils.encodeQueryParameters(
+        "https://www.wdk.symphony.com:8080/path1/path2?key1=value%201&key1=value%402");
+
+    assertThat(encodedUrl).as("Already encoded parameters are re-encoded").isEqualTo(
+        "https://www.wdk.symphony.com:8080/path1/path2?key1=value%25201&key1=value%25402");
+  }
 }

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/utils/UtilityFunctionsMapperTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/utils/UtilityFunctionsMapperTest.java
@@ -1,14 +1,11 @@
 package com.symphony.bdk.workflow.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.symphony.bdk.workflow.engine.camunda.UtilityFunctionsMapper;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 @SuppressWarnings("unchecked")
@@ -50,48 +47,6 @@ class UtilityFunctionsMapperTest {
   void jsonEmptyTest() {
     final Object json = UtilityFunctionsMapper.json("");
     assertThat(json.toString()).isEmpty();
-  }
-
-  @Test
-  void encodeRawQueryTest() throws UnsupportedEncodingException {
-    String encodedUrl = UtilityFunctionsMapper.encodeRawQuery(
-        "https://www.wdk.symphony.com:8080/path1/path2?key1=value 1&key2=value@!$2&key3=value%3",
-        StandardCharsets.UTF_8.toString());
-
-    assertThat(encodedUrl).isEqualTo(
-        "https://www.wdk.symphony.com:8080/path1/path2?key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253");
-  }
-
-  @Test
-  void encodeRawQuery_noPort_noPath_Test() throws UnsupportedEncodingException {
-    String encodedUrl = UtilityFunctionsMapper.encodeRawQuery(
-        "https://www.wdk.symphony.com?key1=value 1&key2=value@!$2&key3=value%3");
-
-    assertThat(encodedUrl).isEqualTo(
-        "https://www.wdk.symphony.com?key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253");
-  }
-
-  @Test
-  void encodeRawQuery_BadEncoding_Test() {
-    assertThatThrownBy(() -> UtilityFunctionsMapper.encodeRawQuery(
-        "https://www.wdk.symphony.com", "UTF-8_BAD_ENCODING"))
-        .isInstanceOf(UnsupportedEncodingException.class);
-  }
-
-  @Test
-  void decodeRawQueryTest() throws UnsupportedEncodingException {
-    String encodedUrl = UtilityFunctionsMapper.decodeRawQuery(
-        "https://www.wdk.symphony.com:8080/path1/path2?key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253");
-
-    assertThat(encodedUrl).isEqualTo(
-        "https://www.wdk.symphony.com:8080/path1/path2?key1=value 1&key2=value@!$2&key3=value%3");
-  }
-
-  @Test
-  void decodeRawQuery_BadEncoding_Test() {
-    assertThatThrownBy(() -> UtilityFunctionsMapper.decodeRawQuery(
-        "https://www.wdk.symphony.com", "UTF-8_BAD_ENCODING"))
-        .isInstanceOf(UnsupportedEncodingException.class);
   }
 
 }

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/utils/UtilityFunctionsMapperTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/utils/UtilityFunctionsMapperTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.symphony.bdk.workflow.engine.camunda.UtilityFunctionsMapper;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.Map;
 
@@ -47,6 +49,49 @@ class UtilityFunctionsMapperTest {
   void jsonEmptyTest() {
     final Object json = UtilityFunctionsMapper.json("");
     assertThat(json.toString()).isEmpty();
+  }
+
+  @Test
+  void encodeQueryParametersTest() {
+    String encodedUrl = UtilityFunctionsMapper.encodeQueryParameters(
+        "https://www.wdk.symphony.com:8080/path1/path2?key1=value 1&key2=value@!$2&key3=value%3");
+
+    assertThat(encodedUrl).as("The parameters have been encoded").isEqualTo(
+        "https://www.wdk.symphony.com:8080/path1/path2?key1=value+1&key2=value%40%21%242&key3=value%253");
+  }
+
+  @Test
+  void encodeQueryParameters_alreadyEncoded_Test() {
+    String alreadyEncoded =
+        "https://www.wdk.symphony.com:8080/path1/path2?key1=value+1&key2=value%40%21%242&key3=value%253";
+    String encodedUrl = UtilityFunctionsMapper.encodeQueryParameters(alreadyEncoded);
+
+    assertThat(encodedUrl).as("The parameters were already encoded").isEqualTo(alreadyEncoded);
+  }
+
+  @Test
+  void encodeQueryParameters_alreadyEncoded_and_decoded_Test() {
+    String fullUrl =
+        "https://www.wdk.symphony.com:8080/path1/path2?key1=value+1&key2=value@!$2&key3=value%253";
+    String encodedUrl = UtilityFunctionsMapper.encodeQueryParameters(fullUrl);
+
+    MultiValueMap<String, String> queryParamsMap =
+        UriComponentsBuilder.fromUriString(encodedUrl).build().getQueryParams();
+
+    // The order of parameters will not be preserved
+    assertThat(queryParamsMap.size()).isEqualTo(3);
+    assertThat(queryParamsMap.get("key1").get(0)).as("The parameter value is already encoded").isEqualTo("value+1");
+    assertThat(queryParamsMap.get("key2").get(0)).as("The parameter value was not already encoded")
+        .isEqualTo("value%40%21%242");
+    assertThat(queryParamsMap.get("key3").get(0)).as("The parameter value is already encoded").isEqualTo("value%253");
+  }
+
+  @Test
+  void encodeQueryParameters_noParameters_Test() {
+    String fullUrl = "https://www.wdk.symphony.com:8080/path1/path2";
+    String encodedUrl = UtilityFunctionsMapper.encodeQueryParameters(fullUrl);
+
+    assertThat(encodedUrl).isEqualTo(fullUrl);
   }
 
 }

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/utils/UtilityFunctionsMapperTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/utils/UtilityFunctionsMapperTest.java
@@ -5,8 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.symphony.bdk.workflow.engine.camunda.UtilityFunctionsMapper;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.Map;
 
@@ -50,48 +48,4 @@ class UtilityFunctionsMapperTest {
     final Object json = UtilityFunctionsMapper.json("");
     assertThat(json.toString()).isEmpty();
   }
-
-  @Test
-  void encodeQueryParametersTest() {
-    String encodedUrl = UtilityFunctionsMapper.encodeQueryParameters(
-        "https://www.wdk.symphony.com:8080/path1/path2?key1=value 1&key2=value@!$2&key3=value%3");
-
-    assertThat(encodedUrl).as("The parameters have been encoded").isEqualTo(
-        "https://www.wdk.symphony.com:8080/path1/path2?key1=value+1&key2=value%40%21%242&key3=value%253");
-  }
-
-  @Test
-  void encodeQueryParameters_alreadyEncoded_Test() {
-    String alreadyEncoded =
-        "https://www.wdk.symphony.com:8080/path1/path2?key1=value+1&key2=value%40%21%242&key3=value%253";
-    String encodedUrl = UtilityFunctionsMapper.encodeQueryParameters(alreadyEncoded);
-
-    assertThat(encodedUrl).as("The parameters were already encoded").isEqualTo(alreadyEncoded);
-  }
-
-  @Test
-  void encodeQueryParameters_alreadyEncoded_and_decoded_Test() {
-    String fullUrl =
-        "https://www.wdk.symphony.com:8080/path1/path2?key1=value+1&key2=value@!$2&key3=value%253";
-    String encodedUrl = UtilityFunctionsMapper.encodeQueryParameters(fullUrl);
-
-    MultiValueMap<String, String> queryParamsMap =
-        UriComponentsBuilder.fromUriString(encodedUrl).build().getQueryParams();
-
-    // The order of parameters will not be preserved
-    assertThat(queryParamsMap.size()).isEqualTo(3);
-    assertThat(queryParamsMap.get("key1").get(0)).as("The parameter value is already encoded").isEqualTo("value+1");
-    assertThat(queryParamsMap.get("key2").get(0)).as("The parameter value was not already encoded")
-        .isEqualTo("value%40%21%242");
-    assertThat(queryParamsMap.get("key3").get(0)).as("The parameter value is already encoded").isEqualTo("value%253");
-  }
-
-  @Test
-  void encodeQueryParameters_noParameters_Test() {
-    String fullUrl = "https://www.wdk.symphony.com:8080/path1/path2";
-    String encodedUrl = UtilityFunctionsMapper.encodeQueryParameters(fullUrl);
-
-    assertThat(encodedUrl).isEqualTo(fullUrl);
-  }
-
 }

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/utils/UtilityFunctionsMapperTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/utils/UtilityFunctionsMapperTest.java
@@ -1,11 +1,14 @@
 package com.symphony.bdk.workflow.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.symphony.bdk.workflow.engine.camunda.UtilityFunctionsMapper;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 @SuppressWarnings("unchecked")
@@ -47,6 +50,48 @@ class UtilityFunctionsMapperTest {
   void jsonEmptyTest() {
     final Object json = UtilityFunctionsMapper.json("");
     assertThat(json.toString()).isEmpty();
+  }
+
+  @Test
+  void encodeRawQueryTest() throws UnsupportedEncodingException {
+    String encodedUrl = UtilityFunctionsMapper.encodeRawQuery(
+        "https://www.wdk.symphony.com:8080/path1/path2?key1=value 1&key2=value@!$2&key3=value%3",
+        StandardCharsets.UTF_8.toString());
+
+    assertThat(encodedUrl).isEqualTo(
+        "https://www.wdk.symphony.com:8080/path1/path2?key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253");
+  }
+
+  @Test
+  void encodeRawQuery_noPort_noPath_Test() throws UnsupportedEncodingException {
+    String encodedUrl = UtilityFunctionsMapper.encodeRawQuery(
+        "https://www.wdk.symphony.com?key1=value 1&key2=value@!$2&key3=value%3");
+
+    assertThat(encodedUrl).isEqualTo(
+        "https://www.wdk.symphony.com?key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253");
+  }
+
+  @Test
+  void encodeRawQuery_BadEncoding_Test() {
+    assertThatThrownBy(() -> UtilityFunctionsMapper.encodeRawQuery(
+        "https://www.wdk.symphony.com", "UTF-8_BAD_ENCODING"))
+        .isInstanceOf(UnsupportedEncodingException.class);
+  }
+
+  @Test
+  void decodeRawQueryTest() throws UnsupportedEncodingException {
+    String encodedUrl = UtilityFunctionsMapper.decodeRawQuery(
+        "https://www.wdk.symphony.com:8080/path1/path2?key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253");
+
+    assertThat(encodedUrl).isEqualTo(
+        "https://www.wdk.symphony.com:8080/path1/path2?key1=value 1&key2=value@!$2&key3=value%3");
+  }
+
+  @Test
+  void decodeRawQuery_BadEncoding_Test() {
+    assertThatThrownBy(() -> UtilityFunctionsMapper.decodeRawQuery(
+        "https://www.wdk.symphony.com", "UTF-8_BAD_ENCODING"))
+        .isInstanceOf(UnsupportedEncodingException.class);
   }
 
 }

--- a/workflow-bot-app/src/test/resources/request/execute-request-encode-query-parameters.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/request/execute-request-encode-query-parameters.swadl.yaml
@@ -1,0 +1,15 @@
+id: execute-head-request
+activities:
+  - execute-request:
+      id: executeRequestWithQueryParams
+      on:
+        message-received:
+          content: "/execute"
+      method: POST
+      url: https://wiremock.com/api?key1=value 1&key2=value@!$2&key3=value%3
+
+  - execute-script:
+      id: assertionScript
+      script: |
+        assert executeRequestWithQueryParams.outputs.body.message == "ok"
+        assert executeRequestWithQueryParams.outputs.status == 200

--- a/workflow-bot-app/src/test/resources/request/execute-request-encode-query-parameters.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/request/execute-request-encode-query-parameters.swadl.yaml
@@ -1,4 +1,4 @@
-id: execute-head-request
+id: execute-request-to-encode-query-params
 activities:
   - execute-request:
       id: executeRequestWithQueryParams

--- a/workflow-bot-app/src/test/resources/request/execute-request-not-encode-query-parameters-no-response.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/request/execute-request-not-encode-query-parameters-no-response.swadl.yaml
@@ -1,0 +1,16 @@
+id: execute-request-not-encode-query-params-no-response
+activities:
+  - execute-request:
+      id: executeRequestWithEncodedQueryParams
+      on:
+        message-received:
+          content: "/execute"
+      method: POST
+      url: https://wiremock.com/api?key1=value%201&key2=value%402
+      encode-query-params: false
+
+  - execute-script:
+      id: assertionScript
+      script: |
+        assert executeRequestWithEncodedQueryParams.outputs.body != "ok"
+        assert executeRequestWithEncodedQueryParams.outputs.status == 404

--- a/workflow-bot-app/src/test/resources/request/execute-request-not-encode-query-parameters.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/request/execute-request-not-encode-query-parameters.swadl.yaml
@@ -1,0 +1,16 @@
+id: execute-request-not-encode-query-params
+activities:
+  - execute-request:
+      id: executeRequestWithEncodedQueryParams
+      on:
+        message-received:
+          content: "/execute"
+      method: POST
+      url: https://wiremock.com/api?key1=value%201&key2=value%402
+      encode-query-params: false
+
+  - execute-script:
+      id: assertionScript
+      script: |
+        assert executeRequestWithEncodedQueryParams.outputs.body.message == "ok"
+        assert executeRequestWithEncodedQueryParams.outputs.status == 200

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/request/ExecuteRequest.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/request/ExecuteRequest.java
@@ -19,4 +19,5 @@ public class ExecuteRequest extends BaseActivity {
   private String method = "GET";
   private Object body;
   private Map<String, Object> headers = Collections.emptyMap();
+  private boolean encodeQueryParams = true;
 }

--- a/workflow-language/src/main/resources/swadl-schema-1.0.json
+++ b/workflow-language/src/main/resources/swadl-schema-1.0.json
@@ -1670,6 +1670,14 @@
                     "description": "Contains the host and the path to be targeted",
                     "minLength": 1
                 },
+                "encode-query-params": {
+                    "type": [
+                        "boolean",
+                        "string"
+                    ],
+                    "description": "If enabled, the query parameters will be encoded in application/x-www-form-urlencoded",
+                    "default": true
+                },
                 "method": {
                     "type": "string",
                     "description": "HTTP method to perform",


### PR DESCRIPTION
### Description
Since the execute-request activity takes the full URL as input and does not handle query parameters separately, the encoding/decoding should be the responsibility of the workflow and not the activity itself. The utility methods are added to be used in execute-script.
encodeRawQuery() only encodes the query parameters and does not change the other components.

closes #106 

### Checklist
- [x] Referenced a ticket in the PR title or description
- [x] Filled properly the description and dependencies, if any
- [x] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
