### PR TITLE
Bump snapshot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 group = 'org.finos.symphony.wdk'
 
-ext.projectVersion = '1.0.0-SNAPSHOT'
+ext.projectVersion = '1.2.0-SNAPSHOT'
 
 ext.mavenRepoUrl = ext.projectVersion.endsWith('SNAPSHOT') ?  'https://oss.sonatype.org/content/repositories/snapshots/' : 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
 ext.mavenRepoUsername = project.properties['mavenRepoUsername'] ?: 'Symphony artifactory user'


### PR DESCRIPTION
Bump snapshot to 1.2.0-SNAPSHOT following 1.1.0 release.
The last time we released 1.0.0, we forgot to bump the snapshot, that's why here we go from 1.0.0-SNAPSHOT to 1.2.0-SNAPSHOT.