### PR TITLE
#28: Support OBO

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2217,6 +2217,58 @@ activities:
 
 Script to execute (only [Groovy](https://groovy-lang.org/) is supported).
 
+
+## OBO
+
+OBO or On-Behalf-Of authentication allows an extension application to be able to execute an activity on behalf of an application end-user, when the activity is OBO enabled.
+
+The property `obo` is used to define the user executing the activity using either his username or the user id.
+
+Example:
+```yaml
+- send-message:
+    id: sendMessageObo
+    content: Message sent on behalf of user 734583310035744 
+    to:
+      stream-id: ${createRoomObo.outputs.roomId}
+    obo:
+      user-id: 734583310035744
+```
+
+```yaml
+- create-room:
+      id: createRoomObo
+      room-name: OBO created room
+      room-description: Example of a room created with obo
+      user-ids:
+        - 734583310035744
+        - 625588317732700
+      obo:
+        username: username@symphony.com
+```
+
+The list of OBO enabled activities:
+- [send-message](#send-message)
+- [pin-message](#pin-message)
+- [unpin-message](#unpin-message)
+- [create-room](#create-room)
+- [update-room](#update-room)
+- [add-room-member](#add-room-member)
+- [remove-room-member](#remove-room-member)
+- [promote-room-owner](#promote-room-owner)
+- [demote-room-owner](#demote-room-owner)
+- [get-stream](#get-stream)
+- [get-room](#get-room)
+- [get-rooms](#get-rooms)
+- [get-user-streams](#get-user-streams)
+- [get-users](#get-users)
+- [create-connection](#create-connection)
+- [get-connection](#get-connection)
+- [get-connections](#get-connections)
+- [remove-connection](#remove-connection)
+- [accept-connection](#accept-connection)
+- [reject-connection](#reject-connection)
+
 ## Utility functions
 
 WDK provides some utility functions that can be used to process data in SWADL or in [templates](#send-message-content).

--- a/workflow-bot-app/build.gradle
+++ b/workflow-bot-app/build.gradle
@@ -12,7 +12,7 @@ javadoc {
 dependencies {
     implementation project(':workflow-language')
 
-    implementation platform('org.finos.symphony.bdk:symphony-bdk-bom:2.7.0')
+    implementation platform('org.finos.symphony.bdk:symphony-bdk-bom:2.9.0')
     implementation platform('com.fasterxml.jackson:jackson-bom:2.13.2.20220328')
     implementation platform('org.springframework.boot:spring-boot-dependencies:2.6.6')
 

--- a/workflow-bot-app/build.gradle
+++ b/workflow-bot-app/build.gradle
@@ -50,6 +50,9 @@ dependencies {
         }
     }
 
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.1'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter-params'

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/configuration/WorkflowBotConfiguration.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/configuration/WorkflowBotConfiguration.java
@@ -4,11 +4,13 @@ import com.symphony.bdk.ext.group.SymphonyGroupBdkExtension;
 import com.symphony.bdk.workflow.engine.ResourceProvider;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 @Configuration
+@EnableCaching
 @Profile("!test")
 public class WorkflowBotConfiguration {
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/SpringBdkGateway.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/SpringBdkGateway.java
@@ -28,6 +28,8 @@ import javax.annotation.Nullable;
 @CacheConfig(cacheNames = "oboAuthSesssions")
 public class SpringBdkGateway implements BdkGateway {
 
+  private static final String OBO_NOT_CONFIGURED_ERROR_MSG = "At least OBO username or userid should be configured.";
+
   private final MessageService messageService;
   private final StreamService streamService;
   private final UserService userService;
@@ -85,7 +87,7 @@ public class SpringBdkGateway implements BdkGateway {
         throw new RuntimeException(e);
       }
     } else {
-      throw new RuntimeException("At least OBO username or userid should be configured.");
+      throw new RuntimeException(OBO_NOT_CONFIGURED_ERROR_MSG);
     }
   }
 
@@ -99,7 +101,7 @@ public class SpringBdkGateway implements BdkGateway {
         throw new RuntimeException(e);
       }
     } else {
-      throw new RuntimeException("At least OBO username or userid should be configured.");
+      throw new RuntimeException(OBO_NOT_CONFIGURED_ERROR_MSG);
     }
   }
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/SpringBdkGateway.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/SpringBdkGateway.java
@@ -90,6 +90,7 @@ public class SpringBdkGateway implements BdkGateway {
   }
 
   @Override
+  @Cacheable
   public AuthSession obo(Long userId) {
     if (config.isOboConfigured()) {
       try {

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/SpringBdkGateway.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/SpringBdkGateway.java
@@ -1,5 +1,11 @@
 package com.symphony.bdk.workflow.engine;
 
+import com.symphony.bdk.core.OboServices;
+import com.symphony.bdk.core.auth.AuthSession;
+import com.symphony.bdk.core.auth.AuthenticatorFactory;
+import com.symphony.bdk.core.auth.exception.AuthInitializationException;
+import com.symphony.bdk.core.auth.exception.AuthUnauthorizedException;
+import com.symphony.bdk.core.config.model.BdkConfig;
 import com.symphony.bdk.core.service.connection.ConnectionService;
 import com.symphony.bdk.core.service.message.MessageService;
 import com.symphony.bdk.core.service.stream.StreamService;
@@ -7,11 +13,19 @@ import com.symphony.bdk.core.service.user.UserService;
 import com.symphony.bdk.ext.group.SymphonyGroupService;
 import com.symphony.bdk.workflow.engine.executor.BdkGateway;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+@Slf4j
 @Component
+@CacheConfig(cacheNames = "oboAuthSesssions")
 public class SpringBdkGateway implements BdkGateway {
 
   private final MessageService messageService;
@@ -19,9 +33,12 @@ public class SpringBdkGateway implements BdkGateway {
   private final UserService userService;
   private final ConnectionService connectionService;
   private final SymphonyGroupService groupService;
+  private final BdkConfig config;
+  private final AuthenticatorFactory authenticatorFactory;
 
   @Autowired
-  public SpringBdkGateway(MessageService messageService,
+  public SpringBdkGateway(@Nonnull BdkConfig config, @Nullable AuthenticatorFactory authenticatorFactory,
+      MessageService messageService,
       StreamService streamService, UserService userService,
       ConnectionService connectionService, @Lazy SymphonyGroupService groupService) {
     this.messageService = messageService;
@@ -29,6 +46,8 @@ public class SpringBdkGateway implements BdkGateway {
     this.userService = userService;
     this.connectionService = connectionService;
     this.groupService = groupService;
+    this.config = config;
+    this.authenticatorFactory = authenticatorFactory;
   }
 
   @Override
@@ -49,6 +68,38 @@ public class SpringBdkGateway implements BdkGateway {
   @Override
   public ConnectionService connections() {
     return connectionService;
+  }
+
+  @Override
+  public OboServices obo(AuthSession oboSession) {
+    return new OboServices(this.config, oboSession);
+  }
+
+  @Override
+  @Cacheable
+  public AuthSession obo(String username) {
+    if (config.isOboConfigured()) {
+      try {
+        return this.authenticatorFactory.getOboAuthenticator().authenticateByUsername(username);
+      } catch (AuthInitializationException | AuthUnauthorizedException e) {
+        throw new RuntimeException(e);
+      }
+    } else {
+      throw new RuntimeException("At least OBO username or userid should be configured.");
+    }
+  }
+
+  @Override
+  public AuthSession obo(Long userId) {
+    if (config.isOboConfigured()) {
+      try {
+        return this.authenticatorFactory.getOboAuthenticator().authenticateByUserId(userId);
+      } catch (AuthInitializationException | AuthUnauthorizedException e) {
+        throw new RuntimeException(e);
+      }
+    } else {
+      throw new RuntimeException("At least OBO username or userid should be configured.");
+    }
   }
 
   @Override

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/connection/GetConnectionExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/connection/GetConnectionExecutor.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.workflow.engine.executor.connection;
 
+import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.gen.api.model.UserConnection;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
@@ -15,7 +16,30 @@ public class GetConnectionExecutor implements ActivityExecutor<GetConnection> {
   @Override
   public void execute(ActivityExecutorContext<GetConnection> context) {
     GetConnection activity = context.getActivity();
-    UserConnection connection = context.bdk().connections().getConnection(Long.parseLong(activity.getUserId()));
+    UserConnection connection;
+    if (this.isObo(activity)) {
+      connection = this.doOboWithCache(context);
+    } else {
+      connection = context.bdk().connections().getConnection(Long.parseLong(activity.getUserId()));
+    }
     context.setOutputVariable(OUTPUT_CONNECTION_KEY, connection);
+  }
+
+  private boolean isObo(GetConnection activity) {
+    return activity.getObo() != null && (activity.getObo().getUsername() != null
+        || activity.getObo().getUserId() != null);
+  }
+
+  private UserConnection doOboWithCache(ActivityExecutorContext<GetConnection> execution) {
+    GetConnection activity = execution.getActivity();
+
+    AuthSession authSession;
+    if (activity.getObo().getUsername() != null) {
+      authSession = execution.bdk().obo(activity.getObo().getUsername());
+    } else {
+      authSession = execution.bdk().obo(activity.getObo().getUserId());
+    }
+
+    return execution.bdk().obo(authSession).connections().getConnection(Long.parseLong(activity.getUserId()));
   }
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/connection/GetConnectionExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/connection/GetConnectionExecutor.java
@@ -4,12 +4,14 @@ import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.gen.api.model.UserConnection;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
+import com.symphony.bdk.workflow.engine.executor.obo.OboExecutor;
 import com.symphony.bdk.workflow.swadl.v1.activity.connection.GetConnection;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class GetConnectionExecutor implements ActivityExecutor<GetConnection> {
+public class GetConnectionExecutor extends OboExecutor<GetConnection, UserConnection>
+    implements ActivityExecutor<GetConnection> {
 
   private static final String OUTPUT_CONNECTION_KEY = "connection";
 
@@ -25,20 +27,9 @@ public class GetConnectionExecutor implements ActivityExecutor<GetConnection> {
     context.setOutputVariable(OUTPUT_CONNECTION_KEY, connection);
   }
 
-  private boolean isObo(GetConnection activity) {
-    return activity.getObo() != null && (activity.getObo().getUsername() != null
-        || activity.getObo().getUserId() != null);
-  }
-
-  private UserConnection doOboWithCache(ActivityExecutorContext<GetConnection> execution) {
+  protected UserConnection doOboWithCache(ActivityExecutorContext<GetConnection> execution) {
     GetConnection activity = execution.getActivity();
-
-    AuthSession authSession;
-    if (activity.getObo().getUsername() != null) {
-      authSession = execution.bdk().obo(activity.getObo().getUsername());
-    } else {
-      authSession = execution.bdk().obo(activity.getObo().getUserId());
-    }
+    AuthSession authSession = this.getOboAuthSession(execution);
 
     return execution.bdk().obo(authSession).connections().getConnection(Long.parseLong(activity.getUserId()));
   }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/connection/GetConnectionsExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/connection/GetConnectionsExecutor.java
@@ -5,6 +5,7 @@ import com.symphony.bdk.core.service.connection.constant.ConnectionStatus;
 import com.symphony.bdk.gen.api.model.UserConnection;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
+import com.symphony.bdk.workflow.engine.executor.obo.OboExecutor;
 import com.symphony.bdk.workflow.swadl.v1.activity.connection.GetConnections;
 
 import lombok.extern.slf4j.Slf4j;
@@ -12,7 +13,8 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.List;
 
 @Slf4j
-public class GetConnectionsExecutor implements ActivityExecutor<GetConnections> {
+public class GetConnectionsExecutor extends OboExecutor<GetConnections, List<UserConnection>>
+    implements ActivityExecutor<GetConnections> {
 
   private static final String OUTPUT_CONNECTIONS_KEY = "connections";
 
@@ -38,20 +40,9 @@ public class GetConnectionsExecutor implements ActivityExecutor<GetConnections> 
     return ConnectionStatus.valueOf(statusString);
   }
 
-  private boolean isObo(GetConnections activity) {
-    return activity.getObo() != null && (activity.getObo().getUsername() != null
-        || activity.getObo().getUserId() != null);
-  }
-
-  private List<UserConnection> doOboWithCache(ActivityExecutorContext<GetConnections> execution) {
+  protected List<UserConnection> doOboWithCache(ActivityExecutorContext<GetConnections> execution) {
     GetConnections activity = execution.getActivity();
-
-    AuthSession authSession;
-    if (activity.getObo().getUsername() != null) {
-      authSession = execution.bdk().obo(activity.getObo().getUsername());
-    } else {
-      authSession = execution.bdk().obo(activity.getObo().getUserId());
-    }
+    AuthSession authSession = this.getOboAuthSession(execution);
 
     return execution.bdk()
         .obo(authSession)

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/connection/GetConnectionsExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/connection/GetConnectionsExecutor.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.workflow.engine.executor.connection;
 
+import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.core.service.connection.constant.ConnectionStatus;
 import com.symphony.bdk.gen.api.model.UserConnection;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
@@ -19,8 +20,13 @@ public class GetConnectionsExecutor implements ActivityExecutor<GetConnections> 
   public void execute(ActivityExecutorContext<GetConnections> context) {
     GetConnections activity = context.getActivity();
 
-    List<UserConnection> connections = context.bdk().connections()
-        .listConnections(toConnectionStatus(activity.getStatus()), activity.getUserIds());
+    List<UserConnection> connections;
+    if (this.isObo(activity)) {
+      connections = this.doOboWithCache(context);
+    } else {
+      connections = context.bdk().connections()
+          .listConnections(toConnectionStatus(activity.getStatus()), activity.getUserIds());
+    }
     context.setOutputVariable(OUTPUT_CONNECTIONS_KEY, connections);
   }
 
@@ -30,6 +36,27 @@ public class GetConnectionsExecutor implements ActivityExecutor<GetConnections> 
     }
 
     return ConnectionStatus.valueOf(statusString);
+  }
+
+  private boolean isObo(GetConnections activity) {
+    return activity.getObo() != null && (activity.getObo().getUsername() != null
+        || activity.getObo().getUserId() != null);
+  }
+
+  private List<UserConnection> doOboWithCache(ActivityExecutorContext<GetConnections> execution) {
+    GetConnections activity = execution.getActivity();
+
+    AuthSession authSession;
+    if (activity.getObo().getUsername() != null) {
+      authSession = execution.bdk().obo(activity.getObo().getUsername());
+    } else {
+      authSession = execution.bdk().obo(activity.getObo().getUserId());
+    }
+
+    return execution.bdk()
+        .obo(authSession)
+        .connections()
+        .listConnections(toConnectionStatus(activity.getStatus()), activity.getUserIds());
   }
 
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/connection/RejectConnectionExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/connection/RejectConnectionExecutor.java
@@ -4,12 +4,14 @@ import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.gen.api.model.UserConnection;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
+import com.symphony.bdk.workflow.engine.executor.obo.OboExecutor;
 import com.symphony.bdk.workflow.swadl.v1.activity.connection.RejectConnection;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class RejectConnectionExecutor implements ActivityExecutor<RejectConnection> {
+public class RejectConnectionExecutor extends OboExecutor<RejectConnection, UserConnection>
+    implements ActivityExecutor<RejectConnection> {
 
   private static final String OUTPUT_CONNECTION_KEY = "connection";
 
@@ -25,20 +27,9 @@ public class RejectConnectionExecutor implements ActivityExecutor<RejectConnecti
     context.setOutputVariable(OUTPUT_CONNECTION_KEY, connection);
   }
 
-  private boolean isObo(RejectConnection activity) {
-    return activity.getObo() != null && (activity.getObo().getUsername() != null
-        || activity.getObo().getUserId() != null);
-  }
-
-  private UserConnection doOboWithCache(ActivityExecutorContext<RejectConnection> execution) {
+  protected UserConnection doOboWithCache(ActivityExecutorContext<RejectConnection> execution) {
     RejectConnection activity = execution.getActivity();
-
-    AuthSession authSession;
-    if (activity.getObo().getUsername() != null) {
-      authSession = execution.bdk().obo(activity.getObo().getUsername());
-    } else {
-      authSession = execution.bdk().obo(activity.getObo().getUserId());
-    }
+    AuthSession authSession = this.getOboAuthSession(execution);
 
     return execution.bdk().obo(authSession).connections().rejectConnection(Long.parseLong(activity.getUserId()));
   }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/connection/RejectConnectionExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/connection/RejectConnectionExecutor.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.workflow.engine.executor.connection;
 
+import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.gen.api.model.UserConnection;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
@@ -15,7 +16,30 @@ public class RejectConnectionExecutor implements ActivityExecutor<RejectConnecti
   @Override
   public void execute(ActivityExecutorContext<RejectConnection> context) {
     RejectConnection activity = context.getActivity();
-    UserConnection connection = context.bdk().connections().rejectConnection(Long.parseLong(activity.getUserId()));
+    UserConnection connection;
+    if (this.isObo(activity)) {
+      connection = this.doOboWithCache(context);
+    } else {
+      connection = context.bdk().connections().rejectConnection(Long.parseLong(activity.getUserId()));
+    }
     context.setOutputVariable(OUTPUT_CONNECTION_KEY, connection);
+  }
+
+  private boolean isObo(RejectConnection activity) {
+    return activity.getObo() != null && (activity.getObo().getUsername() != null
+        || activity.getObo().getUserId() != null);
+  }
+
+  private UserConnection doOboWithCache(ActivityExecutorContext<RejectConnection> execution) {
+    RejectConnection activity = execution.getActivity();
+
+    AuthSession authSession;
+    if (activity.getObo().getUsername() != null) {
+      authSession = execution.bdk().obo(activity.getObo().getUsername());
+    } else {
+      authSession = execution.bdk().obo(activity.getObo().getUserId());
+    }
+
+    return execution.bdk().obo(authSession).connections().rejectConnection(Long.parseLong(activity.getUserId()));
   }
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/connection/RemoveConnectionExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/connection/RemoveConnectionExecutor.java
@@ -3,12 +3,14 @@ package com.symphony.bdk.workflow.engine.executor.connection;
 import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
+import com.symphony.bdk.workflow.engine.executor.obo.OboExecutor;
 import com.symphony.bdk.workflow.swadl.v1.activity.connection.RemoveConnection;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class RemoveConnectionExecutor implements ActivityExecutor<RemoveConnection> {
+public class RemoveConnectionExecutor extends OboExecutor<RemoveConnection, Void>
+    implements ActivityExecutor<RemoveConnection> {
 
   @Override
   public void execute(ActivityExecutorContext<RemoveConnection> context) {
@@ -21,21 +23,12 @@ public class RemoveConnectionExecutor implements ActivityExecutor<RemoveConnecti
     }
   }
 
-  private boolean isObo(RemoveConnection activity) {
-    return activity.getObo() != null && (activity.getObo().getUsername() != null
-        || activity.getObo().getUserId() != null);
-  }
 
-  private void doOboWithCache(ActivityExecutorContext<RemoveConnection> execution) {
+  protected Void doOboWithCache(ActivityExecutorContext<RemoveConnection> execution) {
     RemoveConnection activity = execution.getActivity();
-
-    AuthSession authSession;
-    if (activity.getObo().getUsername() != null) {
-      authSession = execution.bdk().obo(activity.getObo().getUsername());
-    } else {
-      authSession = execution.bdk().obo(activity.getObo().getUserId());
-    }
+    AuthSession authSession = this.getOboAuthSession(execution);
 
     execution.bdk().obo(authSession).connections().removeConnection(Long.parseLong(activity.getUserId()));
+    return null;
   }
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/connection/RemoveConnectionExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/connection/RemoveConnectionExecutor.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.workflow.engine.executor.connection;
 
+import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
 import com.symphony.bdk.workflow.swadl.v1.activity.connection.RemoveConnection;
@@ -12,6 +13,29 @@ public class RemoveConnectionExecutor implements ActivityExecutor<RemoveConnecti
   @Override
   public void execute(ActivityExecutorContext<RemoveConnection> context) {
     RemoveConnection activity = context.getActivity();
-    context.bdk().connections().removeConnection(Long.parseLong(activity.getUserId()));
+
+    if (this.isObo(activity)) {
+      this.doOboWithCache(context);
+    } else {
+      context.bdk().connections().removeConnection(Long.parseLong(activity.getUserId()));
+    }
+  }
+
+  private boolean isObo(RemoveConnection activity) {
+    return activity.getObo() != null && (activity.getObo().getUsername() != null
+        || activity.getObo().getUserId() != null);
+  }
+
+  private void doOboWithCache(ActivityExecutorContext<RemoveConnection> execution) {
+    RemoveConnection activity = execution.getActivity();
+
+    AuthSession authSession;
+    if (activity.getObo().getUsername() != null) {
+      authSession = execution.bdk().obo(activity.getObo().getUsername());
+    } else {
+      authSession = execution.bdk().obo(activity.getObo().getUserId());
+    }
+
+    execution.bdk().obo(authSession).connections().removeConnection(Long.parseLong(activity.getUserId()));
   }
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/PinMessageExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/PinMessageExecutor.java
@@ -37,7 +37,7 @@ public class PinMessageExecutor extends OboExecutor<PinMessage, Void>
       this.updateInstantMessage(execution, messageId, streamId);
     } else if (ROOM.equals(streamType) && this.isObo(activity)) {
       this.doOboWithCache(execution);
-    } else if (ROOM.equals(streamType)){
+    } else if (ROOM.equals(streamType)) {
       this.updateRoomMessage(execution, messageId, streamId);
     } else {
       throw new IllegalArgumentException(

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/PinMessageExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/PinMessageExecutor.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.workflow.engine.executor.message;
 
+import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.gen.api.model.StreamType;
 import com.symphony.bdk.gen.api.model.V1IMAttributes;
 import com.symphony.bdk.gen.api.model.V3RoomAttributes;
@@ -27,21 +28,54 @@ public class PinMessageExecutor implements ActivityExecutor<PinMessage> {
     String streamType = messageToPin.getStream().getStreamType();
 
     if (IM.equals(streamType)) {
-      V1IMAttributes imAttributes = new V1IMAttributes();
-      imAttributes.setPinnedMessageId(messageId);
-
-      log.debug("Pin message {} in IM {}", messageId, streamId);
-      execution.bdk().streams().updateInstantMessage(streamId, imAttributes);
+      this.updateInstantMessage(execution, messageId, streamId);
     } else if (ROOM.equals(streamType)) {
-      V3RoomAttributes roomAttributes = new V3RoomAttributes();
-      roomAttributes.setPinnedMessageId(messageId);
-
-      log.debug("Pin message {} in Room {}", messageId, streamId);
-      execution.bdk().streams().updateRoom(streamId, roomAttributes);
+      this.updateRoomMessage(execution, messageId, streamId);
     } else {
       throw new IllegalArgumentException(
           String.format("Unable to pin message in stream type %s in activity %s", streamType,
               execution.getActivity().getId()));
+    }
+  }
+
+  private boolean isObo(PinMessage activity) {
+    return activity.getObo() != null && (activity.getObo().getUsername() != null
+        || activity.getObo().getUserId() != null);
+  }
+
+  private void updateInstantMessage(ActivityExecutorContext<PinMessage> execution, String messageId, String streamId) {
+    PinMessage activity = execution.getActivity();
+    V1IMAttributes imAttributes = new V1IMAttributes();
+    imAttributes.setPinnedMessageId(messageId);
+
+    log.debug("Pin message {} in IM {}", messageId, streamId);
+
+    if (this.isObo(activity)) {
+      throw new IllegalArgumentException(
+          String.format("Pin instant message, in activity %s, is not OBO enabled", activity.getId()));
+    } else {
+      execution.bdk().streams().updateInstantMessage(streamId, imAttributes);
+    }
+  }
+
+  private void updateRoomMessage(ActivityExecutorContext<PinMessage> execution, String messageId, String streamId) {
+    PinMessage activity = execution.getActivity();
+    V3RoomAttributes roomAttributes = new V3RoomAttributes();
+    roomAttributes.setPinnedMessageId(messageId);
+
+    log.debug("Pin message {} in Room {}", messageId, streamId);
+
+    if (this.isObo(activity)) {
+      AuthSession authSession;
+      if (activity.getObo().getUsername() != null) {
+        authSession = execution.bdk().obo(activity.getObo().getUsername());
+      } else {
+        authSession = execution.bdk().obo(activity.getObo().getUserId());
+      }
+
+      execution.bdk().obo(authSession).streams().updateRoom(streamId, roomAttributes);
+    } else {
+      execution.bdk().streams().updateRoom(streamId, roomAttributes);
     }
   }
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/SendMessageExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/SendMessageExecutor.java
@@ -52,13 +52,13 @@ public class SendMessageExecutor implements ActivityExecutor<SendMessage> {
       throw new IllegalArgumentException(
           String.format("No stream ids set to send a message in activity %s", activity.getId()));
 
-    } else if (isObo(activity) && activity.getOnBehalfOf() != null && streamIds.size() == 1) {
+    } else if (isObo(activity) && activity.getObo() != null && streamIds.size() == 1) {
 
       AuthSession authSession;
-      if (activity.getOnBehalfOf().getUsername() != null) {
-        authSession = execution.bdk().obo(activity.getOnBehalfOf().getUsername());
+      if (activity.getObo().getUsername() != null) {
+        authSession = execution.bdk().obo(activity.getObo().getUsername());
       } else {
-        authSession = execution.bdk().obo(activity.getOnBehalfOf().getUserId());
+        authSession = execution.bdk().obo(activity.getObo().getUserId());
       }
 
       message = this.doOboWithCache(execution, authSession, streamIds.get(0), messageToSend);
@@ -83,8 +83,8 @@ public class SendMessageExecutor implements ActivityExecutor<SendMessage> {
   }
 
   private boolean isObo(SendMessage activity) {
-    return activity.getOnBehalfOf() != null && (activity.getOnBehalfOf().getUsername() != null
-        || activity.getOnBehalfOf().getUserId() != null);
+    return activity.getObo() != null && (activity.getObo().getUsername() != null
+        || activity.getObo().getUserId() != null);
   }
 
   private V4Message doOboWithCache(ActivityExecutorContext<SendMessage> execution, AuthSession authSession,

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/UnpinMessageExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/UnpinMessageExecutor.java
@@ -3,6 +3,7 @@ package com.symphony.bdk.workflow.engine.executor.message;
 import static com.symphony.bdk.workflow.engine.executor.message.PinMessageExecutor.IM;
 import static com.symphony.bdk.workflow.engine.executor.message.PinMessageExecutor.ROOM;
 
+import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.gen.api.model.V1IMAttributes;
 import com.symphony.bdk.gen.api.model.V2StreamAttributes;
 import com.symphony.bdk.gen.api.model.V3RoomAttributes;
@@ -25,23 +26,55 @@ public class UnpinMessageExecutor implements ActivityExecutor<UnpinMessage> {
     String streamType = stream.getStreamType().getType();
 
     if (IM.equals(streamType)) {
-
-      V1IMAttributes imAttributes = new V1IMAttributes();
-      imAttributes.setPinnedMessageId("");
-
-      log.debug("Unpin message in IM {}", streamId);
-      execution.bdk().streams().updateInstantMessage(streamId, imAttributes);
+      this.unpinInstantMessage(execution, streamId);
     } else if (ROOM.equals(streamType)) {
-
-      V3RoomAttributes roomAttributes = new V3RoomAttributes();
-      roomAttributes.setPinnedMessageId("");
-
-      log.debug("Unpin message in Room {}", streamId);
-      execution.bdk().streams().updateRoom(streamId, roomAttributes);
+      this.unpinRoomMessage(execution, streamId);
     } else {
       throw new IllegalArgumentException(
           String.format("Unable to unpin message in stream type %s in activity %s", streamType,
               execution.getActivity().getId()));
+    }
+  }
+
+  private boolean isObo(UnpinMessage activity) {
+    return activity.getObo() != null && (activity.getObo().getUsername() != null
+        || activity.getObo().getUserId() != null);
+  }
+
+  private void unpinInstantMessage(ActivityExecutorContext<UnpinMessage> execution, String streamId) {
+    UnpinMessage activity = execution.getActivity();
+
+    V1IMAttributes imAttributes = new V1IMAttributes();
+    imAttributes.setPinnedMessageId("");
+
+    log.debug("Unpin message in IM {}", streamId);
+
+    if (this.isObo(activity)) {
+      throw new IllegalArgumentException(
+          String.format("Unpin instant message, in activity %s, is not OBO enabled", activity.getId()));
+    } else {
+      execution.bdk().streams().updateInstantMessage(streamId, imAttributes);
+    }
+  }
+
+  private void unpinRoomMessage(ActivityExecutorContext<UnpinMessage> execution, String streamId) {
+    UnpinMessage activity = execution.getActivity();
+    V3RoomAttributes roomAttributes = new V3RoomAttributes();
+    roomAttributes.setPinnedMessageId("");
+
+    log.debug("Unpin message in Room {}", streamId);
+
+    if (this.isObo(activity)) {
+      AuthSession authSession;
+      if (activity.getObo().getUsername() != null) {
+        authSession = execution.bdk().obo(activity.getObo().getUsername());
+      } else {
+        authSession = execution.bdk().obo(activity.getObo().getUserId());
+      }
+
+      execution.bdk().obo(authSession).streams().updateRoom(streamId, roomAttributes);
+    } else {
+      execution.bdk().streams().updateRoom(streamId, roomAttributes);
     }
   }
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/obo/OboExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/obo/OboExecutor.java
@@ -1,0 +1,25 @@
+package com.symphony.bdk.workflow.engine.executor.obo;
+
+import com.symphony.bdk.core.auth.AuthSession;
+import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
+import com.symphony.bdk.workflow.swadl.v1.activity.OboActivity;
+
+public abstract class OboExecutor<T extends OboActivity, R> {
+
+  protected boolean isObo(T activity) {
+    return activity.getObo() != null && (activity.getObo().getUsername() != null
+        || activity.getObo().getUserId() != null);
+  }
+
+  protected AuthSession getOboAuthSession(ActivityExecutorContext<T> execution) {
+    T activity = execution.getActivity();
+
+    if (activity.getObo().getUsername() != null) {
+      return execution.bdk().obo(activity.getObo().getUsername());
+    } else {
+      return execution.bdk().obo(activity.getObo().getUserId());
+    }
+  }
+
+  protected abstract R doOboWithCache(ActivityExecutorContext<T> execution) throws Exception;
+}

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/AddRoomMemberExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/AddRoomMemberExecutor.java
@@ -3,6 +3,7 @@ package com.symphony.bdk.workflow.engine.executor.room;
 import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
+import com.symphony.bdk.workflow.engine.executor.obo.OboExecutor;
 import com.symphony.bdk.workflow.swadl.v1.activity.room.AddRoomMember;
 
 import lombok.extern.slf4j.Slf4j;
@@ -10,14 +11,15 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-public class AddRoomMemberExecutor implements ActivityExecutor<AddRoomMember> {
+public class AddRoomMemberExecutor extends OboExecutor<AddRoomMember, Void>
+    implements ActivityExecutor<AddRoomMember> {
 
   @Override
   public void execute(ActivityExecutorContext<AddRoomMember> execution) {
     AddRoomMember addRoomMember = execution.getActivity();
 
     if (this.isObo(addRoomMember)) {
-      this.doOboWithCache(execution, addRoomMember);
+      this.doOboWithCache(execution);
     } else {
       for (Long uid : addRoomMember.getUserIds()) {
         log.debug("Add user {} to room {}", uid, addRoomMember.getStreamId());
@@ -26,23 +28,17 @@ public class AddRoomMemberExecutor implements ActivityExecutor<AddRoomMember> {
     }
   }
 
-  private boolean isObo(AddRoomMember activity) {
-    return activity.getObo() != null && (activity.getObo().getUsername() != null
-        || activity.getObo().getUserId() != null);
-  }
-
-  private void doOboWithCache(ActivityExecutorContext<AddRoomMember> execution, AddRoomMember addRoomMember) {
-    AuthSession authSession;
-    if (addRoomMember.getObo().getUsername() != null) {
-      authSession = execution.bdk().obo(addRoomMember.getObo().getUsername());
-    } else {
-      authSession = execution.bdk().obo(addRoomMember.getObo().getUserId());
-    }
+  @Override
+  protected Void doOboWithCache(ActivityExecutorContext<AddRoomMember> execution) {
+    AddRoomMember addRoomMember = execution.getActivity();
+    AuthSession authSession = this.getOboAuthSession(execution);
 
     for (Long uid : addRoomMember.getUserIds()) {
       log.debug("Add user {} to room {}", uid, addRoomMember.getStreamId());
       execution.bdk().obo(authSession).streams().addMemberToRoom(uid, addRoomMember.getStreamId());
     }
+
+    return null;
   }
 
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/AddRoomMemberExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/AddRoomMemberExecutor.java
@@ -27,16 +27,16 @@ public class AddRoomMemberExecutor implements ActivityExecutor<AddRoomMember> {
   }
 
   private boolean isObo(AddRoomMember activity) {
-    return activity.getOnBehalfOf() != null && (activity.getOnBehalfOf().getUsername() != null
-        || activity.getOnBehalfOf().getUserId() != null);
+    return activity.getObo() != null && (activity.getObo().getUsername() != null
+        || activity.getObo().getUserId() != null);
   }
 
   private void doOboWithCache(ActivityExecutorContext<AddRoomMember> execution, AddRoomMember addRoomMember) {
     AuthSession authSession;
-    if (addRoomMember.getOnBehalfOf().getUsername() != null) {
-      authSession = execution.bdk().obo(addRoomMember.getOnBehalfOf().getUsername());
+    if (addRoomMember.getObo().getUsername() != null) {
+      authSession = execution.bdk().obo(addRoomMember.getObo().getUsername());
     } else {
-      authSession = execution.bdk().obo(addRoomMember.getOnBehalfOf().getUserId());
+      authSession = execution.bdk().obo(addRoomMember.getObo().getUserId());
     }
 
     for (Long uid : addRoomMember.getUserIds()) {

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/AddRoomMemberExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/AddRoomMemberExecutor.java
@@ -1,21 +1,47 @@
 package com.symphony.bdk.workflow.engine.executor.room;
 
+import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
 import com.symphony.bdk.workflow.swadl.v1.activity.room.AddRoomMember;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
 
 @Slf4j
+@Component
 public class AddRoomMemberExecutor implements ActivityExecutor<AddRoomMember> {
 
   @Override
   public void execute(ActivityExecutorContext<AddRoomMember> execution) {
     AddRoomMember addRoomMember = execution.getActivity();
 
+    if (this.isObo(addRoomMember)) {
+      this.doOboWithCache(execution, addRoomMember);
+    } else {
+      for (Long uid : addRoomMember.getUserIds()) {
+        log.debug("Add user {} to room {}", uid, addRoomMember.getStreamId());
+        execution.bdk().streams().addMemberToRoom(uid, addRoomMember.getStreamId());
+      }
+    }
+  }
+
+  private boolean isObo(AddRoomMember activity) {
+    return activity.getOnBehalfOf() != null && (activity.getOnBehalfOf().getUsername() != null
+        || activity.getOnBehalfOf().getUserId() != null);
+  }
+
+  private void doOboWithCache(ActivityExecutorContext<AddRoomMember> execution, AddRoomMember addRoomMember) {
+    AuthSession authSession;
+    if (addRoomMember.getOnBehalfOf().getUsername() != null) {
+      authSession = execution.bdk().obo(addRoomMember.getOnBehalfOf().getUsername());
+    } else {
+      authSession = execution.bdk().obo(addRoomMember.getOnBehalfOf().getUserId());
+    }
+
     for (Long uid : addRoomMember.getUserIds()) {
       log.debug("Add user {} to room {}", uid, addRoomMember.getStreamId());
-      execution.bdk().streams().addMemberToRoom(uid, addRoomMember.getStreamId());
+      execution.bdk().obo(authSession).streams().addMemberToRoom(uid, addRoomMember.getStreamId());
     }
   }
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/CreateRoomExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/CreateRoomExecutor.java
@@ -7,6 +7,7 @@ import com.symphony.bdk.gen.api.model.V3RoomAttributes;
 import com.symphony.bdk.gen.api.model.V3RoomDetail;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
+import com.symphony.bdk.workflow.engine.executor.obo.OboExecutor;
 import com.symphony.bdk.workflow.swadl.v1.activity.room.CreateRoom;
 
 import lombok.extern.slf4j.Slf4j;
@@ -16,7 +17,8 @@ import java.util.List;
 import java.util.Map;
 
 @Slf4j
-public class CreateRoomExecutor implements ActivityExecutor<CreateRoom> {
+public class CreateRoomExecutor extends OboExecutor<CreateRoom, String>
+    implements ActivityExecutor<CreateRoom> {
 
   private static final String OUTPUT_ROOM_ID_KEY = "roomId";
 
@@ -29,7 +31,9 @@ public class CreateRoomExecutor implements ActivityExecutor<CreateRoom> {
 
     final String createdRoomId;
 
-    if (uids != null && !uids.isEmpty() && !StringUtils.isEmpty(name) && !StringUtils.isEmpty(description)) {
+    if (this.isObo(activity)) {
+      createdRoomId = this.doOboWithCache(execution);
+    } else if (uids != null && !uids.isEmpty() && !StringUtils.isEmpty(name) && !StringUtils.isEmpty(description)) {
       createdRoomId = this.createRoom(execution, uids, toRoomAttributes(activity));
       log.debug("Stream {} created with {} users, id={}", name, uids.size(), createdRoomId);
     } else if (uids != null && !uids.isEmpty()) {
@@ -72,55 +76,58 @@ public class CreateRoomExecutor implements ActivityExecutor<CreateRoom> {
   private String createRoom(ActivityExecutorContext<CreateRoom> execution, List<Long> uids,
       V3RoomAttributes v3RoomAttributes) {
     String roomId = createRoom(execution, v3RoomAttributes);
-
-    if (this.isObo(execution.getActivity())) {
-      AuthSession authSession = this.getOboAuthSession(execution, execution.getActivity());
-      uids.forEach(uid -> execution.bdk().obo(authSession).streams().addMemberToRoom(uid, roomId));
-    } else {
-      uids.forEach(uid -> execution.bdk().streams().addMemberToRoom(uid, roomId));
-    }
+    uids.forEach(uid -> execution.bdk().streams().addMemberToRoom(uid, roomId));
 
     return roomId;
   }
 
   private String createRoom(ActivityExecutorContext<CreateRoom> execution, List<Long> uids) {
-    Stream stream;
-    CreateRoom createRoomActivity = execution.getActivity();
-
-    if (this.isObo(createRoomActivity)) {
-      AuthSession authSession = this.getOboAuthSession(execution, createRoomActivity);
-      stream = execution.bdk().obo(authSession).streams().create(uids);
-    } else {
-      stream = execution.bdk().streams().create(uids);
-    }
+    Stream stream = execution.bdk().streams().create(uids);
     return stream.getId();
   }
 
   private String createRoom(ActivityExecutorContext<CreateRoom> execution, V3RoomAttributes v3RoomAttributes) {
-    CreateRoom createRoomActivity = execution.getActivity();
-    V3RoomDetail v3RoomDetail;
-
-    if (this.isObo(createRoomActivity)) {
-      AuthSession authSession = this.getOboAuthSession(execution, createRoomActivity);
-      v3RoomDetail = execution.bdk().obo(authSession).streams().create(v3RoomAttributes);
-    } else {
-      v3RoomDetail = execution.bdk().streams().create(v3RoomAttributes);
-    }
-
+    V3RoomDetail v3RoomDetail = execution.bdk().streams().create(v3RoomAttributes);
     return v3RoomDetail.getRoomSystemInfo().getId();
   }
 
-  private boolean isObo(CreateRoom createRoom) {
-    return createRoom.getObo() != null && (createRoom.getObo().getUsername() != null
-        || createRoom.getObo().getUserId() != null);
-  }
+  @Override
+  protected String doOboWithCache(ActivityExecutorContext<CreateRoom> execution) {
+    CreateRoom createRoomActivity = execution.getActivity();
+    AuthSession authSession = this.getOboAuthSession(execution);
 
-  private AuthSession getOboAuthSession(ActivityExecutorContext<CreateRoom> execution, CreateRoom createRoomActivity) {
-    if (createRoomActivity.getObo().getUsername() != null) {
-      return execution.bdk().obo(createRoomActivity.getObo().getUsername());
+    List<Long> uids = createRoomActivity.getUserIdsAsLongs();
+    String name = createRoomActivity.getRoomName();
+    String description = createRoomActivity.getRoomDescription();
+    String createdRoomId;
+
+    V3RoomAttributes v3RoomAttributes = toRoomAttributes(createRoomActivity);
+
+    if (uids != null && !uids.isEmpty() && !StringUtils.isEmpty(name) && !StringUtils.isEmpty(description)) {
+      V3RoomDetail v3RoomDetail = execution.bdk().obo(authSession).streams().create(v3RoomAttributes);
+      createdRoomId = v3RoomDetail.getRoomSystemInfo().getId();
+
+      uids.forEach(uid -> execution.bdk()
+          .obo(authSession)
+          .streams()
+          .addMemberToRoom(uid, createdRoomId));
+
+      log.debug("Stream {} created with {} users, id={}", name, uids.size(), createdRoomId);
+
+    } else if (uids != null && !uids.isEmpty()) {
+      Stream stream = execution.bdk().obo(authSession).streams().create(uids);
+      createdRoomId = stream.getId();
+
+      log.debug("MIM created with {} users, id={}", uids.size(), createdRoomId);
+
     } else {
-      return execution.bdk().obo(createRoomActivity.getObo().getUserId());
+      V3RoomDetail v3RoomDetail = execution.bdk().obo(authSession).streams().create(v3RoomAttributes);
+      createdRoomId = v3RoomDetail.getRoomSystemInfo().getId();
+
+      log.debug("Stream {} created, id={}", name, createdRoomId);
     }
+
+    return createdRoomId;
   }
 
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/DemoteRoomOwnerExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/DemoteRoomOwnerExecutor.java
@@ -3,19 +3,21 @@ package com.symphony.bdk.workflow.engine.executor.room;
 import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
+import com.symphony.bdk.workflow.engine.executor.obo.OboExecutor;
 import com.symphony.bdk.workflow.swadl.v1.activity.room.DemoteRoomOwner;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class DemoteRoomOwnerExecutor implements ActivityExecutor<DemoteRoomOwner> {
+public class DemoteRoomOwnerExecutor extends OboExecutor<DemoteRoomOwner, Void>
+    implements ActivityExecutor<DemoteRoomOwner> {
 
   @Override
   public void execute(ActivityExecutorContext<DemoteRoomOwner> execution) {
     DemoteRoomOwner demoteRoomOwner = execution.getActivity();
 
     if (this.isObo(demoteRoomOwner)) {
-      this.doOboWithCache(execution, demoteRoomOwner);
+      this.doOboWithCache(execution);
     } else {
       for (Long uid : demoteRoomOwner.getUserIds()) {
         log.debug("Demote owner {} for room {}", uid, demoteRoomOwner.getStreamId());
@@ -24,22 +26,16 @@ public class DemoteRoomOwnerExecutor implements ActivityExecutor<DemoteRoomOwner
     }
   }
 
-  private boolean isObo(DemoteRoomOwner activity) {
-    return activity.getObo() != null && (activity.getObo().getUsername() != null
-        || activity.getObo().getUserId() != null);
-  }
-
-  private void doOboWithCache(ActivityExecutorContext<DemoteRoomOwner> execution, DemoteRoomOwner demoteRoomOwner) {
-    AuthSession authSession;
-    if (demoteRoomOwner.getObo().getUsername() != null) {
-      authSession = execution.bdk().obo(demoteRoomOwner.getObo().getUsername());
-    } else {
-      authSession = execution.bdk().obo(demoteRoomOwner.getObo().getUserId());
-    }
+  @Override
+  protected Void doOboWithCache(ActivityExecutorContext<DemoteRoomOwner> execution) {
+    DemoteRoomOwner demoteRoomOwner = execution.getActivity();
+    AuthSession authSession = this.getOboAuthSession(execution);
 
     for (Long uid : demoteRoomOwner.getUserIds()) {
       log.debug("Demote owner {} for room {}", uid, demoteRoomOwner.getStreamId());
       execution.bdk().obo(authSession).streams().demoteUserToRoomParticipant(uid, demoteRoomOwner.getStreamId());
     }
+
+    return null;
   }
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/DemoteRoomOwnerExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/DemoteRoomOwnerExecutor.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.workflow.engine.executor.room;
 
+import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
 import com.symphony.bdk.workflow.swadl.v1.activity.room.DemoteRoomOwner;
@@ -13,10 +14,32 @@ public class DemoteRoomOwnerExecutor implements ActivityExecutor<DemoteRoomOwner
   public void execute(ActivityExecutorContext<DemoteRoomOwner> execution) {
     DemoteRoomOwner demoteRoomOwner = execution.getActivity();
 
-    for (Long uid : demoteRoomOwner.getUserIds()) {
-      log.debug("Demote owner {} for room {}", uid, demoteRoomOwner.getStreamId());
-      execution.bdk().streams().demoteUserToRoomParticipant(uid, demoteRoomOwner.getStreamId());
+    if (this.isObo(demoteRoomOwner)) {
+      this.doOboWithCache(execution, demoteRoomOwner);
+    } else {
+      for (Long uid : demoteRoomOwner.getUserIds()) {
+        log.debug("Demote owner {} for room {}", uid, demoteRoomOwner.getStreamId());
+        execution.bdk().streams().demoteUserToRoomParticipant(uid, demoteRoomOwner.getStreamId());
+      }
     }
   }
 
+  private boolean isObo(DemoteRoomOwner activity) {
+    return activity.getObo() != null && (activity.getObo().getUsername() != null
+        || activity.getObo().getUserId() != null);
+  }
+
+  private void doOboWithCache(ActivityExecutorContext<DemoteRoomOwner> execution, DemoteRoomOwner demoteRoomOwner) {
+    AuthSession authSession;
+    if (demoteRoomOwner.getObo().getUsername() != null) {
+      authSession = execution.bdk().obo(demoteRoomOwner.getObo().getUsername());
+    } else {
+      authSession = execution.bdk().obo(demoteRoomOwner.getObo().getUserId());
+    }
+
+    for (Long uid : demoteRoomOwner.getUserIds()) {
+      log.debug("Demote owner {} for room {}", uid, demoteRoomOwner.getStreamId());
+      execution.bdk().obo(authSession).streams().demoteUserToRoomParticipant(uid, demoteRoomOwner.getStreamId());
+    }
+  }
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/GetRoomExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/GetRoomExecutor.java
@@ -4,12 +4,14 @@ import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.gen.api.model.V3RoomDetail;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
+import com.symphony.bdk.workflow.engine.executor.obo.OboExecutor;
 import com.symphony.bdk.workflow.swadl.v1.activity.room.GetRoom;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class GetRoomExecutor implements ActivityExecutor<GetRoom> {
+public class GetRoomExecutor extends OboExecutor<GetRoom, V3RoomDetail>
+    implements ActivityExecutor<GetRoom> {
 
   private static final String OUTPUTS_ROOM_KEY = "room";
 
@@ -28,19 +30,9 @@ public class GetRoomExecutor implements ActivityExecutor<GetRoom> {
     execution.setOutputVariable(OUTPUTS_ROOM_KEY, roomInfo);
   }
 
-  private boolean isObo(GetRoom activity) {
-    return activity.getObo() != null && (activity.getObo().getUsername() != null
-        || activity.getObo().getUserId() != null);
-  }
-
-  private V3RoomDetail doOboWithCache(ActivityExecutorContext<GetRoom> execution) {
-    AuthSession authSession;
-    if (execution.getActivity().getObo().getUsername() != null) {
-      authSession = execution.bdk().obo(execution.getActivity().getObo().getUsername());
-    } else {
-      authSession = execution.bdk().obo(execution.getActivity().getObo().getUserId());
-    }
-
+  @Override
+  protected V3RoomDetail doOboWithCache(ActivityExecutorContext<GetRoom> execution) {
+    AuthSession authSession = this.getOboAuthSession(execution);
     return execution.bdk().obo(authSession).streams().getRoomInfo(execution.getActivity().getStreamId());
   }
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/GetRoomExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/GetRoomExecutor.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.workflow.engine.executor.room;
 
+import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.gen.api.model.V3RoomDetail;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
@@ -16,8 +17,31 @@ public class GetRoomExecutor implements ActivityExecutor<GetRoom> {
   public void execute(ActivityExecutorContext<GetRoom> execution) {
     String streamId = execution.getActivity().getStreamId();
     log.debug("Getting room {}", streamId);
-    V3RoomDetail roomInfo = execution.bdk().streams().getRoomInfo(streamId);
+
+    V3RoomDetail roomInfo;
+    if (this.isObo(execution.getActivity())) {
+      roomInfo = this.doOboWithCache(execution);
+    } else {
+      roomInfo = execution.bdk().streams().getRoomInfo(streamId);
+    }
+
     execution.setOutputVariable(OUTPUTS_ROOM_KEY, roomInfo);
+  }
+
+  private boolean isObo(GetRoom activity) {
+    return activity.getObo() != null && (activity.getObo().getUsername() != null
+        || activity.getObo().getUserId() != null);
+  }
+
+  private V3RoomDetail doOboWithCache(ActivityExecutorContext<GetRoom> execution) {
+    AuthSession authSession;
+    if (execution.getActivity().getObo().getUsername() != null) {
+      authSession = execution.bdk().obo(execution.getActivity().getObo().getUsername());
+    } else {
+      authSession = execution.bdk().obo(execution.getActivity().getObo().getUserId());
+    }
+
+    return execution.bdk().obo(authSession).streams().getRoomInfo(execution.getActivity().getStreamId());
   }
 
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/GetRoomsExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/GetRoomsExecutor.java
@@ -2,17 +2,20 @@ package com.symphony.bdk.workflow.engine.executor.room;
 
 import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.core.service.pagination.model.PaginationAttribute;
+import com.symphony.bdk.core.service.stream.OboStreamService;
 import com.symphony.bdk.gen.api.model.UserId;
 import com.symphony.bdk.gen.api.model.V2RoomSearchCriteria;
 import com.symphony.bdk.gen.api.model.V3RoomSearchResults;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
+import com.symphony.bdk.workflow.engine.executor.obo.OboExecutor;
 import com.symphony.bdk.workflow.swadl.v1.activity.room.GetRooms;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class GetRoomsExecutor implements ActivityExecutor<GetRooms> {
+public class GetRoomsExecutor extends OboExecutor<GetRooms, V3RoomSearchResults>
+    implements ActivityExecutor<GetRooms> {
 
   private static final String OUTPUTS_ROOMS_KEY = "rooms";
 
@@ -22,7 +25,10 @@ public class GetRoomsExecutor implements ActivityExecutor<GetRooms> {
 
     GetRooms getRooms = execution.getActivity();
     V3RoomSearchResults rooms;
-    if (getRooms.getLimit() != null && getRooms.getSkip() != null) {
+
+    if (this.isObo(getRooms)) {
+      rooms = this.doOboWithCache(execution);
+    } else if (getRooms.getLimit() != null && getRooms.getSkip() != null) {
       rooms = this.searchRoomsWithPagination(execution);
     } else if (getRooms.getLimit() == null && getRooms.getSkip() == null) {
       rooms = this.searchRoomsNoPagination(execution);
@@ -57,51 +63,36 @@ public class GetRoomsExecutor implements ActivityExecutor<GetRooms> {
 
   private V3RoomSearchResults searchRoomsWithPagination(ActivityExecutorContext<GetRooms> execution) {
     GetRooms getRooms = execution.getActivity();
-
-    if (this.isObo(getRooms)) {
-      AuthSession authSession;
-      if (getRooms.getObo().getUsername() != null) {
-        authSession = execution.bdk().obo(getRooms.getObo().getUsername());
-      } else {
-        authSession = execution.bdk().obo(getRooms.getObo().getUserId());
-      }
-
-      return execution.bdk()
-          .obo(authSession)
-          .streams()
-          .searchRooms(toCriteria(getRooms), new PaginationAttribute(getRooms.getSkip(), getRooms.getLimit()));
-    } else {
-      return execution.bdk()
-          .streams()
-          .searchRooms(toCriteria(getRooms), new PaginationAttribute(getRooms.getSkip(), getRooms.getLimit()));
-    }
+    return execution.bdk()
+        .streams()
+        .searchRooms(toCriteria(getRooms), new PaginationAttribute(getRooms.getSkip(), getRooms.getLimit()));
   }
 
   private V3RoomSearchResults searchRoomsNoPagination(ActivityExecutorContext<GetRooms> execution) {
     GetRooms getRooms = execution.getActivity();
+    return execution.bdk()
+        .streams()
+        .searchRooms(toCriteria(getRooms));
+  }
 
-    if (this.isObo(getRooms)) {
-      AuthSession authSession;
-      if (getRooms.getObo().getUsername() != null) {
-        authSession = execution.bdk().obo(getRooms.getObo().getUsername());
-      } else {
-        authSession = execution.bdk().obo(getRooms.getObo().getUserId());
-      }
 
-      return execution.bdk()
-          .obo(authSession)
-          .streams()
-          .searchRooms(toCriteria(getRooms));
+  @Override
+  protected V3RoomSearchResults doOboWithCache(ActivityExecutorContext<GetRooms> execution) {
+    GetRooms getRooms = execution.getActivity();
+    AuthSession authSession = this.getOboAuthSession(execution);
+    OboStreamService streamOboService = execution.bdk()
+        .obo(authSession)
+        .streams();
+
+    if (getRooms.getLimit() != null && getRooms.getSkip() != null) {
+      return streamOboService.searchRooms(toCriteria(getRooms),
+          new PaginationAttribute(getRooms.getSkip(), getRooms.getLimit()));
+
+    } else if (getRooms.getLimit() == null && getRooms.getSkip() == null) {
+      return streamOboService.searchRooms(toCriteria(getRooms));
     } else {
-      return execution.bdk()
-          .streams()
-          .searchRooms(toCriteria(getRooms));
+      throw new IllegalArgumentException(
+          String.format("Skip and limit should both be set to get rooms in activity %s", getRooms.getId()));
     }
   }
-
-  private boolean isObo(GetRooms activity) {
-    return activity.getObo() != null && (activity.getObo().getUsername() != null
-        || activity.getObo().getUserId() != null);
-  }
-
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/PromoteRoomOwnerExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/PromoteRoomOwnerExecutor.java
@@ -3,19 +3,21 @@ package com.symphony.bdk.workflow.engine.executor.room;
 import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
+import com.symphony.bdk.workflow.engine.executor.obo.OboExecutor;
 import com.symphony.bdk.workflow.swadl.v1.activity.room.PromoteRoomOwner;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class PromoteRoomOwnerExecutor implements ActivityExecutor<PromoteRoomOwner> {
+public class PromoteRoomOwnerExecutor extends OboExecutor<PromoteRoomOwner, Void>
+    implements ActivityExecutor<PromoteRoomOwner> {
 
   @Override
   public void execute(ActivityExecutorContext<PromoteRoomOwner> execution) {
     PromoteRoomOwner promoteRoomOwner = execution.getActivity();
 
     if (this.isObo(promoteRoomOwner)) {
-      this.doOboWithCache(execution, promoteRoomOwner);
+      this.doOboWithCache(execution);
     } else {
       for (Long uid : promoteRoomOwner.getUserIds()) {
         log.debug("Demote owner {} for room {}", uid, promoteRoomOwner.getStreamId());
@@ -24,23 +26,17 @@ public class PromoteRoomOwnerExecutor implements ActivityExecutor<PromoteRoomOwn
     }
   }
 
-  private boolean isObo(PromoteRoomOwner activity) {
-    return activity.getObo() != null && (activity.getObo().getUsername() != null
-        || activity.getObo().getUserId() != null);
-  }
-
-  private void doOboWithCache(ActivityExecutorContext<PromoteRoomOwner> execution, PromoteRoomOwner promoteRoomOwner) {
-    AuthSession authSession;
-    if (promoteRoomOwner.getObo().getUsername() != null) {
-      authSession = execution.bdk().obo(promoteRoomOwner.getObo().getUsername());
-    } else {
-      authSession = execution.bdk().obo(promoteRoomOwner.getObo().getUserId());
-    }
+  @Override
+  protected Void doOboWithCache(ActivityExecutorContext<PromoteRoomOwner> execution) {
+    PromoteRoomOwner promoteRoomOwner = execution.getActivity();
+    AuthSession authSession = this.getOboAuthSession(execution);
 
     for (Long uid : promoteRoomOwner.getUserIds()) {
       log.debug("Demote owner {} for room {}", uid, promoteRoomOwner.getStreamId());
       execution.bdk().obo(authSession).streams().promoteUserToRoomOwner(uid, promoteRoomOwner.getStreamId());
     }
+
+    return null;
   }
 
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/PromoteRoomOwnerExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/PromoteRoomOwnerExecutor.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.workflow.engine.executor.room;
 
+import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
 import com.symphony.bdk.workflow.swadl.v1.activity.room.PromoteRoomOwner;
@@ -13,9 +14,32 @@ public class PromoteRoomOwnerExecutor implements ActivityExecutor<PromoteRoomOwn
   public void execute(ActivityExecutorContext<PromoteRoomOwner> execution) {
     PromoteRoomOwner promoteRoomOwner = execution.getActivity();
 
+    if (this.isObo(promoteRoomOwner)) {
+      this.doOboWithCache(execution, promoteRoomOwner);
+    } else {
+      for (Long uid : promoteRoomOwner.getUserIds()) {
+        log.debug("Demote owner {} for room {}", uid, promoteRoomOwner.getStreamId());
+        execution.bdk().streams().promoteUserToRoomOwner(uid, promoteRoomOwner.getStreamId());
+      }
+    }
+  }
+
+  private boolean isObo(PromoteRoomOwner activity) {
+    return activity.getObo() != null && (activity.getObo().getUsername() != null
+        || activity.getObo().getUserId() != null);
+  }
+
+  private void doOboWithCache(ActivityExecutorContext<PromoteRoomOwner> execution, PromoteRoomOwner promoteRoomOwner) {
+    AuthSession authSession;
+    if (promoteRoomOwner.getObo().getUsername() != null) {
+      authSession = execution.bdk().obo(promoteRoomOwner.getObo().getUsername());
+    } else {
+      authSession = execution.bdk().obo(promoteRoomOwner.getObo().getUserId());
+    }
+
     for (Long uid : promoteRoomOwner.getUserIds()) {
       log.debug("Demote owner {} for room {}", uid, promoteRoomOwner.getStreamId());
-      execution.bdk().streams().promoteUserToRoomOwner(uid, promoteRoomOwner.getStreamId());
+      execution.bdk().obo(authSession).streams().promoteUserToRoomOwner(uid, promoteRoomOwner.getStreamId());
     }
   }
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/RemoveRoomMemberExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/RemoveRoomMemberExecutor.java
@@ -3,19 +3,21 @@ package com.symphony.bdk.workflow.engine.executor.room;
 import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
+import com.symphony.bdk.workflow.engine.executor.obo.OboExecutor;
 import com.symphony.bdk.workflow.swadl.v1.activity.room.RemoveRoomMember;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class RemoveRoomMemberExecutor implements ActivityExecutor<RemoveRoomMember> {
+public class RemoveRoomMemberExecutor extends OboExecutor<RemoveRoomMember, Void>
+    implements ActivityExecutor<RemoveRoomMember> {
 
   @Override
   public void execute(ActivityExecutorContext<RemoveRoomMember> execution) {
     RemoveRoomMember removeRoomMember = execution.getActivity();
 
     if (this.isObo(removeRoomMember)) {
-      this.doOboWithCache(execution, removeRoomMember);
+      this.doOboWithCache(execution);
     } else {
       for (Long uid : removeRoomMember.getUserIds()) {
         log.debug("Remove member {} from room {}", uid, removeRoomMember.getStreamId());
@@ -24,23 +26,17 @@ public class RemoveRoomMemberExecutor implements ActivityExecutor<RemoveRoomMemb
     }
   }
 
-  private boolean isObo(RemoveRoomMember activity) {
-    return activity.getObo() != null && (activity.getObo().getUsername() != null
-        || activity.getObo().getUserId() != null);
-  }
-
-  private void doOboWithCache(ActivityExecutorContext<RemoveRoomMember> execution, RemoveRoomMember removeRoomMember) {
-    AuthSession authSession;
-    if (removeRoomMember.getObo().getUsername() != null) {
-      authSession = execution.bdk().obo(removeRoomMember.getObo().getUsername());
-    } else {
-      authSession = execution.bdk().obo(removeRoomMember.getObo().getUserId());
-    }
+  @Override
+  protected Void doOboWithCache(ActivityExecutorContext<RemoveRoomMember> execution) {
+    RemoveRoomMember removeRoomMember = execution.getActivity();
+    AuthSession authSession = this.getOboAuthSession(execution);
 
     for (Long uid : removeRoomMember.getUserIds()) {
       log.debug("Remove member {} from room {}", uid, removeRoomMember.getStreamId());
       execution.bdk().obo(authSession).streams().removeMemberFromRoom(uid, removeRoomMember.getStreamId());
     }
+
+    return null;
   }
 
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/RemoveRoomMemberExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/RemoveRoomMemberExecutor.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.workflow.engine.executor.room;
 
+import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
 import com.symphony.bdk.workflow.swadl.v1.activity.room.RemoveRoomMember;
@@ -13,9 +14,32 @@ public class RemoveRoomMemberExecutor implements ActivityExecutor<RemoveRoomMemb
   public void execute(ActivityExecutorContext<RemoveRoomMember> execution) {
     RemoveRoomMember removeRoomMember = execution.getActivity();
 
+    if (this.isObo(removeRoomMember)) {
+      this.doOboWithCache(execution, removeRoomMember);
+    } else {
+      for (Long uid : removeRoomMember.getUserIds()) {
+        log.debug("Remove member {} from room {}", uid, removeRoomMember.getStreamId());
+        execution.bdk().streams().removeMemberFromRoom(uid, removeRoomMember.getStreamId());
+      }
+    }
+  }
+
+  private boolean isObo(RemoveRoomMember activity) {
+    return activity.getObo() != null && (activity.getObo().getUsername() != null
+        || activity.getObo().getUserId() != null);
+  }
+
+  private void doOboWithCache(ActivityExecutorContext<RemoveRoomMember> execution, RemoveRoomMember removeRoomMember) {
+    AuthSession authSession;
+    if (removeRoomMember.getObo().getUsername() != null) {
+      authSession = execution.bdk().obo(removeRoomMember.getObo().getUsername());
+    } else {
+      authSession = execution.bdk().obo(removeRoomMember.getObo().getUserId());
+    }
+
     for (Long uid : removeRoomMember.getUserIds()) {
       log.debug("Remove member {} from room {}", uid, removeRoomMember.getStreamId());
-      execution.bdk().streams().removeMemberFromRoom(uid, removeRoomMember.getStreamId());
+      execution.bdk().obo(authSession).streams().removeMemberFromRoom(uid, removeRoomMember.getStreamId());
     }
   }
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/UpdateRoomExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/UpdateRoomExecutor.java
@@ -52,7 +52,7 @@ public class UpdateRoomExecutor extends OboExecutor<UpdateRoom, V3RoomDetail> im
     UpdateRoom updateRoom = execution.getActivity();
     AuthSession authSession = this.getOboAuthSession(execution);
 
-    if(shouldUpdateRoom(updateRoom)) {
+    if (shouldUpdateRoom(updateRoom)) {
       log.debug("Updating room {} attributes with OBO", updateRoom.getStreamId());
       execution.bdk().obo(authSession).streams().updateRoom(updateRoom.getStreamId(), toAttributes(updateRoom));
     }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/UpdateRoomExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/UpdateRoomExecutor.java
@@ -40,7 +40,7 @@ public class UpdateRoomExecutor implements ActivityExecutor<UpdateRoom> {
         throw new IllegalArgumentException(
             String.format("Room active status update, in activity %s, is not OBO enabled", updateRoom.getId()));
       } else {
-        // this is a different API call but we support it in the same activity
+        // this is a different API call, but we support it in the same activity
         log.debug("Updating room {} active status", updateRoom.getStreamId());
         execution.bdk().streams().setRoomActive(updateRoom.getStreamId(), updateRoom.getActive());
       }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/UpdateRoomExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/UpdateRoomExecutor.java
@@ -6,6 +6,7 @@ import com.symphony.bdk.gen.api.model.V3RoomAttributes;
 import com.symphony.bdk.gen.api.model.V3RoomDetail;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
+import com.symphony.bdk.workflow.engine.executor.obo.OboExecutor;
 import com.symphony.bdk.workflow.swadl.v1.activity.room.UpdateRoom;
 
 import lombok.extern.slf4j.Slf4j;
@@ -14,61 +15,54 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Slf4j
-public class UpdateRoomExecutor implements ActivityExecutor<UpdateRoom> {
+public class UpdateRoomExecutor extends OboExecutor<UpdateRoom, V3RoomDetail> implements ActivityExecutor<UpdateRoom> {
 
   private static final String OUTPUT_ROOM_KEY = "room";
 
   @Override
   public void execute(ActivityExecutorContext<UpdateRoom> execution) {
     UpdateRoom updateRoom = execution.getActivity();
-    final boolean isObo = this.isObo(updateRoom);
-    AuthSession authSession = null;
+    final V3RoomDetail updatedRoomDetails;
 
-    if (shouldUpdateRoom(updateRoom)) {
-      log.debug("Updating room {} attributes", updateRoom.getStreamId());
-      V3RoomAttributes attributes = toAttributes(updateRoom);
-      if (isObo) {
-        authSession = this.getOboAuthSession(execution, updateRoom);
-        execution.bdk().obo(authSession).streams().updateRoom(updateRoom.getStreamId(), attributes);
-      } else {
+    if (this.isObo(updateRoom)) {
+      updatedRoomDetails = this.doOboWithCache(execution);
+    } else {
+      if (shouldUpdateRoom(updateRoom)) {
+        log.debug("Updating room {} attributes", updateRoom.getStreamId());
+        V3RoomAttributes attributes = toAttributes(updateRoom);
         execution.bdk().streams().updateRoom(updateRoom.getStreamId(), attributes);
       }
-    }
 
-    if (updateRoom.getActive() != null) {
-      if (isObo) {
-        throw new IllegalArgumentException(
-            String.format("Room active status update, in activity %s, is not OBO enabled", updateRoom.getId()));
-      } else {
+      if (updateRoom.getActive() != null) {
         // this is a different API call, but we support it in the same activity
         log.debug("Updating room {} active status", updateRoom.getStreamId());
         execution.bdk().streams().setRoomActive(updateRoom.getStreamId(), updateRoom.getActive());
       }
+
+      // services called above return different results and might end up not being called so we explicitly call the API
+      // to return the same info in all cases
+      updatedRoomDetails = execution.bdk().streams().getRoomInfo(updateRoom.getStreamId());
     }
 
-    // services called above return different results and might end up not being called so we explicitly call the API
-    // to return the same info in all cases
-    final V3RoomDetail updatedRoom;
-    if (isObo) {
-      updatedRoom = execution.bdk().obo(authSession).streams().getRoomInfo(updateRoom.getStreamId());
-    } else {
-      updatedRoom = execution.bdk().streams().getRoomInfo(updateRoom.getStreamId());
-    }
-
-    execution.setOutputVariable(OUTPUT_ROOM_KEY, updatedRoom);
+    execution.setOutputVariable(OUTPUT_ROOM_KEY, updatedRoomDetails);
   }
 
-  private boolean isObo(UpdateRoom updateRoom) {
-    return updateRoom.getObo() != null && (updateRoom.getObo().getUsername() != null
-        || updateRoom.getObo().getUserId() != null);
-  }
+  @Override
+  protected V3RoomDetail doOboWithCache(ActivityExecutorContext<UpdateRoom> execution) {
+    UpdateRoom updateRoom = execution.getActivity();
+    AuthSession authSession = this.getOboAuthSession(execution);
 
-  private AuthSession getOboAuthSession(ActivityExecutorContext<UpdateRoom> execution, UpdateRoom updateRoomActivity) {
-    if (updateRoomActivity.getObo().getUsername() != null) {
-      return execution.bdk().obo(updateRoomActivity.getObo().getUsername());
-    } else {
-      return execution.bdk().obo(updateRoomActivity.getObo().getUserId());
+    if(shouldUpdateRoom(updateRoom)) {
+      log.debug("Updating room {} attributes with OBO", updateRoom.getStreamId());
+      execution.bdk().obo(authSession).streams().updateRoom(updateRoom.getStreamId(), toAttributes(updateRoom));
     }
+
+    if (updateRoom.getActive() != null) {
+      throw new IllegalArgumentException(
+          String.format("Room active status update, in activity %s, is not OBO enabled", updateRoom.getId()));
+    }
+
+    return execution.bdk().obo(authSession).streams().getRoomInfo(updateRoom.getStreamId());
   }
 
   private boolean shouldUpdateRoom(UpdateRoom updateRoom) {

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/UpdateRoomExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/UpdateRoomExecutor.java
@@ -50,9 +50,9 @@ public class UpdateRoomExecutor implements ActivityExecutor<UpdateRoom> {
     // to return the same info in all cases
     final V3RoomDetail updatedRoom;
     if (isObo) {
-       updatedRoom = execution.bdk().obo(authSession).streams().getRoomInfo(updateRoom.getStreamId());
+      updatedRoom = execution.bdk().obo(authSession).streams().getRoomInfo(updateRoom.getStreamId());
     } else {
-       updatedRoom = execution.bdk().streams().getRoomInfo(updateRoom.getStreamId());
+      updatedRoom = execution.bdk().streams().getRoomInfo(updateRoom.getStreamId());
     }
 
     execution.setOutputVariable(OUTPUT_ROOM_KEY, updatedRoom);

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/stream/GetStreamExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/stream/GetStreamExecutor.java
@@ -4,12 +4,14 @@ import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.gen.api.model.V2StreamAttributes;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
+import com.symphony.bdk.workflow.engine.executor.obo.OboExecutor;
 import com.symphony.bdk.workflow.swadl.v1.activity.stream.GetStream;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class GetStreamExecutor implements ActivityExecutor<GetStream> {
+public class GetStreamExecutor extends OboExecutor<GetStream, V2StreamAttributes>
+    implements ActivityExecutor<GetStream> {
 
   private static final String OUTPUTS_STREAM_KEY = "stream";
 
@@ -27,19 +29,9 @@ public class GetStreamExecutor implements ActivityExecutor<GetStream> {
     execution.setOutputVariable(OUTPUTS_STREAM_KEY, roomInfo);
   }
 
-  private boolean isObo(GetStream activity) {
-    return activity.getObo() != null && (activity.getObo().getUsername() != null
-        || activity.getObo().getUserId() != null);
-  }
-
-  private V2StreamAttributes doOboWithCache(ActivityExecutorContext<GetStream> execution) {
-    AuthSession authSession;
-    if (execution.getActivity().getObo().getUsername() != null) {
-      authSession = execution.bdk().obo(execution.getActivity().getObo().getUsername());
-    } else {
-      authSession = execution.bdk().obo(execution.getActivity().getObo().getUserId());
-    }
-
+  @Override
+  protected V2StreamAttributes doOboWithCache(ActivityExecutorContext<GetStream> execution) {
+    AuthSession authSession = this.getOboAuthSession(execution);
     return execution.bdk().obo(authSession).streams().getStream(execution.getActivity().getStreamId());
   }
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/stream/GetStreamExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/stream/GetStreamExecutor.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.workflow.engine.executor.stream;
 
+import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.gen.api.model.V2StreamAttributes;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
@@ -16,8 +17,30 @@ public class GetStreamExecutor implements ActivityExecutor<GetStream> {
   public void execute(ActivityExecutorContext<GetStream> execution) {
     String streamId = execution.getActivity().getStreamId();
     log.debug("Getting stream {}", streamId);
-    V2StreamAttributes roomInfo = execution.bdk().streams().getStream(streamId);
+
+    V2StreamAttributes roomInfo;
+    if (this.isObo(execution.getActivity())) {
+      roomInfo = this.doOboWithCache(execution);
+    } else {
+      roomInfo = execution.bdk().streams().getStream(streamId);
+    }
     execution.setOutputVariable(OUTPUTS_STREAM_KEY, roomInfo);
+  }
+
+  private boolean isObo(GetStream activity) {
+    return activity.getObo() != null && (activity.getObo().getUsername() != null
+        || activity.getObo().getUserId() != null);
+  }
+
+  private V2StreamAttributes doOboWithCache(ActivityExecutorContext<GetStream> execution) {
+    AuthSession authSession;
+    if (execution.getActivity().getObo().getUsername() != null) {
+      authSession = execution.bdk().obo(execution.getActivity().getObo().getUsername());
+    } else {
+      authSession = execution.bdk().obo(execution.getActivity().getObo().getUserId());
+    }
+
+    return execution.bdk().obo(authSession).streams().getStream(execution.getActivity().getStreamId());
   }
 
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/stream/GetUserStreamsExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/stream/GetUserStreamsExecutor.java
@@ -2,11 +2,13 @@ package com.symphony.bdk.workflow.engine.executor.stream;
 
 import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.core.service.pagination.model.PaginationAttribute;
+import com.symphony.bdk.core.service.stream.OboStreamService;
 import com.symphony.bdk.gen.api.model.StreamAttributes;
 import com.symphony.bdk.gen.api.model.StreamFilter;
 import com.symphony.bdk.gen.api.model.StreamType;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
+import com.symphony.bdk.workflow.engine.executor.obo.OboExecutor;
 import com.symphony.bdk.workflow.swadl.v1.activity.stream.GetUserStreams;
 
 import lombok.extern.slf4j.Slf4j;
@@ -15,7 +17,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Slf4j
-public class GetUserStreamsExecutor implements ActivityExecutor<GetUserStreams> {
+public class GetUserStreamsExecutor extends OboExecutor<GetUserStreams, List<StreamAttributes>>
+    implements ActivityExecutor<GetUserStreams> {
 
   private static final String OUTPUTS_STREAMS_KEY = "streams";
 
@@ -25,7 +28,9 @@ public class GetUserStreamsExecutor implements ActivityExecutor<GetUserStreams> 
 
     GetUserStreams getUserStreams = execution.getActivity();
     List<StreamAttributes> userStreams;
-    if (getUserStreams.getLimit() != null && getUserStreams.getSkip() != null) {
+    if (this.isObo(getUserStreams)) {
+      userStreams = this.doOboWithCache(execution);
+    } else if (getUserStreams.getLimit() != null && getUserStreams.getSkip() != null) {
       userStreams = this.listUserStreamsWithPagination(execution);
     } else {
       userStreams = this.listUserStreamsNoPagination(execution);
@@ -48,52 +53,33 @@ public class GetUserStreamsExecutor implements ActivityExecutor<GetUserStreams> 
 
   private List<StreamAttributes> listUserStreamsWithPagination(ActivityExecutorContext<GetUserStreams> execution) {
     GetUserStreams getUserStreams = execution.getActivity();
-
-    if (this.isObo(getUserStreams)) {
-      AuthSession authSession;
-      if (getUserStreams.getObo().getUsername() != null) {
-        authSession = execution.bdk().obo(getUserStreams.getObo().getUsername());
-      } else {
-        authSession = execution.bdk().obo(getUserStreams.getObo().getUserId());
-      }
-
-      return execution.bdk()
-          .obo(authSession)
-          .streams()
-          .listStreams(toFilter(getUserStreams),
-              new PaginationAttribute(getUserStreams.getSkip(), getUserStreams.getLimit()));
-    } else {
-      return execution.bdk()
-          .streams()
-          .listStreams(toFilter(getUserStreams),
-              new PaginationAttribute(getUserStreams.getSkip(), getUserStreams.getLimit()));
-    }
+    return execution.bdk()
+        .streams()
+        .listStreams(toFilter(getUserStreams),
+            new PaginationAttribute(getUserStreams.getSkip(), getUserStreams.getLimit()));
   }
 
   private List<StreamAttributes> listUserStreamsNoPagination(ActivityExecutorContext<GetUserStreams> execution) {
     GetUserStreams getUserStreams = execution.getActivity();
-
-    if (this.isObo(getUserStreams)) {
-      AuthSession authSession;
-      if (getUserStreams.getObo().getUsername() != null) {
-        authSession = execution.bdk().obo(getUserStreams.getObo().getUsername());
-      } else {
-        authSession = execution.bdk().obo(getUserStreams.getObo().getUserId());
-      }
-
-      return execution.bdk()
-          .obo(authSession)
-          .streams()
-          .listStreams(toFilter(getUserStreams));
-    } else {
-      return execution.bdk()
-          .streams()
-          .listStreams(toFilter(getUserStreams));
-    }
+    return execution.bdk()
+        .streams()
+        .listStreams(toFilter(getUserStreams));
   }
 
-  private boolean isObo(GetUserStreams activity) {
-    return activity.getObo() != null && (activity.getObo().getUsername() != null
-        || activity.getObo().getUserId() != null);
+  @Override
+  protected List<StreamAttributes> doOboWithCache(
+      ActivityExecutorContext<GetUserStreams> execution) {
+    GetUserStreams getUserStreams = execution.getActivity();
+    AuthSession authSession = this.getOboAuthSession(execution);
+    OboStreamService streamOboService = execution.bdk()
+        .obo(authSession)
+        .streams();
+
+    if (getUserStreams.getLimit() != null && getUserStreams.getSkip() != null) {
+      return streamOboService.listStreams(toFilter(getUserStreams),
+          new PaginationAttribute(getUserStreams.getSkip(), getUserStreams.getLimit()));
+    } else {
+      return streamOboService.listStreams(toFilter(getUserStreams));
+    }
   }
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/user/GetUsersExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/user/GetUsersExecutor.java
@@ -1,6 +1,6 @@
 package com.symphony.bdk.workflow.engine.executor.user;
 
-import com.symphony.bdk.core.service.user.UserService;
+import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.gen.api.model.UserV2;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
@@ -24,21 +24,77 @@ public class GetUsersExecutor implements ActivityExecutor<GetUsers> {
     List<UserV2> users = null;
 
     // Since the workflow is validated by swadl-schema, at least one of the following attributes is not null
-    UserService userService = context.bdk().users();
     if (getUsers.getUsernames() != null) {
-      users = userService.listUsersByUsernames(getUsers.getUsernames(), getUsers.getActive());
+      users = this.listUsersByUsernames(context);
 
     } else if (getUsers.getUserIds() != null) {
-      users = userService.listUsersByIds(getUsers.getUserIds(), getUsers.getLocal(),
-          getUsers.getActive());
+      users = this.listUsersByIds(context);
 
     } else if (getUsers.getEmails() != null) {
-      users = userService.listUsersByEmails(getUsers.getEmails(), getUsers.getLocal(),
-          getUsers.getActive());
-
+      users = this.listUsersByEmails(context);
     }
 
     context.setOutputVariable(OUTPUT_USERS_KEY, users);
+  }
+
+  private boolean isObo(GetUsers activity) {
+    return activity.getObo() != null && (activity.getObo().getUsername() != null
+        || activity.getObo().getUserId() != null);
+  }
+
+  private List<UserV2> listUsersByUsernames(ActivityExecutorContext<GetUsers> context) {
+    GetUsers activity = context.getActivity();
+
+    if (this.isObo(activity)) {
+      AuthSession authSession = this.getAuthSession(context);
+
+      return context.bdk().obo(authSession).users().listUsersByUsernames(activity.getUsernames(), activity.getActive());
+    } else {
+      return context.bdk().users().listUsersByUsernames(activity.getUsernames(), activity.getActive());
+    }
+  }
+
+  private List<UserV2> listUsersByIds(ActivityExecutorContext<GetUsers> context) {
+    GetUsers activity = context.getActivity();
+
+    if (this.isObo(activity)) {
+      AuthSession authSession = this.getAuthSession(context);
+
+      return context.bdk()
+          .obo(authSession)
+          .users()
+          .listUsersByIds(activity.getUserIds(), activity.getLocal(), activity.getActive());
+    } else {
+      return context.bdk().users().listUsersByIds(activity.getUserIds(), activity.getLocal(), activity.getActive());
+    }
+  }
+
+  private List<UserV2> listUsersByEmails(ActivityExecutorContext<GetUsers> context) {
+    GetUsers activity = context.getActivity();
+
+    if (this.isObo(activity)) {
+      AuthSession authSession = this.getAuthSession(context);
+
+      return context.bdk()
+          .obo(authSession)
+          .users()
+          .listUsersByEmails(activity.getEmails(), activity.getLocal(), activity.getActive());
+    } else {
+      return context.bdk().users().listUsersByEmails(activity.getEmails(), activity.getLocal(), activity.getActive());
+    }
+  }
+
+  private AuthSession getAuthSession(ActivityExecutorContext<GetUsers> context) {
+    AuthSession authSession;
+    GetUsers activity = context.getActivity();
+
+    if (activity.getObo().getUsername() != null) {
+      authSession = context.bdk().obo(activity.getObo().getUsername());
+    } else {
+      authSession = context.bdk().obo(activity.getObo().getUserId());
+    }
+
+    return authSession;
   }
 
 }

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/ConnectionsIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/ConnectionsIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.workflow;
 
 import static com.symphony.bdk.workflow.custom.assertion.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -13,6 +14,8 @@ import com.symphony.bdk.workflow.swadl.v1.Workflow;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -65,6 +68,46 @@ class ConnectionsIntegrationTest extends IntegrationTest {
         .hasOutput(String.format(OUTPUTS_CONNECTIONS_KEY, "getConnections"), userConnections);
   }
 
+  @ParameterizedTest
+  @CsvSource(
+      {"/connection/obo/get-connections-obo-valid-username.swadl.yaml, /get-connections-obo-valid-username, "
+          + "getConnectionsOboValidUsername",
+          "/connection/obo/get-connections-obo-valid-userid.swadl.yaml, /get-connections-obo-valid-userid, "
+              + "getConnectionsOboValidUserid"})
+  void listConnectionsStatusObo(String workflowFile, String command, String output) throws Exception {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream(workflowFile));
+
+    final List<Long> userIds = Arrays.asList(666L, 777L);
+    final List<UserConnection> userConnections = Arrays.asList(connection(666L, UserConnection.StatusEnum.ACCEPTED),
+        connection(777L, UserConnection.StatusEnum.ACCEPTED));
+
+    when(bdkGateway.obo(any(String.class))).thenReturn(botSession);
+    when(bdkGateway.obo(any(Long.class))).thenReturn(botSession);
+    when(oboConnectionService.listConnections(ConnectionStatus.ACCEPTED, userIds)).thenReturn(userConnections);
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived(command));
+
+    verify(oboConnectionService, timeout(5000)).listConnections(ConnectionStatus.ACCEPTED, userIds);
+
+    assertThat(workflow).isExecuted()
+        .hasOutput(String.format(OUTPUTS_CONNECTIONS_KEY, output), userConnections);
+  }
+
+  @Test
+  void listConnectionsStatusOboUnauthorized() throws Exception {
+    final Workflow workflow = SwadlParser.fromYaml(
+        getClass().getResourceAsStream("/connection/obo/get-connections-obo-unauthorized.swadl.yaml"));
+
+    when(bdkGateway.obo(any(Long.class))).thenThrow(new RuntimeException("Unauthorized user"));
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/get-connections-obo-unauthorized"));
+
+    assertThat(workflow).executed("getConnectionsOboUnauthorized").notExecuted("scriptActivityNotToBeExecuted");
+  }
+
   @Test
   @DisplayName("Given a connection with a user, when the workflow is triggered, then the connection is returned")
   void getConnectionStatus() throws IOException, ProcessingException {
@@ -83,6 +126,45 @@ class ConnectionsIntegrationTest extends IntegrationTest {
 
     assertThat(workflow).isExecuted()
         .hasOutput(String.format(OUTPUT_CONNECTION_KEY, "getConnection"), userConnection);
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+      {"/connection/obo/get-connection-obo-valid-username.swadl.yaml, /get-connection-obo-valid-username, "
+          + "getConnectionOboValidUsername",
+          "/connection/obo/get-connection-obo-valid-userid.swadl.yaml, /get-connection-obo-valid-userid, "
+              + "getConnectionOboValidUserid"})
+  void getConnectionStatusObo(String workflowFile, String command, String output) throws Exception {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream(workflowFile));
+
+    final Long userId = 1234L;
+    final UserConnection userConnection = connection(userId);
+
+    when(bdkGateway.obo(any(String.class))).thenReturn(botSession);
+    when(bdkGateway.obo(any(Long.class))).thenReturn(botSession);
+    when(oboConnectionService.getConnection(userId)).thenReturn(userConnection);
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived(command));
+
+    verify(oboConnectionService, timeout(5000)).getConnection(userId);
+
+    assertThat(workflow).isExecuted()
+        .hasOutput(String.format(OUTPUT_CONNECTION_KEY, output), userConnection);
+  }
+
+  @Test
+  void getConnectionStatusOboUnauthorized() throws Exception {
+    final Workflow workflow = SwadlParser.fromYaml(
+        getClass().getResourceAsStream("/connection/obo/get-connection-obo-unauthorized.swadl.yaml"));
+
+    when(bdkGateway.obo(any(Long.class))).thenThrow(new RuntimeException("Unauthorized user"));
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/get-connection-obo-unauthorized"));
+
+    assertThat(workflow).executed("getConnectionOboUnauthorized").notExecuted("scriptActivityNotToBeExecuted");
   }
 
   @Test
@@ -104,6 +186,45 @@ class ConnectionsIntegrationTest extends IntegrationTest {
 
     assertThat(workflow).isExecuted()
         .hasOutput(String.format(OUTPUT_CONNECTION_KEY, "createConnection"), userConnection);
+  }
+
+  @ParameterizedTest
+  @CsvSource(
+      {"/connection/obo/create-connection-obo-valid-username.swadl.yaml, /create-connection-obo-valid-username, "
+          + "createConnectionOboValidUsername",
+          "/connection/obo/create-connection-obo-valid-userid.swadl.yaml, /create-connection-obo-valid-userid, "
+              + "createConnectionOboValidUserid"})
+  void createConnectionObo(String workflowFile, String command, String outputName) throws Exception {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream(workflowFile));
+
+    final Long userId = 1234L;
+    final UserConnection userConnection = connection(userId, UserConnection.StatusEnum.PENDING_OUTGOING);
+
+    when(bdkGateway.obo(any(String.class))).thenReturn(botSession);
+    when(bdkGateway.obo(any(Long.class))).thenReturn(botSession);
+    when(oboConnectionService.createConnection(userId)).thenReturn(userConnection);
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived(command));
+
+    verify(oboConnectionService, timeout(5000)).createConnection(userId);
+
+    assertThat(workflow).isExecuted().hasOutput(String.format(OUTPUT_CONNECTION_KEY, outputName), userConnection);
+  }
+
+  @Test
+  void createConnectionOboUnauthorized() throws Exception {
+    final Workflow workflow =
+        SwadlParser.fromYaml(
+            getClass().getResourceAsStream("/connection/obo/create-connection-obo-unauthorized.swadl.yaml"));
+
+    when(bdkGateway.obo(any(Long.class))).thenThrow(new RuntimeException("Unauthorized user"));
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/create-connection-obo-unauthorized"));
+
+    assertThat(workflow).executed("createConnectionOboUnauthorized").notExecuted("scriptActivityNotToBeExecuted");
   }
 
   @Test
@@ -128,6 +249,45 @@ class ConnectionsIntegrationTest extends IntegrationTest {
         .hasOutput(String.format(OUTPUT_CONNECTION_KEY, "acceptConnection"), userConnection);
   }
 
+  @ParameterizedTest
+  @CsvSource(
+      {"/connection/obo/accept-connection-obo-valid-username.swadl.yaml, /accept-connection-obo-valid-username, "
+          + "acceptConnectionOboValidUsername",
+          "/connection/obo/accept-connection-obo-valid-userid.swadl.yaml, /accept-connection-obo-valid-userid, "
+              + "acceptConnectionOboValidUserid"})
+  void acceptConnectionStatusObo(String workflowFile, String command, String output) throws Exception {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream(workflowFile));
+
+    final Long userId = 1234L;
+    final UserConnection userConnection = connection(userId, UserConnection.StatusEnum.ACCEPTED);
+
+    when(bdkGateway.obo(any(String.class))).thenReturn(botSession);
+    when(bdkGateway.obo(any(Long.class))).thenReturn(botSession);
+    when(oboConnectionService.acceptConnection(userId)).thenReturn(userConnection);
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived(command));
+
+    verify(oboConnectionService, timeout(5000)).acceptConnection(userId);
+
+    assertThat(workflow).isExecuted().hasOutput(String.format(OUTPUT_CONNECTION_KEY, output), userConnection);
+  }
+
+  @Test
+  void acceptConnectionStatusOboUnauthorized() throws Exception {
+    final Workflow workflow = SwadlParser.fromYaml(
+        getClass().getResourceAsStream("/connection/obo/accept-connection-obo-unauthorized.swadl.yaml"));
+
+    when(bdkGateway.obo(any(Long.class))).thenThrow(new RuntimeException("unauthorized user"));
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/accept-connection-obo-unauthorized"));
+
+    assertThat(workflow).executed("acceptConnectionOboUnauthorized").notExecuted("scriptActivityNotToBeExecuted");
+
+  }
+
   @Test
   @DisplayName(
       "Given an incoming connection request from a user, when the workflow is triggered,"
@@ -150,6 +310,44 @@ class ConnectionsIntegrationTest extends IntegrationTest {
         .hasOutput(String.format(OUTPUT_CONNECTION_KEY, "rejectConnection"), userConnection);
   }
 
+  @ParameterizedTest
+  @CsvSource(
+      {"/connection/obo/reject-connection-obo-valid-username.swadl.yaml, /reject-connection-obo-valid-username, "
+          + "rejectConnectionOboValidUsername",
+          "/connection/obo/reject-connection-obo-valid-userid.swadl.yaml, /reject-connection-obo-valid-userid, "
+              + "rejectConnectionOboValidUserid"})
+  void rejectConnectionStatusObo(String workflowFile, String command, String output) throws Exception {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream(workflowFile));
+
+    final Long userId = 1234L;
+    final UserConnection userConnection = connection(userId, UserConnection.StatusEnum.REJECTED);
+
+    when(bdkGateway.obo(any(String.class))).thenReturn(botSession);
+    when(bdkGateway.obo(any(Long.class))).thenReturn(botSession);
+    when(oboConnectionService.rejectConnection(userId)).thenReturn(userConnection);
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived(command));
+
+    verify(oboConnectionService, timeout(5000)).rejectConnection(userId);
+
+    assertThat(workflow).isExecuted().hasOutput(String.format(OUTPUT_CONNECTION_KEY, output), userConnection);
+  }
+
+  @Test
+  void rejectConnectionStatusOboUnauthorized() throws Exception {
+    final Workflow workflow = SwadlParser.fromYaml(
+        getClass().getResourceAsStream("/connection/obo/reject-connection-obo-unauthorized.swadl.yaml"));
+
+    when(bdkGateway.obo(any(Long.class))).thenThrow(new RuntimeException("Unauthorized user"));
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/reject-connection-obo-unauthorized"));
+
+    assertThat(workflow).executed("rejectConnectionOboUnauthorized").notExecuted("scriptActivityNotToBeExecuted");
+  }
+
   @Test
   @DisplayName(
       "Given connection request from a user, when the workflow is triggered, then the connection is removed")
@@ -167,4 +365,36 @@ class ConnectionsIntegrationTest extends IntegrationTest {
     assertThat(workflow).isExecuted();
   }
 
+  @ParameterizedTest
+  @CsvSource({"/connection/obo/remove-connection-obo-valid-username.swadl.yaml, /remove-connection-obo-valid-username",
+      "/connection/obo/remove-connection-obo-valid-userid.swadl.yaml, /remove-connection-obo-valid-userid"})
+  void removeConnectionStatusObo(String workflowFile, String command) throws Exception {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream(workflowFile));
+
+    final Long userId = 1234L;
+
+    when(bdkGateway.obo(any(String.class))).thenReturn(botSession);
+    when(bdkGateway.obo(any(Long.class))).thenReturn(botSession);
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived(command));
+
+    verify(oboConnectionService, timeout(5000)).removeConnection(userId);
+
+    assertThat(workflow).isExecuted();
+  }
+
+  @Test
+  void removeConnectionStatusOboUnauthorized() throws Exception {
+    final Workflow workflow = SwadlParser.fromYaml(
+        getClass().getResourceAsStream("/connection/obo/remove-connection-obo-unauthorized.swadl.yaml"));
+
+    when(bdkGateway.obo(any(Long.class))).thenThrow(new RuntimeException("Unauthorized user"));
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/remove-connection-obo-unauthorized"));
+
+    assertThat(workflow).executed("removeConnectionOboUnauthorized").notExecuted("scriptActivityNotToBeExecuted");
+  }
 }

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/IntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/IntegrationTest.java
@@ -3,14 +3,18 @@ package com.symphony.bdk.workflow;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import com.symphony.bdk.core.OboServices;
 import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.core.service.connection.ConnectionService;
 import com.symphony.bdk.core.service.message.MessageService;
+import com.symphony.bdk.core.service.message.OboMessageService;
 import com.symphony.bdk.core.service.message.model.Attachment;
 import com.symphony.bdk.core.service.message.model.Message;
 import com.symphony.bdk.core.service.session.SessionService;
+import com.symphony.bdk.core.service.stream.OboStreamService;
 import com.symphony.bdk.core.service.stream.StreamService;
 import com.symphony.bdk.core.service.user.UserService;
 import com.symphony.bdk.ext.group.SymphonyGroupService;
@@ -68,6 +72,15 @@ public abstract class IntegrationTest {
   // Mock the BDK
   @MockBean
   AuthSession botSession;
+
+  @MockBean
+  OboServices oboServices;
+
+  @MockBean(name = "oboMessageService")
+  OboMessageService oboMessageService;
+
+  @MockBean(name = "oboStreamService")
+  OboStreamService oboStreamService;
 
   @MockBean(name = "streamService")
   StreamService streamService;
@@ -131,6 +144,9 @@ public abstract class IntegrationTest {
     when(bdkGateway.connections()).thenReturn(this.connectionService);
     when(bdkGateway.users()).thenReturn(this.userService);
     when(bdkGateway.groups()).thenReturn(this.groupService);
+    when(bdkGateway.obo(any(AuthSession.class))).thenReturn(this.oboServices);
+    when(oboServices.messages()).thenReturn(this.oboMessageService);
+    when(oboServices.streams()).thenReturn(this.oboStreamService);
   }
 
   // make sure we start the test with a clean engine to avoid the same /command to be registered

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/IntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/IntegrationTest.java
@@ -17,6 +17,7 @@ import com.symphony.bdk.core.service.message.model.Message;
 import com.symphony.bdk.core.service.session.SessionService;
 import com.symphony.bdk.core.service.stream.OboStreamService;
 import com.symphony.bdk.core.service.stream.StreamService;
+import com.symphony.bdk.core.service.user.OboUserService;
 import com.symphony.bdk.core.service.user.UserService;
 import com.symphony.bdk.ext.group.SymphonyGroupService;
 import com.symphony.bdk.gen.api.model.Stream;
@@ -82,6 +83,9 @@ public abstract class IntegrationTest {
 
   @MockBean(name = "oboStreamService")
   OboStreamService oboStreamService;
+
+  @MockBean(name = "oboUserService")
+  OboUserService oboUserService;
 
   @MockBean(name = "oboConnectionService")
   OboConnectionService oboConnectionService;
@@ -151,6 +155,7 @@ public abstract class IntegrationTest {
     when(bdkGateway.obo(any(AuthSession.class))).thenReturn(this.oboServices);
     when(oboServices.messages()).thenReturn(this.oboMessageService);
     when(oboServices.streams()).thenReturn(this.oboStreamService);
+    when(oboServices.users()).thenReturn(this.oboUserService);
     when(oboServices.connections()).thenReturn(this.oboConnectionService);
   }
 

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/IntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/IntegrationTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import com.symphony.bdk.core.OboServices;
 import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.core.service.connection.ConnectionService;
+import com.symphony.bdk.core.service.connection.OboConnectionService;
 import com.symphony.bdk.core.service.message.MessageService;
 import com.symphony.bdk.core.service.message.OboMessageService;
 import com.symphony.bdk.core.service.message.model.Attachment;
@@ -82,6 +83,9 @@ public abstract class IntegrationTest {
   @MockBean(name = "oboStreamService")
   OboStreamService oboStreamService;
 
+  @MockBean(name = "oboConnectionService")
+  OboConnectionService oboConnectionService;
+
   @MockBean(name = "streamService")
   StreamService streamService;
 
@@ -147,6 +151,7 @@ public abstract class IntegrationTest {
     when(bdkGateway.obo(any(AuthSession.class))).thenReturn(this.oboServices);
     when(oboServices.messages()).thenReturn(this.oboMessageService);
     when(oboServices.streams()).thenReturn(this.oboStreamService);
+    when(oboServices.connections()).thenReturn(this.oboConnectionService);
   }
 
   // make sure we start the test with a clean engine to avoid the same /command to be registered

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/RoomIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/RoomIntegrationTest.java
@@ -3,7 +3,6 @@ package com.symphony.bdk.workflow;
 import static com.symphony.bdk.workflow.custom.assertion.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -28,8 +27,7 @@ import com.symphony.bdk.workflow.swadl.v1.Workflow;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Arrays;
@@ -245,15 +243,9 @@ class RoomIntegrationTest extends IntegrationTest {
     verify(streamService, timeout(5000)).addMemberToRoom(456L, "abc");
   }
 
-  static java.util.stream.Stream<Arguments> validOboActivities() {
-    return java.util.stream.Stream.of(
-        arguments("/room/add-room-member-obo-valid-username.swadl.yaml"),
-        arguments("/room/add-room-member-obo-valid-userid.swadl.yaml")
-    );
-  }
-
   @ParameterizedTest
-  @MethodSource("validOboActivities")
+  @ValueSource(strings = {"/room/obo/add-room-member-obo-valid-username.swadl.yaml",
+      "/room/obo/add-room-member-obo-valid-userid.swadl.yaml"})
   void addRoomMemberObo(String workflowFile) throws Exception {
     final Workflow workflow =
         SwadlParser.fromYaml(getClass().getResourceAsStream(workflowFile));
@@ -271,7 +263,7 @@ class RoomIntegrationTest extends IntegrationTest {
   @Test
   void addRoomMemberOboUnauthorized() throws Exception {
     final Workflow workflow =
-        SwadlParser.fromYaml(getClass().getResourceAsStream("/room/add-room-member-obo-unauthorized.swadl.yaml"));
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/room/obo/add-room-member-obo-unauthorized.swadl.yaml"));
 
     when(bdkGateway.obo(any(String.class))).thenThrow(new RuntimeException("Unauthorized user"));
 

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/RoomIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/RoomIntegrationTest.java
@@ -423,8 +423,8 @@ class RoomIntegrationTest extends IntegrationTest {
 
   @Test
   void removeRoomMemberOboUnauthorized() throws Exception {
-    final Workflow workflow =
-        SwadlParser.fromYaml(getClass().getResourceAsStream("/room/obo/remove-room-member-obo-unauthorized.swadl.yaml"));
+    final Workflow workflow = SwadlParser.fromYaml(
+        getClass().getResourceAsStream("/room/obo/remove-room-member-obo-unauthorized.swadl.yaml"));
 
     when(bdkGateway.obo(any(String.class))).thenThrow(new RuntimeException("Unauthorized user"));
 
@@ -465,8 +465,8 @@ class RoomIntegrationTest extends IntegrationTest {
 
   @Test
   void promoteRoomOwnerOboUnauthorized() throws Exception {
-    final Workflow workflow =
-        SwadlParser.fromYaml(getClass().getResourceAsStream("/room/obo/promote-room-owner-obo-unauthorized.swadl.yaml"));
+    final Workflow workflow = SwadlParser.fromYaml(
+        getClass().getResourceAsStream("/room/obo/promote-room-owner-obo-unauthorized.swadl.yaml"));
 
     when(bdkGateway.obo(any(String.class))).thenThrow(new RuntimeException("Unauthorized user"));
 
@@ -598,7 +598,7 @@ class RoomIntegrationTest extends IntegrationTest {
   @SuppressWarnings("ConstantConditions") // for null pagination attribute with refEq
   @ParameterizedTest
   @CsvSource({"/room/obo/get-rooms-obo-valid-userid.swadl.yaml, /get-rooms-obo-valid-userid",
-    "/room/obo/get-rooms-obo-valid-username.swadl.yaml, /get-rooms-obo-valid-username"})
+      "/room/obo/get-rooms-obo-valid-username.swadl.yaml, /get-rooms-obo-valid-username"})
   void getRoomsObo(String workflowFile, String command) throws Exception {
     final Workflow workflow = SwadlParser.fromYaml(getClass().getResourceAsStream(workflowFile));
 

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/SendMessageIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/SendMessageIntegrationTest.java
@@ -3,7 +3,6 @@ package com.symphony.bdk.workflow;
 import static com.symphony.bdk.workflow.custom.assertion.Assertions.assertThat;
 import static com.symphony.bdk.workflow.custom.assertion.WorkflowAssert.assertMessage;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -28,8 +27,7 @@ import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
 import java.io.ByteArrayInputStream;
@@ -386,15 +384,9 @@ class SendMessageIntegrationTest extends IntegrationTest {
     verify(messageService, timeout(5000)).send(eq(List.of("ABC", "DEF")), any());
   }
 
-  static java.util.stream.Stream<Arguments> validOboActivities() {
-    return java.util.stream.Stream.of(
-      arguments("/obo/send-message-obo-valid-username.swadl.yaml"),
-      arguments("/obo/send-message-obo-valid-userid.swadl.yaml")
-    );
-  }
-
   @ParameterizedTest
-  @MethodSource("validOboActivities")
+  @ValueSource(strings = {"/message/obo/send-message-obo-valid-username.swadl.yaml",
+      "/message/obo/send-message-obo-valid-userid.swadl.yaml"})
   void sendMessageObo(String workflowFile) throws Exception {
     final Workflow workflow =
         SwadlParser.fromYaml(getClass().getResourceAsStream(workflowFile));
@@ -417,7 +409,7 @@ class SendMessageIntegrationTest extends IntegrationTest {
   @Test
   void sendMessageOboUnauthorized() throws Exception {
     final Workflow workflow =
-        SwadlParser.fromYaml(getClass().getResourceAsStream("/obo/send-message-obo-unauthorized.swadl.yaml"));
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/message/obo/send-message-obo-unauthorized.swadl.yaml"));
 
     when(bdkGateway.obo(any(Long.class))).thenThrow(new RuntimeException("Unauthorized user"));
 
@@ -431,7 +423,8 @@ class SendMessageIntegrationTest extends IntegrationTest {
   @Test
   void sendBlastMessageOboNotSupported() throws Exception {
     final Workflow workflow =
-        SwadlParser.fromYaml(getClass().getResourceAsStream("/obo/send-blast-message-obo-not-supported.swadl.yaml"));
+        SwadlParser.fromYaml(getClass().getResourceAsStream(
+            "/message/obo/send-blast-message-obo-not-supported.swadl.yaml"));
 
     when(bdkGateway.obo(any(String.class))).thenReturn(botSession);
     when(bdkGateway.obo(any(Long.class))).thenReturn(botSession);

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/UsersIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/UsersIntegrationTest.java
@@ -19,6 +19,8 @@ import com.symphony.bdk.workflow.swadl.v1.Workflow;
 
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
@@ -247,6 +249,36 @@ class UsersIntegrationTest extends IntegrationTest {
     assertThat(workflow).isExecuted();
   }
 
+  @ParameterizedTest
+  @CsvSource({"/user/obo/get-users-ids-obo-valid-username.swadl.yaml, /get-users-ids-obo-valid-username",
+      "/user/obo/get-users-ids-obo-valid-userid.swadl.yaml, /get-users-ids-obo-valid-userid"})
+  void getUsersIdsObo(String workflowFile, String command) throws  Exception {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream(workflowFile));
+
+    when(bdkGateway.obo(any(String.class))).thenReturn(botSession);
+    when(bdkGateway.obo(any(Long.class))).thenReturn(botSession);
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived(command));
+
+    verify(oboUserService, timeout(5000)).listUsersByIds(List.of(123L, 456L), true, false);
+    assertThat(workflow).isExecuted();
+  }
+
+  @Test
+  void getUsersIdsOboUnauthorized() throws Exception {
+    final Workflow workflow = SwadlParser.fromYaml(
+        getClass().getResourceAsStream("/user/obo/get-users-ids-obo-unauthorized.swadl.yaml"));
+
+    when(bdkGateway.obo(any(Long.class))).thenThrow(new RuntimeException("Unauthorized user"));
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/get-users-ids-obo-unauthorized"));
+
+    assertThat(workflow).executed("getUsersIdsOboUnauthorized").notExecuted("scriptActivityNotToBeExecuted");
+  }
+
   @Test
   void getUsersEmails() throws IOException, ProcessingException {
     final Workflow workflow =
@@ -259,6 +291,36 @@ class UsersIntegrationTest extends IntegrationTest {
     assertThat(workflow).isExecuted();
   }
 
+  @ParameterizedTest
+  @CsvSource({"/user/obo/get-users-emails-obo-valid-username.swadl.yaml, /get-users-emails-obo-valid-username",
+      "/user/obo/get-users-emails-obo-valid-userid.swadl.yaml, /get-users-emails-obo-valid-userid"})
+  void getUsersEmailsObo(String workflowFile, String command) throws  Exception {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream(workflowFile));
+
+    when(bdkGateway.obo(any(String.class))).thenReturn(botSession);
+    when(bdkGateway.obo(any(Long.class))).thenReturn(botSession);
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived(command));
+
+    verify(oboUserService, timeout(5000)).listUsersByEmails(List.of("bob@mail.com", "eve@mail.com"), true, false);
+    assertThat(workflow).isExecuted();
+  }
+
+  @Test
+  void getUsersEmailsOboUnauthorized() throws Exception {
+    final Workflow workflow = SwadlParser.fromYaml(
+        getClass().getResourceAsStream("/user/obo/get-users-emails-obo-unauthorized.swadl.yaml"));
+
+    when(bdkGateway.obo(any(Long.class))).thenThrow(new RuntimeException("Unauthorized user"));
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/get-users-emails-obo-unauthorized"));
+
+    assertThat(workflow).executed("getUsersEmailsOboUnauthorized").notExecuted("scriptActivityNotToBeExecuted");
+  }
+
   @Test
   void getUsersUsernames() throws IOException, ProcessingException {
     final Workflow workflow =
@@ -269,6 +331,36 @@ class UsersIntegrationTest extends IntegrationTest {
 
     verify(userService, timeout(5000)).listUsersByUsernames(List.of("bob", "eve"), false);
     assertThat(workflow).isExecuted();
+  }
+
+  @ParameterizedTest
+  @CsvSource({"/user/obo/get-users-usernames-obo-valid-username.swadl.yaml, /get-users-usernames-obo-valid-username",
+      "/user/obo/get-users-usernames-obo-valid-userid.swadl.yaml, /get-users-usernames-obo-valid-userid"})
+  void getUsersUsernamesObo(String workflowFile, String command) throws  Exception {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream(workflowFile));
+
+    when(bdkGateway.obo(any(String.class))).thenReturn(botSession);
+    when(bdkGateway.obo(any(Long.class))).thenReturn(botSession);
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived(command));
+
+    verify(oboUserService, timeout(5000)).listUsersByUsernames(List.of("bob", "eve"), false);
+    assertThat(workflow).isExecuted();
+  }
+
+  @Test
+  void getUsersUsernamesOboUnauthorized() throws Exception {
+    final Workflow workflow = SwadlParser.fromYaml(
+        getClass().getResourceAsStream("/user/obo/get-users-usernames-obo-unauthorized.swadl.yaml"));
+
+    when(bdkGateway.obo(any(Long.class))).thenThrow(new RuntimeException("Unauthorized user"));
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/get-users-usernames-obo-unauthorized"));
+
+    assertThat(workflow).executed("getUsersUsernamesOboUnauthorized").notExecuted("scriptActivityNotToBeExecuted");
   }
 
   @Test

--- a/workflow-bot-app/src/test/resources/connection/obo/accept-connection-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/connection/obo/accept-connection-obo-unauthorized.swadl.yaml
@@ -1,0 +1,16 @@
+id: accept-connection-obo-unauthorized
+activities:
+  - accept-connection:
+      id: acceptConnectionOboUnauthorized
+      on:
+        message-received:
+          content: /accept-connection-obo-unauthorized
+      user-id: 1234
+      obo:
+        user-id: 123
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/connection/obo/accept-connection-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/connection/obo/accept-connection-obo-valid-userid.swadl.yaml
@@ -1,0 +1,10 @@
+id: accept-connection-obo-valid-userid
+activities:
+  - accept-connection:
+      id: acceptConnectionOboValidUserid
+      on:
+        message-received:
+          content: /accept-connection-obo-valid-userid
+      user-id: 1234
+      obo:
+        user-id: 123

--- a/workflow-bot-app/src/test/resources/connection/obo/accept-connection-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/connection/obo/accept-connection-obo-valid-username.swadl.yaml
@@ -1,0 +1,10 @@
+id: accept-connection-obo-valid-username
+activities:
+  - accept-connection:
+      id: acceptConnectionOboValidUsername
+      on:
+        message-received:
+          content: /accept-connection-obo-valid-username
+      user-id: 1234
+      obo:
+        username: "John"

--- a/workflow-bot-app/src/test/resources/connection/obo/create-connection-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/connection/obo/create-connection-obo-unauthorized.swadl.yaml
@@ -1,0 +1,16 @@
+id: create-connection-obo-unauthorized
+activities:
+  - create-connection:
+      id: createConnectionOboUnauthorized
+      on:
+        message-received:
+          content: /create-connection-obo-unauthorized
+      user-id: 1234
+      obo:
+        user-id: 12345
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/connection/obo/create-connection-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/connection/obo/create-connection-obo-valid-userid.swadl.yaml
@@ -1,0 +1,10 @@
+id: create-connection-obo-valid-userid
+activities:
+  - create-connection:
+      id: createConnectionOboValidUserid
+      on:
+        message-received:
+          content: /create-connection-obo-valid-userid
+      user-id: 1234
+      obo:
+        user-id: 123

--- a/workflow-bot-app/src/test/resources/connection/obo/create-connection-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/connection/obo/create-connection-obo-valid-username.swadl.yaml
@@ -1,0 +1,10 @@
+id: create-connection-obo-valid-username
+activities:
+  - create-connection:
+      id: createConnectionOboValidUsername
+      on:
+        message-received:
+          content: /create-connection-obo-valid-username
+      user-id: 1234
+      obo:
+        username: "John"

--- a/workflow-bot-app/src/test/resources/connection/obo/get-connection-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/connection/obo/get-connection-obo-unauthorized.swadl.yaml
@@ -1,0 +1,16 @@
+id: get-connection-obo-unauthorized
+activities:
+  - get-connection:
+      id: getConnectionOboUnauthorized
+      on:
+        message-received:
+          content: /get-connection-obo-unauthorized
+      user-id: 1234
+      obo:
+        user-id: 123
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/connection/obo/get-connection-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/connection/obo/get-connection-obo-valid-userid.swadl.yaml
@@ -1,0 +1,10 @@
+id: get-connection-obo-valid-userid
+activities:
+  - get-connection:
+      id: getConnectionOboValidUserid
+      on:
+        message-received:
+          content: /get-connection-obo-valid-userid
+      user-id: 1234
+      obo:
+        user-id: 123

--- a/workflow-bot-app/src/test/resources/connection/obo/get-connection-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/connection/obo/get-connection-obo-valid-username.swadl.yaml
@@ -1,0 +1,10 @@
+id: get-connection-obo-valid-username
+activities:
+  - get-connection:
+      id: getConnectionOboValidUsername
+      on:
+        message-received:
+          content: /get-connection-obo-valid-username
+      user-id: 1234
+      obo:
+        username: "John"

--- a/workflow-bot-app/src/test/resources/connection/obo/get-connections-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/connection/obo/get-connections-obo-unauthorized.swadl.yaml
@@ -1,0 +1,19 @@
+id: get-connections-obo-unauthorized
+activities:
+  - get-connections:
+      id: getConnectionsOboUnauthorized
+      on:
+        message-received:
+          content: /get-connections-obo-unauthorized
+      user-ids:
+        - 666
+        - 777
+      status: ACCEPTED
+      obo:
+        user-id: 123
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/connection/obo/get-connections-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/connection/obo/get-connections-obo-valid-userid.swadl.yaml
@@ -1,0 +1,13 @@
+id: get-connections-obo-valid-userid
+activities:
+  - get-connections:
+      id: getConnectionsOboValidUserid
+      on:
+        message-received:
+          content: /get-connections-obo-valid-userid
+      user-ids:
+        - 666
+        - 777
+      status: ACCEPTED
+      obo:
+        user-id: 123

--- a/workflow-bot-app/src/test/resources/connection/obo/get-connections-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/connection/obo/get-connections-obo-valid-username.swadl.yaml
@@ -1,0 +1,13 @@
+id: get-connections-obo-valid-username
+activities:
+  - get-connections:
+      id: getConnectionsOboValidUsername
+      on:
+        message-received:
+          content: /get-connections-obo-valid-username
+      user-ids:
+        - 666
+        - 777
+      status: ACCEPTED
+      obo:
+        username: "John"

--- a/workflow-bot-app/src/test/resources/connection/obo/reject-connection-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/connection/obo/reject-connection-obo-unauthorized.swadl.yaml
@@ -1,0 +1,16 @@
+id: reject-connection-obo-unauthorized
+activities:
+  - reject-connection:
+      id: rejectConnectionOboUnauthorized
+      on:
+        message-received:
+          content: /reject-connection-obo-unauthorized
+      user-id: 1234
+      obo:
+        user-id: 123
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/connection/obo/reject-connection-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/connection/obo/reject-connection-obo-valid-userid.swadl.yaml
@@ -1,0 +1,10 @@
+id: reject-connection-obo-valid-userid
+activities:
+  - reject-connection:
+      id: rejectConnectionOboValidUserid
+      on:
+        message-received:
+          content: /reject-connection-obo-valid-userid
+      user-id: 1234
+      obo:
+        user-id: 123

--- a/workflow-bot-app/src/test/resources/connection/obo/reject-connection-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/connection/obo/reject-connection-obo-valid-username.swadl.yaml
@@ -1,0 +1,10 @@
+id: reject-connection-obo-valid-username
+activities:
+  - reject-connection:
+      id: rejectConnectionOboValidUsername
+      on:
+        message-received:
+          content: /reject-connection-obo-valid-username
+      user-id: 1234
+      obo:
+        username: "John"

--- a/workflow-bot-app/src/test/resources/connection/obo/remove-connection-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/connection/obo/remove-connection-obo-unauthorized.swadl.yaml
@@ -1,0 +1,16 @@
+id: remove-connection-obo-unauthorized
+activities:
+  - remove-connection:
+      id: removeConnectionOboUnauthorized
+      on:
+        message-received:
+          content: /remove-connection-obo-unauthorized
+      user-id: 1234
+      obo:
+        user-id: 123
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/connection/obo/remove-connection-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/connection/obo/remove-connection-obo-valid-userid.swadl.yaml
@@ -1,0 +1,10 @@
+id: remove-connection-obo-valid-userid
+activities:
+  - remove-connection:
+      id: removeConnectionOboValidUserid
+      on:
+        message-received:
+          content: /remove-connection-obo-valid-userid
+      user-id: 1234
+      obo:
+        user-id: 123

--- a/workflow-bot-app/src/test/resources/connection/obo/remove-connection-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/connection/obo/remove-connection-obo-valid-username.swadl.yaml
@@ -1,0 +1,10 @@
+id: remove-connection-obo-valid-username
+activities:
+  - remove-connection:
+      id: removeConnectionOboValidUsername
+      on:
+        message-received:
+          content: /remove-connection-obo-valid-username
+      user-id: 1234
+      obo:
+        username: "John"

--- a/workflow-bot-app/src/test/resources/message/obo/pin-message-im-obo-not-supported.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/obo/pin-message-im-obo-not-supported.swadl.yaml
@@ -1,0 +1,16 @@
+id: pin-message-im-obo-not-supported
+activities:
+  - pin-message:
+      id: pinMessageImOboNotSupported
+      on:
+        message-received:
+          content: /pin-message-im-obo-not-supported
+      message-id: MSG_ID
+      obo:
+        user-id: 123
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/message/obo/pin-message-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/obo/pin-message-obo-unauthorized.swadl.yaml
@@ -1,0 +1,10 @@
+id: pin-message-obo-unauthorized
+activities:
+  - pin-message:
+      id: pinMessageOboUnauthorized
+      on:
+        message-received:
+          content: /pin-message-obo-unauthorized
+      message-id: MSG_ID
+      obo:
+        username: "John"

--- a/workflow-bot-app/src/test/resources/message/obo/pin-message-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/obo/pin-message-obo-valid-userid.swadl.yaml
@@ -1,0 +1,10 @@
+id: pin-message-obo-valid-userid
+activities:
+  - pin-message:
+      id: pinMessageOboValidUserid
+      on:
+        message-received:
+          content: /pin-message-obo-valid-userid
+      message-id: MSG_ID
+      obo:
+        user-id: 123

--- a/workflow-bot-app/src/test/resources/message/obo/pin-message-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/obo/pin-message-obo-valid-username.swadl.yaml
@@ -1,0 +1,10 @@
+id: pin-message-obo-valid-username
+activities:
+  - pin-message:
+      id: pinMessageOboValidUsername
+      on:
+        message-received:
+          content: /pin-message-obo-valid-username
+      message-id: MSG_ID
+      obo:
+        username: "John"

--- a/workflow-bot-app/src/test/resources/message/obo/send-blast-message-obo-not-supported.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/obo/send-blast-message-obo-not-supported.swadl.yaml
@@ -10,7 +10,7 @@ activities:
           - "123"
           - "456"
       content: <messageML>Hello!</messageML>
-      on-behalf-of:
+      obo:
         user-id: 12345
 
   - execute-script:

--- a/workflow-bot-app/src/test/resources/message/obo/send-blast-message-obo-not-supported.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/obo/send-blast-message-obo-not-supported.swadl.yaml
@@ -4,7 +4,7 @@ activities:
       id: sendBlastMessageObo
       on:
         message-received:
-          content: "/message"
+          content: "/message-not-supported"
       to:
         stream-ids:
           - "123"

--- a/workflow-bot-app/src/test/resources/message/obo/send-message-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/obo/send-message-obo-unauthorized.swadl.yaml
@@ -8,7 +8,7 @@ activities:
       to:
         stream-id: "123"
       content: <messageML>Hello!</messageML>
-      on-behalf-of:
+      obo:
         user-id: 12345
 
   - execute-script:

--- a/workflow-bot-app/src/test/resources/message/obo/send-message-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/obo/send-message-obo-unauthorized.swadl.yaml
@@ -4,7 +4,7 @@ activities:
       id: sendMessageObo
       on:
         message-received:
-          content: "/message"
+          content: "/message-obo-unauthorized"
       to:
         stream-id: "123"
       content: <messageML>Hello!</messageML>

--- a/workflow-bot-app/src/test/resources/message/obo/send-message-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/obo/send-message-obo-valid-userid.swadl.yaml
@@ -1,4 +1,4 @@
-id: send-message-on-behalf-of-user-valid-username
+id: send-message-on-behalf-of-user-valid-userid
 activities:
   - send-message:
       id: sendMessageObo
@@ -8,5 +8,5 @@ activities:
       to:
         stream-id: "123"
       content: <messageML>Hello!</messageML>
-      on-behalf-of:
-        username: "john"
+      obo:
+        user-id: 12345

--- a/workflow-bot-app/src/test/resources/message/obo/send-message-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/obo/send-message-obo-valid-userid.swadl.yaml
@@ -4,7 +4,7 @@ activities:
       id: sendMessageObo
       on:
         message-received:
-          content: "/message"
+          content: "/message-obo-valid-userid"
       to:
         stream-id: "123"
       content: <messageML>Hello!</messageML>

--- a/workflow-bot-app/src/test/resources/message/obo/send-message-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/obo/send-message-obo-valid-username.swadl.yaml
@@ -1,4 +1,4 @@
-id: send-message-on-behalf-of-user-valid-userid
+id: send-message-on-behalf-of-user-valid-username
 activities:
   - send-message:
       id: sendMessageObo
@@ -8,5 +8,5 @@ activities:
       to:
         stream-id: "123"
       content: <messageML>Hello!</messageML>
-      on-behalf-of:
-        user-id: 12345
+      obo:
+        username: "john"

--- a/workflow-bot-app/src/test/resources/message/obo/send-message-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/obo/send-message-obo-valid-username.swadl.yaml
@@ -4,7 +4,7 @@ activities:
       id: sendMessageObo
       on:
         message-received:
-          content: "/message"
+          content: "/message-obo-valid-username"
       to:
         stream-id: "123"
       content: <messageML>Hello!</messageML>

--- a/workflow-bot-app/src/test/resources/message/obo/unpin-message-im-obo-not-supported.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/obo/unpin-message-im-obo-not-supported.swadl.yaml
@@ -1,0 +1,16 @@
+id: unpin-message-im-obo-not-supported
+activities:
+  - unpin-message:
+      id: unpinMessageImOboNotSupported
+      on:
+        message-received:
+          content: /unpin-message-im-obo-not-supported
+      stream-id: STREAM_ID
+      obo:
+        user-id: 123
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/message/obo/unpin-message-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/obo/unpin-message-obo-unauthorized.swadl.yaml
@@ -1,0 +1,10 @@
+id: unpin-message-obo-unauthorized
+activities:
+  - unpin-message:
+      id: unpinMessageOboUnauthorized
+      on:
+        message-received:
+          content: /unpin-message-obo-unauthorized
+      stream-id: STREAM_ID
+      obo:
+        username: "John"

--- a/workflow-bot-app/src/test/resources/message/obo/unpin-message-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/obo/unpin-message-obo-valid-userid.swadl.yaml
@@ -1,0 +1,10 @@
+id: unpin-message-obo-valid-userid
+activities:
+  - unpin-message:
+      id: unpinMessageOboValidUserid
+      on:
+        message-received:
+          content: /unpin-message-obo-valid-userid
+      stream-id: STREAM_ID
+      obo:
+        user-id: 123

--- a/workflow-bot-app/src/test/resources/message/obo/unpin-message-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/obo/unpin-message-obo-valid-username.swadl.yaml
@@ -1,0 +1,10 @@
+id: unpin-message-obo-valid-username
+activities:
+  - unpin-message:
+      id: unpinMessageOboValidUsername
+      on:
+        message-received:
+          content: /unpin-message-obo-valid-username
+      stream-id: STREAM_ID
+      obo:
+        username: "John"

--- a/workflow-bot-app/src/test/resources/message/send-message-with-freemarker.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/send-message-with-freemarker.swadl.yaml
@@ -10,4 +10,4 @@ activities:
         stream-id: "123"
       on:
         message-received:
-          content: "/send"
+          content: "/send-with-freemarker"

--- a/workflow-bot-app/src/test/resources/message/send-message-with-uids-variables.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/send-message-with-uids-variables.swadl.yaml
@@ -7,7 +7,7 @@ activities:
       content: "<messageML>hello</messageML>"
       on:
         message-received:
-          content: "/send"
+          content: "/send-with-variables"
       to:
         user-ids:
           - ${variables.foo}

--- a/workflow-bot-app/src/test/resources/obo/send-blast-message-obo-not-supported.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/obo/send-blast-message-obo-not-supported.swadl.yaml
@@ -1,0 +1,20 @@
+id: send-blast-message-on-behalf-of-user-not-supported
+activities:
+  - send-message:
+      id: sendBlastMessageObo
+      on:
+        message-received:
+          content: "/message"
+      to:
+        stream-ids:
+          - "123"
+          - "456"
+      content: <messageML>Hello!</messageML>
+      on-behalf-of:
+        user-id: 12345
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/obo/send-message-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/obo/send-message-obo-unauthorized.swadl.yaml
@@ -1,0 +1,18 @@
+id: send-message-on-behalf-of-user-unauthorized
+activities:
+  - send-message:
+      id: sendMessageObo
+      on:
+        message-received:
+          content: "/message"
+      to:
+        stream-id: "123"
+      content: <messageML>Hello!</messageML>
+      on-behalf-of:
+        user-id: 12345
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/obo/send-message-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/obo/send-message-obo-valid-userid.swadl.yaml
@@ -1,0 +1,12 @@
+id: send-message-on-behalf-of-user-valid-userid
+activities:
+  - send-message:
+      id: sendMessageObo
+      on:
+        message-received:
+          content: "/message"
+      to:
+        stream-id: "123"
+      content: <messageML>Hello!</messageML>
+      on-behalf-of:
+        user-id: 12345

--- a/workflow-bot-app/src/test/resources/obo/send-message-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/obo/send-message-obo-valid-username.swadl.yaml
@@ -1,0 +1,12 @@
+id: send-message-on-behalf-of-user-valid-username
+activities:
+  - send-message:
+      id: sendMessageObo
+      on:
+        message-received:
+          content: "/message"
+      to:
+        stream-id: "123"
+      content: <messageML>Hello!</messageML>
+      on-behalf-of:
+        username: "john"

--- a/workflow-bot-app/src/test/resources/room/add-room-member-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/add-room-member-obo-unauthorized.swadl.yaml
@@ -1,0 +1,19 @@
+id: add-room-member-on-behalf-of-user-unauthorized
+activities:
+  - add-room-member:
+      id: addRoomMember
+      on:
+        message-received:
+          content: "/add-room-member"
+      stream-id: abc
+      user-ids:
+        - 123
+        - 456
+      on-behalf-of:
+        username: "john"
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/room/add-room-member-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/add-room-member-obo-valid-userid.swadl.yaml
@@ -1,0 +1,13 @@
+id: add-room-member-on-behalf-of-user-valid-userid
+activities:
+  - add-room-member:
+      id: addRoomMember
+      on:
+        message-received:
+          content: "/add-room-member"
+      stream-id: abc
+      user-ids:
+        - 123
+        - 456
+      on-behalf-of:
+        user-id: 12345

--- a/workflow-bot-app/src/test/resources/room/add-room-member-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/add-room-member-obo-valid-username.swadl.yaml
@@ -1,0 +1,13 @@
+id: add-room-member-on-behalf-of-user-valid-username
+activities:
+  - add-room-member:
+      id: addRoomMember
+      on:
+        message-received:
+          content: "/add-room-member"
+      stream-id: abc
+      user-ids:
+        - 123
+        - 456
+      on-behalf-of:
+        username: "john"

--- a/workflow-bot-app/src/test/resources/room/create-mim-with-uids.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/create-mim-with-uids.swadl.yaml
@@ -1,10 +1,10 @@
-id: create-mim-with-userids--workflow
+id: create-mim-with-userids-workflow
 activities:
   - create-room:
       id: act
       on:
         message-received:
-          content: "/create-mim"
+          content: "/create-mim-with-userids"
       user-ids:
         - 666
         - 777

--- a/workflow-bot-app/src/test/resources/room/create-room-and-send-message.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/create-room-and-send-message.swadl.yaml
@@ -1,17 +1,17 @@
-id: my-proposal
+id: create-room-and-send-message
 activities:
-  - create-room: #has as output {"streamId": "AbcDEFgHiJK"}
+  - create-room:
       id: createRoom
       on:
         message-received:
-          content: "/create-room"
+          content: "/create-room-and-send-msg"
       room-name: Test
-      user-ids:  #optional if name is set
+      user-ids:
         - 1234
         - 5678
       public: true
 
-  - send-message: #has as output {"messageId": "LmNOpqrStUVw"}
+  - send-message:
       id: sendmessageid
       to:
         stream-id: ${createRoom.outputs.roomId}

--- a/workflow-bot-app/src/test/resources/room/create-room-with-details.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/create-room-with-details.swadl.yaml
@@ -4,7 +4,7 @@ activities:
       id: "create_room_with_details"
       on:
         message-received:
-          content: "/create-room"
+          content: "/create-room-with-details"
       room-name: "The best room ever"
       room-description: "this is room description"
       public: true

--- a/workflow-bot-app/src/test/resources/room/obo/add-room-member-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/add-room-member-obo-unauthorized.swadl.yaml
@@ -9,7 +9,7 @@ activities:
       user-ids:
         - 123
         - 456
-      on-behalf-of:
+      obo:
         username: "john"
 
   - execute-script:

--- a/workflow-bot-app/src/test/resources/room/obo/add-room-member-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/add-room-member-obo-unauthorized.swadl.yaml
@@ -4,7 +4,7 @@ activities:
       id: addRoomMember
       on:
         message-received:
-          content: "/add-room-member"
+          content: "/add-room-member-obo-unauthorized"
       stream-id: abc
       user-ids:
         - 123

--- a/workflow-bot-app/src/test/resources/room/obo/add-room-member-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/add-room-member-obo-valid-userid.swadl.yaml
@@ -1,4 +1,4 @@
-id: add-room-member-on-behalf-of-user-valid-username
+id: add-room-member-on-behalf-of-user-valid-userid
 activities:
   - add-room-member:
       id: addRoomMember
@@ -9,5 +9,5 @@ activities:
       user-ids:
         - 123
         - 456
-      on-behalf-of:
-        username: "john"
+      obo:
+        user-id: 12345

--- a/workflow-bot-app/src/test/resources/room/obo/add-room-member-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/add-room-member-obo-valid-userid.swadl.yaml
@@ -4,7 +4,7 @@ activities:
       id: addRoomMember
       on:
         message-received:
-          content: "/add-room-member"
+          content: "/add-room-member-obo-valid-userid"
       stream-id: abc
       user-ids:
         - 123

--- a/workflow-bot-app/src/test/resources/room/obo/add-room-member-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/add-room-member-obo-valid-userid.swadl.yaml
@@ -1,7 +1,7 @@
 id: add-room-member-on-behalf-of-user-valid-userid
 activities:
   - add-room-member:
-      id: addRoomMember
+      id: addRoomMemberOboValidUserid
       on:
         message-received:
           content: "/add-room-member-obo-valid-userid"

--- a/workflow-bot-app/src/test/resources/room/obo/add-room-member-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/add-room-member-obo-valid-username.swadl.yaml
@@ -1,7 +1,7 @@
 id: add-room-member-on-behalf-of-user-valid-username
 activities:
   - add-room-member:
-      id: addRoomMember
+      id: addRoomMemberOboValidUsername
       on:
         message-received:
           content: "/add-room-member-obo-valid-username"

--- a/workflow-bot-app/src/test/resources/room/obo/add-room-member-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/add-room-member-obo-valid-username.swadl.yaml
@@ -4,7 +4,7 @@ activities:
       id: addRoomMember
       on:
         message-received:
-          content: "/add-room-member"
+          content: "/add-room-member-obo-valid-username"
       stream-id: abc
       user-ids:
         - 123

--- a/workflow-bot-app/src/test/resources/room/obo/add-room-member-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/add-room-member-obo-valid-username.swadl.yaml
@@ -1,4 +1,4 @@
-id: add-room-member-on-behalf-of-user-valid-userid
+id: add-room-member-on-behalf-of-user-valid-username
 activities:
   - add-room-member:
       id: addRoomMember
@@ -9,5 +9,5 @@ activities:
       user-ids:
         - 123
         - 456
-      on-behalf-of:
-        user-id: 12345
+      obo:
+        username: "john"

--- a/workflow-bot-app/src/test/resources/room/obo/create-mim-with-uids-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/create-mim-with-uids-obo-valid-userid.swadl.yaml
@@ -1,10 +1,10 @@
-id: create-mim-with-userids--workflow
+id: create-mim-with-userids-obo-workflow
 activities:
   - create-room:
       id: createRoomObo
       on:
         message-received:
-          content: "/create-mim"
+          content: "/create-mim-obo-valid-userid"
       user-ids:
         - 666
         - 777

--- a/workflow-bot-app/src/test/resources/room/obo/create-mim-with-uids-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/create-mim-with-uids-obo-valid-userid.swadl.yaml
@@ -1,0 +1,13 @@
+id: create-mim-with-userids--workflow
+activities:
+  - create-room:
+      id: createRoomObo
+      on:
+        message-received:
+          content: "/create-mim"
+      user-ids:
+        - 666
+        - 777
+        - 999
+      obo:
+        user-id: 12345

--- a/workflow-bot-app/src/test/resources/room/obo/create-mim-with-uids-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/create-mim-with-uids-obo-valid-username.swadl.yaml
@@ -1,10 +1,10 @@
-id: create-mim-with-userids--workflow
+id: create-mim-with-valid-username-obo-workflow
 activities:
   - create-room:
       id: createRoomObo
       on:
         message-received:
-          content: "/create-mim"
+          content: "/create-mim-obo-valid-username"
       user-ids:
         - 666
         - 777

--- a/workflow-bot-app/src/test/resources/room/obo/create-mim-with-uids-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/create-mim-with-uids-obo-valid-username.swadl.yaml
@@ -1,0 +1,13 @@
+id: create-mim-with-userids--workflow
+activities:
+  - create-room:
+      id: createRoomObo
+      on:
+        message-received:
+          content: "/create-mim"
+      user-ids:
+        - 666
+        - 777
+        - 999
+      obo:
+        username: "john"

--- a/workflow-bot-app/src/test/resources/room/obo/create-room-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/create-room-obo-unauthorized.swadl.yaml
@@ -4,7 +4,7 @@ activities:
       id: "createRoomOboUnauthorized"
       on:
         message-received:
-          content: "/create-room"
+          content: "/create-room-obo-unauthorized"
       room-name: "The best room ever"
       room-description: "this is room description"
       public: true

--- a/workflow-bot-app/src/test/resources/room/obo/create-room-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/create-room-obo-unauthorized.swadl.yaml
@@ -1,0 +1,29 @@
+id: create-room-obo-unauthroized
+activities:
+  - create-room:
+      id: "createRoomOboUnauthorized"
+      on:
+        message-received:
+          content: "/create-room"
+      room-name: "The best room ever"
+      room-description: "this is room description"
+      public: true
+      view-history: true
+      keywords:
+        "A": "AA"
+        "B": "BB"
+      discoverable: false
+      read-only: true
+      copy-protected: true
+      cross-pod: true
+      multilateral-room: false
+      members-can-invite: true
+      sub-type: EMAIL
+      obo:
+        user-id: 12345
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/room/obo/create-room-with-details-members-obo-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/create-room-with-details-members-obo-userid.swadl.yaml
@@ -1,10 +1,10 @@
-id: create-mim-with-details-members-workflow
+id: create-mim-with-details-members-workflow-obo-userid
 activities:
   - create-room:
-      id: "create_room_with_details_members"
+      id: create_room_with_details_members_obo_userid
       on:
         message-received:
-          content: "/create-room-members"
+          content: "/create-mim-details-members-obo-userid"
       user-ids:
         - 666
         - 777

--- a/workflow-bot-app/src/test/resources/room/obo/create-room-with-details-members-obo-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/create-room-with-details-members-obo-userid.swadl.yaml
@@ -1,0 +1,17 @@
+id: create-mim-with-details-members-workflow
+activities:
+  - create-room:
+      id: "create_room_with_details_members"
+      on:
+        message-received:
+          content: "/create-room-members"
+      user-ids:
+        - 666
+        - 777
+        - 999
+      room-name: "The best room ever"
+      room-description: "this is room description"
+      public: false
+      cross-pod: true
+      obo:
+        user-id: 12345

--- a/workflow-bot-app/src/test/resources/room/obo/create-room-with-details-members-obo-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/create-room-with-details-members-obo-username.swadl.yaml
@@ -1,0 +1,17 @@
+id: create-mim-with-details-members-workflow-obo
+activities:
+  - create-room:
+      id: "create_room_with_details_members"
+      on:
+        message-received:
+          content: "/create-room-members"
+      user-ids:
+        - 666
+        - 777
+        - 999
+      room-name: "The best room ever"
+      room-description: "this is room description"
+      public: false
+      cross-pod: true
+      obo:
+        username: "john"

--- a/workflow-bot-app/src/test/resources/room/obo/create-room-with-details-members-obo-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/create-room-with-details-members-obo-username.swadl.yaml
@@ -1,10 +1,10 @@
-id: create-mim-with-details-members-workflow-obo
+id: create-mim-with-details-members-workflow-obo-username
 activities:
   - create-room:
-      id: "create_room_with_details_members"
+      id: create_room_with_details_members_obo_username
       on:
         message-received:
-          content: "/create-room-members"
+          content: "/create-mim-details-members-obo-username"
       user-ids:
         - 666
         - 777

--- a/workflow-bot-app/src/test/resources/room/obo/create-room-with-details-obo-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/create-room-with-details-obo-userid.swadl.yaml
@@ -4,7 +4,7 @@ activities:
       id: "create_room_with_details"
       on:
         message-received:
-          content: "/create-room"
+          content: "/create-room-with-details-obo-valid-userid"
       room-name: "The best room ever"
       room-description: "this is room description"
       public: true

--- a/workflow-bot-app/src/test/resources/room/obo/create-room-with-details-obo-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/create-room-with-details-obo-userid.swadl.yaml
@@ -1,0 +1,24 @@
+id: create-room-with-details-workflow
+activities:
+  - create-room:
+      id: "create_room_with_details"
+      on:
+        message-received:
+          content: "/create-room"
+      room-name: "The best room ever"
+      room-description: "this is room description"
+      public: true
+      view-history: true
+      keywords:
+        "A": "AA"
+        "B": "BB"
+      discoverable: false
+      read-only: true
+      copy-protected: true
+      cross-pod: true
+      multilateral-room: false
+      members-can-invite: true
+      sub-type: EMAIL
+      obo:
+        user-id: 12345
+

--- a/workflow-bot-app/src/test/resources/room/obo/create-room-with-details-obo-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/create-room-with-details-obo-username.swadl.yaml
@@ -4,7 +4,7 @@ activities:
       id: "create_room_with_details"
       on:
         message-received:
-          content: "/create-room"
+          content: "/create-room-with-details-obo-valid-username"
       room-name: "The best room ever"
       room-description: "this is room description"
       public: true

--- a/workflow-bot-app/src/test/resources/room/obo/create-room-with-details-obo-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/create-room-with-details-obo-username.swadl.yaml
@@ -1,0 +1,23 @@
+id: create-room-with-details-workflow
+activities:
+  - create-room:
+      id: "create_room_with_details"
+      on:
+        message-received:
+          content: "/create-room"
+      room-name: "The best room ever"
+      room-description: "this is room description"
+      public: true
+      view-history: true
+      keywords:
+        "A": "AA"
+        "B": "BB"
+      discoverable: false
+      read-only: true
+      copy-protected: true
+      cross-pod: true
+      multilateral-room: false
+      members-can-invite: true
+      sub-type: EMAIL
+      obo:
+        username: "john"

--- a/workflow-bot-app/src/test/resources/room/obo/demote-room-owner-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/demote-room-owner-obo-unauthorized.swadl.yaml
@@ -1,0 +1,18 @@
+id: demote-room-owner-on-behalf-of-user-unauthorized
+activities:
+  - demote-room-owner:
+      id: demoteRoomOwnerOboUnauthorized
+      on:
+        message-received:
+          content: "/demote-room-owner-obo-unauthorized"
+      stream-id: abc
+      user-ids:
+        - 123
+      obo:
+        username: "john"
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/room/obo/demote-room-owner-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/demote-room-owner-obo-valid-userid.swadl.yaml
@@ -1,0 +1,12 @@
+id: demote-room-owner-on-behalf-of-user-valid-userid
+activities:
+  - demote-room-owner:
+      id: demoteRoomOwnerOboValidUserid
+      on:
+        message-received:
+          content: "/demote-room-owner-obo-valid-userid"
+      stream-id: abc
+      user-ids:
+        - 123
+      obo:
+        user-id: 12345

--- a/workflow-bot-app/src/test/resources/room/obo/demote-room-owner-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/demote-room-owner-obo-valid-username.swadl.yaml
@@ -1,0 +1,12 @@
+id: demote-room-member-on-behalf-of-user-valid-username
+activities:
+  - demote-room-owner:
+      id: demoteRoomOwnerOboValidUsername
+      on:
+        message-received:
+          content: "/demote-room-owner-obo-valid-username"
+      stream-id: abc
+      user-ids:
+        - 123
+      obo:
+        username: "john"

--- a/workflow-bot-app/src/test/resources/room/obo/get-room-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/get-room-obo-unauthorized.swadl.yaml
@@ -1,0 +1,16 @@
+id: get-room-on-behalf-of-user-unauthorized
+activities:
+  - get-room:
+      id: getRoomOboUnauthorized
+      on:
+        message-received:
+          content: "/get-room-obo-unauthorized"
+      stream-id: abc
+      obo:
+        username: "john"
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/room/obo/get-room-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/get-room-obo-valid-userid.swadl.yaml
@@ -1,0 +1,14 @@
+id: get-room-on-behalf-of-user-valid-userid
+activities:
+  - get-room:
+      id: getRoomOboValidUserid
+      on:
+        message-received:
+          content: "/get-room-obo-valid-userid"
+      stream-id: abc
+      obo:
+        user-id: 12345
+  - execute-script:
+      id: script
+      script: |
+        assert getRoomOboValidUserid.outputs.room != null

--- a/workflow-bot-app/src/test/resources/room/obo/get-room-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/get-room-obo-valid-username.swadl.yaml
@@ -1,0 +1,14 @@
+id: get-room-on-behalf-of-user-valid-username
+activities:
+  - get-room:
+      id: getRoomOboValidUsername
+      on:
+        message-received:
+          content: "/get-room-obo-valid-username"
+      stream-id: abc
+      obo:
+        username: "john"
+  - execute-script:
+      id: script
+      script: |
+        assert getRoomOboValidUsername.outputs.room != null

--- a/workflow-bot-app/src/test/resources/room/obo/get-rooms-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/get-rooms-obo-unauthorized.swadl.yaml
@@ -1,0 +1,21 @@
+id: get-rooms-on-behalf-of-user-unauthorized
+activities:
+  - get-rooms:
+      id: getRoomsOboUnauthorized
+      on:
+        message-received:
+          content: "/get-rooms-obo-unauthorized"
+      active: true
+      labels:
+        - test
+        - test1
+      query: test
+      sort-order: BASIC
+      obo:
+        username: "john"
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/room/obo/get-rooms-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/get-rooms-obo-valid-userid.swadl.yaml
@@ -1,0 +1,19 @@
+id: get-rooms-on-behalf-of-user-valid-userid
+activities:
+  - get-rooms:
+      id: getRoomsOboValidUserid
+      on:
+        message-received:
+          content: "/get-rooms-obo-valid-userid"
+      active: true
+      labels:
+        - test
+        - test1
+      query: test
+      sort-order: BASIC
+      obo:
+        user-id: 12345
+  - execute-script:
+      id: script
+      script: |
+        assert getRoomsOboValidUserid.outputs.rooms != null

--- a/workflow-bot-app/src/test/resources/room/obo/get-rooms-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/get-rooms-obo-valid-username.swadl.yaml
@@ -1,0 +1,19 @@
+id: get-rooms-on-behalf-of-user-valid-username
+activities:
+  - get-rooms:
+      id: getRoomsOboValidUsername
+      on:
+        message-received:
+          content: "/get-rooms-obo-valid-username"
+      active: true
+      labels:
+        - test
+        - test1
+      query: test
+      sort-order: BASIC
+      obo:
+        username: "john"
+  - execute-script:
+      id: script
+      script: |
+        assert getRoomsOboValidUsername.outputs.rooms != null

--- a/workflow-bot-app/src/test/resources/room/obo/get-rooms-pagination-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/get-rooms-pagination-obo-unauthorized.swadl.yaml
@@ -1,0 +1,25 @@
+id: get-rooms-pagination-on-behalf-of-user-unauthorized
+variables:
+  skip: 10
+  limit: 10
+activities:
+  - get-rooms:
+      id: getRoomsPaginationOboUnauthorized
+      on:
+        message-received:
+          content: "/get-rooms-pagination-obo-unauthorized"
+      active: true
+      labels:
+        - test
+        - test1
+      query: test
+      skip: ${variables.skip}
+      limit: ${variables.limit}
+      obo:
+        username: "john"
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/room/obo/get-rooms-pagination-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/get-rooms-pagination-obo-valid-userid.swadl.yaml
@@ -1,0 +1,23 @@
+id: get-rooms-pagination-on-behalf-of-user-valid-userid
+variables:
+  skip: 10
+  limit: 10
+activities:
+  - get-rooms:
+      id: getRoomsPaginationOboValidUserid
+      on:
+        message-received:
+          content: "/get-rooms-pagination-obo-valid-userid"
+      active: true
+      labels:
+        - test
+        - test1
+      query: test
+      skip: ${variables.skip}
+      limit: ${variables.limit}
+      obo:
+        user-id: 12345
+  - execute-script:
+      id: script
+      script: |
+        assert getRoomsPaginationOboValidUserid.outputs.rooms != null

--- a/workflow-bot-app/src/test/resources/room/obo/get-rooms-pagination-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/get-rooms-pagination-obo-valid-username.swadl.yaml
@@ -1,0 +1,23 @@
+id: get-rooms-pagination-on-behalf-of-user-valid-username
+variables:
+  skip: 10
+  limit: 10
+activities:
+  - get-rooms:
+      id: getRoomsPaginationOboValidUsername
+      on:
+        message-received:
+          content: "/get-rooms-pagination-obo-valid-username"
+      active: true
+      labels:
+        - test
+        - test1
+      query: test
+      skip: ${variables.skip}
+      limit: ${variables.limit}
+      obo:
+        username: "john"
+  - execute-script:
+      id: script
+      script: |
+        assert getRoomsPaginationOboValidUsername.outputs.rooms != null

--- a/workflow-bot-app/src/test/resources/room/obo/promote-room-owner-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/promote-room-owner-obo-unauthorized.swadl.yaml
@@ -1,0 +1,18 @@
+id: promote-room-owner-on-behalf-of-user-unauthorized
+activities:
+  - promote-room-owner:
+      id: promoteRoomOwnerOboUnauthorized
+      on:
+        message-received:
+          content: "/promote-room-owner-obo-unauthorized"
+      stream-id: abc
+      user-ids:
+        - 123
+      obo:
+        username: "john"
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/room/obo/promote-room-owner-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/promote-room-owner-obo-valid-userid.swadl.yaml
@@ -1,0 +1,12 @@
+id: promote-room-owner-on-behalf-of-user-valid-userid
+activities:
+  - promote-room-owner:
+      id: promoteRoomOwnerOboValidUserid
+      on:
+        message-received:
+          content: "/promote-room-owner-obo-valid-userid"
+      stream-id: abc
+      user-ids:
+        - 123
+      obo:
+        user-id: 12345

--- a/workflow-bot-app/src/test/resources/room/obo/promote-room-owner-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/promote-room-owner-obo-valid-username.swadl.yaml
@@ -1,0 +1,12 @@
+id: promote-room-member-on-behalf-of-user-valid-username
+activities:
+  - promote-room-owner:
+      id: promoteRoomOwnerOboValidUsername
+      on:
+        message-received:
+          content: "/promote-room-owner-obo-valid-username"
+      stream-id: abc
+      user-ids:
+        - 123
+      obo:
+        username: "john"

--- a/workflow-bot-app/src/test/resources/room/obo/remove-room-member-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/remove-room-member-obo-unauthorized.swadl.yaml
@@ -1,0 +1,19 @@
+id: remove-room-member-on-behalf-of-user-unauthorized
+activities:
+  - remove-room-member:
+      id: removeRoomMemberOboUnauthorized
+      on:
+        message-received:
+          content: "/remove-room-member-obo-unauthorized"
+      stream-id: abc
+      user-ids:
+        - 123
+        - 456
+      obo:
+        username: "john"
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/room/obo/remove-room-member-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/remove-room-member-obo-valid-userid.swadl.yaml
@@ -1,0 +1,13 @@
+id: remove-room-member-on-behalf-of-user-valid-userid
+activities:
+  - remove-room-member:
+      id: removeRoomMemberOboValidUderid
+      on:
+        message-received:
+          content: "/remove-room-member-obo-valid-userid"
+      stream-id: abc
+      user-ids:
+        - 123
+        - 456
+      obo:
+        user-id: 12345

--- a/workflow-bot-app/src/test/resources/room/obo/remove-room-member-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/remove-room-member-obo-valid-username.swadl.yaml
@@ -1,0 +1,13 @@
+id: remove-room-member-on-behalf-of-user-valid-username
+activities:
+  - remove-room-member:
+      id: removeRoomMemberOboValidUsername
+      on:
+        message-received:
+          content: "/remove-room-member-obo-valid-username"
+      stream-id: abc
+      user-ids:
+        - 123
+        - 456
+      obo:
+        username: "john"

--- a/workflow-bot-app/src/test/resources/room/obo/update-room-activate-obo-not-supported.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/update-room-activate-obo-not-supported.swadl.yaml
@@ -1,0 +1,18 @@
+id: update-room-activate-obo-not-supported
+activities:
+  - update-room:
+      id: updateRoomOboNotSupported
+      on:
+        message-received:
+          content: "/update-room-obo-not-supported"
+      stream-id: abc
+      active: true
+      obo:
+        user-id: 1234
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false
+

--- a/workflow-bot-app/src/test/resources/room/obo/update-room-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/update-room-obo-unauthorized.swadl.yaml
@@ -1,0 +1,18 @@
+id: update-room-obo-unauthorized
+activities:
+  - update-room:
+      id: updateRoomOboUnauthorized
+      on:
+        message-received:
+          content: "/update-room-obo-unauthorized"
+      stream-id: abc
+      room-description: "Test"
+      discoverable: true
+      obo:
+        user-id: 12345
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/room/obo/update-room-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/update-room-obo-valid-userid.swadl.yaml
@@ -1,0 +1,16 @@
+id: update-room-obo-valid-userid
+activities:
+  - update-room:
+      id: updateRoomValidUserId
+      on:
+        message-received:
+          content: "/update-room-obo-userid"
+      stream-id: abc
+      room-description: "Test"
+      discoverable: true
+      obo:
+        user-id: 1234
+  - execute-script:
+      id: checkOutputOboUserId
+      script: |
+        assert updateRoomValidUserId.outputs.room.roomSystemInfo.id == "abc"

--- a/workflow-bot-app/src/test/resources/room/obo/update-room-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/update-room-obo-valid-username.swadl.yaml
@@ -1,0 +1,16 @@
+id: update-room-obo-valid-username
+activities:
+  - update-room:
+      id: updateRoomOboValidUsername
+      on:
+        message-received:
+          content: "/update-room-obo-username"
+      stream-id: abc
+      room-description: "Test"
+      discoverable: true
+      obo:
+        username: "john"
+  - execute-script:
+      id: checkOutputOboUsername
+      script: |
+        assert updateRoomOboValidUsername.outputs.room.roomSystemInfo.id == "abc"

--- a/workflow-bot-app/src/test/resources/room/update-room-activate.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/update-room-activate.swadl.yaml
@@ -4,7 +4,7 @@ activities:
       id: updateRoom
       on:
         message-received:
-          content: "/update-room"
+          content: "/update-room-activate"
       stream-id: abc
       active: true
   - execute-script:

--- a/workflow-bot-app/src/test/resources/stream/obo/get-stream-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/stream/obo/get-stream-obo-unauthorized.swadl.yaml
@@ -1,0 +1,15 @@
+id: get-stream-obo-unauthorized
+activities:
+  - get-stream:
+      id: getStreamOboUnauthorized
+      on:
+        message-received:
+          content: /get-stream-obo-unauthorized
+      stream-id: abc
+      obo:
+        username: "john"
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/stream/obo/get-stream-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/stream/obo/get-stream-obo-valid-userid.swadl.yaml
@@ -1,0 +1,14 @@
+id: get-stream-obo-valid-userid
+activities:
+  - get-stream:
+      id: getStreamOboValidUserid
+      on:
+        message-received:
+          content: /get-stream-obo-valid-userid
+      stream-id: abc
+      obo:
+        user-id: 123
+  - execute-script:
+      id: script
+      script: |
+        assert getStreamOboValidUserid.outputs.stream != null

--- a/workflow-bot-app/src/test/resources/stream/obo/get-stream-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/stream/obo/get-stream-obo-valid-username.swadl.yaml
@@ -1,0 +1,14 @@
+id: get-stream-obo-valid-username
+activities:
+  - get-stream:
+      id: getStreamOboValidUsername
+      on:
+        message-received:
+          content: /get-stream-obo-valid-username
+      stream-id: abc
+      obo:
+        username: "john"
+  - execute-script:
+      id: script
+      script: |
+        assert getStreamOboValidUsername.outputs.stream != null

--- a/workflow-bot-app/src/test/resources/stream/obo/get-user-streams-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/stream/obo/get-user-streams-obo-unauthorized.swadl.yaml
@@ -1,0 +1,18 @@
+id: get-user-streams-obo-unauthorized
+activities:
+  - get-user-streams:
+      id: getUserStreamsOboUnauthorized
+      on:
+        message-received:
+          content: /get-user-streams-obo-unauthorized
+      types:
+        - ROOM
+        - POST
+      include-inactive-streams: true
+      obo:
+        username: "John"
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/stream/obo/get-user-streams-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/stream/obo/get-user-streams-obo-valid-userid.swadl.yaml
@@ -1,0 +1,17 @@
+id: get-user-streams-obo-valid-userid
+activities:
+  - get-user-streams:
+      id: getUserStreamsOboValidUserid
+      on:
+        message-received:
+          content: /get-user-streams-obo-valid-userid
+      types:
+        - ROOM
+        - POST
+      include-inactive-streams: true
+      obo:
+        user-id: 123
+  - execute-script:
+      id: script
+      script: |
+        assert getUserStreamsOboValidUserid.outputs.streams != null

--- a/workflow-bot-app/src/test/resources/stream/obo/get-user-streams-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/stream/obo/get-user-streams-obo-valid-username.swadl.yaml
@@ -1,0 +1,17 @@
+id: get-user-streams-obo-valid-username
+activities:
+  - get-user-streams:
+      id: getUserStreamsOboValidUsername
+      on:
+        message-received:
+          content: /get-user-streams-obo-valid-username
+      types:
+        - ROOM
+        - POST
+      include-inactive-streams: true
+      obo:
+        username: "John"
+  - execute-script:
+      id: script
+      script: |
+        assert getUserStreamsOboValidUsername.outputs.streams != null

--- a/workflow-bot-app/src/test/resources/user/obo/get-users-emails-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/user/obo/get-users-emails-obo-unauthorized.swadl.yaml
@@ -1,0 +1,20 @@
+id: get-users-emails-obo-unauthorized
+activities:
+  - get-users:
+      id: getUsersEmailsOboUnauthorized
+      on:
+        message-received:
+          content: /get-users-emails-obo-unauthorized
+      emails:
+        - "bob@mail.com"
+        - "eve@mail.com"
+      local: true
+      active: false
+      obo:
+        user-id: 1234
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/user/obo/get-users-emails-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/user/obo/get-users-emails-obo-valid-userid.swadl.yaml
@@ -1,0 +1,19 @@
+id: get-users-emails-obo-valid-userid
+activities:
+  - get-users:
+      id: getUsersEmailsOboValidUserid
+      on:
+        message-received:
+          content: /get-users-emails-obo-valid-userid
+      emails:
+        - "bob@mail.com"
+        - "eve@mail.com"
+      local: true
+      active: false
+      obo:
+        user-id: 1234
+
+  - execute-script:
+      id: script
+      script: |
+        assert getUsersEmailsOboValidUserid.outputs.users != null

--- a/workflow-bot-app/src/test/resources/user/obo/get-users-emails-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/user/obo/get-users-emails-obo-valid-username.swadl.yaml
@@ -1,0 +1,19 @@
+id: get-users-emails-obo-valid-username
+activities:
+  - get-users:
+      id: getUsersEmailsOboValidUsername
+      on:
+        message-received:
+          content: /get-users-emails-obo-valid-username
+      emails:
+        - "bob@mail.com"
+        - "eve@mail.com"
+      local: true
+      active: false
+      obo:
+        username: "John"
+
+  - execute-script:
+      id: script
+      script: |
+        assert getUsersEmailsOboValidUsername.outputs.users != null

--- a/workflow-bot-app/src/test/resources/user/obo/get-users-ids-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/user/obo/get-users-ids-obo-unauthorized.swadl.yaml
@@ -1,0 +1,20 @@
+id: get-users-ids-obo-unauthorized
+activities:
+  - get-users:
+      id: getUsersIdsOboUnauthorized
+      on:
+        message-received:
+          content: /get-users-ids-obo-unauthorized
+      user-ids:
+        - 123
+        - 456
+      local: true
+      active: false
+      obo:
+        user-id: 1234
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/user/obo/get-users-ids-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/user/obo/get-users-ids-obo-valid-userid.swadl.yaml
@@ -1,0 +1,19 @@
+id: get-users-ids-obo-valid-userid
+activities:
+  - get-users:
+      id: getUsersIdsOboValidUserid
+      on:
+        message-received:
+          content: /get-users-ids-obo-valid-userid
+      user-ids:
+        - 123
+        - 456
+      local: true
+      active: false
+      obo:
+        user-id: 1234
+
+  - execute-script:
+      id: script
+      script: |
+        assert getUsersIdsOboValidUserid.outputs.users != null

--- a/workflow-bot-app/src/test/resources/user/obo/get-users-ids-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/user/obo/get-users-ids-obo-valid-username.swadl.yaml
@@ -1,0 +1,19 @@
+id: get-users-ids-obo-valid-username
+activities:
+  - get-users:
+      id: getUsersIdsOboValidUsername
+      on:
+        message-received:
+          content: /get-users-ids-obo-valid-username
+      user-ids:
+        - 123
+        - 456
+      local: true
+      active: false
+      obo:
+        username: "John"
+
+  - execute-script:
+      id: script
+      script: |
+        assert getUsersIdsOboValidUsername.outputs.users != null

--- a/workflow-bot-app/src/test/resources/user/obo/get-users-usernames-obo-unauthorized.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/user/obo/get-users-usernames-obo-unauthorized.swadl.yaml
@@ -1,0 +1,19 @@
+id: get-users-usernames-obo-unauthorized
+activities:
+  - get-users:
+      id: getUsersUsernamesOboUnauthorized
+      on:
+        message-received:
+          content: /get-users-usernames-obo-unauthorized
+      usernames:
+        - "bob"
+        - "eve"
+      active: false
+      obo:
+        user-id: 1234
+
+  - execute-script:
+      id: scriptActivityNotToBeExecuted
+      # workflow should fail if this script is executed
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/user/obo/get-users-usernames-obo-valid-userid.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/user/obo/get-users-usernames-obo-valid-userid.swadl.yaml
@@ -1,0 +1,18 @@
+id: get-users-usernames-obo-valid-userid
+activities:
+  - get-users:
+      id: getUsersUsernamesOboValidUserid
+      on:
+        message-received:
+          content: /get-users-usernames-obo-valid-userid
+      usernames:
+        - "bob"
+        - "eve"
+      active: false
+      obo:
+        user-id: 1234
+
+  - execute-script:
+      id: script
+      script: |
+        assert getUsersUsernamesOboValidUserid.outputs.users != null

--- a/workflow-bot-app/src/test/resources/user/obo/get-users-usernames-obo-valid-username.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/user/obo/get-users-usernames-obo-valid-username.swadl.yaml
@@ -1,0 +1,18 @@
+id: get-users-usernames-obo-valid-username
+activities:
+  - get-users:
+      id: getUsersUsernamesOboValidUsername
+      on:
+        message-received:
+          content: /get-users-usernames-obo-valid-username
+      usernames:
+        - "bob"
+        - "eve"
+      active: false
+      obo:
+        username: "John"
+
+  - execute-script:
+      id: script
+      script: |
+        assert getUsersUsernamesOboValidUsername.outputs.users != null

--- a/workflow-language/build.gradle
+++ b/workflow-language/build.gradle
@@ -8,7 +8,7 @@ javadoc {
 }
 
 dependencies {
-    api platform('org.finos.symphony.bdk:symphony-bdk-bom:2.7.0')
+    api platform('org.finos.symphony.bdk:symphony-bdk-bom:2.9.0')
 
     api 'org.finos.symphony.bdk:symphony-bdk-core'
     api 'org.finos.symphony.bdk.ext:symphony-group-extension'

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/engine/executor/BdkGateway.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/engine/executor/BdkGateway.java
@@ -1,5 +1,7 @@
 package com.symphony.bdk.workflow.engine.executor;
 
+import com.symphony.bdk.core.OboServices;
+import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.core.service.connection.ConnectionService;
 import com.symphony.bdk.core.service.message.MessageService;
 import com.symphony.bdk.core.service.stream.StreamService;
@@ -29,6 +31,12 @@ public interface BdkGateway {
    * @return BDK service to manage connections.
    */
   ConnectionService connections();
+
+  OboServices obo(AuthSession oboSession);
+
+  AuthSession obo(String username);
+
+  AuthSession obo(Long userId);
 
   /**
    * @return BDK service to manage Symphony groups (aka SDLs).

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/Obo.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/Obo.java
@@ -7,7 +7,7 @@ import javax.annotation.Nullable;
 
 @EqualsAndHashCode
 @Data
-public class OnBehalfOf {
+public class Obo {
   @Nullable private String username;
   @Nullable private Long userId;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/OboActivity.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/OboActivity.java
@@ -1,0 +1,10 @@
+package com.symphony.bdk.workflow.swadl.v1.activity;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class OboActivity extends BaseActivity {
+  private Obo obo;
+}

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/OnBehalfOf.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/OnBehalfOf.java
@@ -1,0 +1,13 @@
+package com.symphony.bdk.workflow.swadl.v1.activity;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import javax.annotation.Nullable;
+
+@EqualsAndHashCode
+@Data
+public class OnBehalfOf {
+  @Nullable private String username;
+  @Nullable private Long userId;
+}

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/connection/Connection.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/connection/Connection.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.connection;
 
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
+import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -9,4 +10,5 @@ import lombok.EqualsAndHashCode;
 @Data
 public class Connection extends BaseActivity {
   private String userId;
+  private Obo obo;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/connection/Connection.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/connection/Connection.java
@@ -1,14 +1,14 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.connection;
 
-import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
+import com.symphony.bdk.workflow.swadl.v1.activity.OboActivity;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class Connection extends BaseActivity {
+public class Connection extends OboActivity {
   private String userId;
   private Obo obo;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/connection/GetConnections.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/connection/GetConnections.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.connection;
 
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
+import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -16,4 +17,5 @@ import javax.annotation.Nullable;
 public class GetConnections extends BaseActivity {
   private List<Long> userIds;
   @Nullable private String status;
+  private Obo obo;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/connection/GetConnections.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/connection/GetConnections.java
@@ -1,7 +1,6 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.connection;
 
-import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
-import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
+import com.symphony.bdk.workflow.swadl.v1.activity.OboActivity;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -14,8 +13,7 @@ import javax.annotation.Nullable;
  */
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class GetConnections extends BaseActivity {
+public class GetConnections extends OboActivity {
   private List<Long> userIds;
   @Nullable private String status;
-  private Obo obo;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/PinMessage.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/PinMessage.java
@@ -1,14 +1,12 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.message;
 
-import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
-import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
+import com.symphony.bdk.workflow.swadl.v1.activity.OboActivity;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class PinMessage extends BaseActivity {
+public class PinMessage extends OboActivity {
   private String messageId;
-  private Obo obo;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/PinMessage.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/PinMessage.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.message;
 
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
+import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -9,4 +10,5 @@ import lombok.EqualsAndHashCode;
 @Data
 public class PinMessage extends BaseActivity {
   private String messageId;
+  private Obo obo;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/SendMessage.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/SendMessage.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.message;
 
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
+import com.symphony.bdk.workflow.swadl.v1.activity.OnBehalfOf;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -17,6 +18,7 @@ public class SendMessage extends BaseActivity {
   @Nullable private String content;
   @Nullable private To to;
   @Nullable private List<Attachment> attachments;
+  @Nullable private OnBehalfOf onBehalfOf;
 
   @SuppressWarnings("unchecked")
   public void setContent(Object content) {

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/SendMessage.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/SendMessage.java
@@ -1,7 +1,7 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.message;
 
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
-import com.symphony.bdk.workflow.swadl.v1.activity.OnBehalfOf;
+import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -18,7 +18,7 @@ public class SendMessage extends BaseActivity {
   @Nullable private String content;
   @Nullable private To to;
   @Nullable private List<Attachment> attachments;
-  @Nullable private OnBehalfOf onBehalfOf;
+  @Nullable private Obo obo;
 
   @SuppressWarnings("unchecked")
   public void setContent(Object content) {

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/SendMessage.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/SendMessage.java
@@ -1,7 +1,6 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.message;
 
-import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
-import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
+import com.symphony.bdk.workflow.swadl.v1.activity.OboActivity;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -12,13 +11,12 @@ import javax.annotation.Nullable;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class SendMessage extends BaseActivity {
+public class SendMessage extends OboActivity {
 
   @Nullable private String template;
   @Nullable private String content;
   @Nullable private To to;
   @Nullable private List<Attachment> attachments;
-  @Nullable private Obo obo;
 
   @SuppressWarnings("unchecked")
   public void setContent(Object content) {

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/UnpinMessage.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/UnpinMessage.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.message;
 
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
+import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -9,4 +10,5 @@ import lombok.EqualsAndHashCode;
 @Data
 public class UnpinMessage extends BaseActivity {
   private String streamId;
+  private Obo obo;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/UnpinMessage.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/UnpinMessage.java
@@ -2,13 +2,13 @@ package com.symphony.bdk.workflow.swadl.v1.activity.message;
 
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
+import com.symphony.bdk.workflow.swadl.v1.activity.OboActivity;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class UnpinMessage extends BaseActivity {
+public class UnpinMessage extends OboActivity {
   private String streamId;
-  private Obo obo;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/AddRoomMember.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/AddRoomMember.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
+import com.symphony.bdk.workflow.swadl.v1.activity.OnBehalfOf;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -15,4 +16,5 @@ import java.util.List;
 public class AddRoomMember extends BaseActivity {
   private String streamId;
   private List<Long> userIds = List.of();
+  private OnBehalfOf onBehalfOf;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/AddRoomMember.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/AddRoomMember.java
@@ -1,7 +1,7 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
-import com.symphony.bdk.workflow.swadl.v1.activity.OnBehalfOf;
+import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -16,5 +16,5 @@ import java.util.List;
 public class AddRoomMember extends BaseActivity {
   private String streamId;
   private List<Long> userIds = List.of();
-  private OnBehalfOf onBehalfOf;
+  private Obo obo;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/AddRoomMember.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/AddRoomMember.java
@@ -1,7 +1,6 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
-import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
-import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
+import com.symphony.bdk.workflow.swadl.v1.activity.OboActivity;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -13,8 +12,7 @@ import java.util.List;
  */
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class AddRoomMember extends BaseActivity {
+public class AddRoomMember extends OboActivity {
   private String streamId;
   private List<Long> userIds = List.of();
-  private Obo obo;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/CreateRoom.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/CreateRoom.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
+import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -19,8 +20,10 @@ import javax.annotation.Nullable;
 public class CreateRoom extends BaseActivity {
   @Nullable private String roomName;
   @Nullable private String roomDescription;
-  private List<Long> userIds;
   @Nullable private Map<String, String> keywords;
+  @Nullable private String subType;
+  @Nullable private Obo obo;
+  private List<Long> userIds;
   private Boolean membersCanInvite;
   private Boolean discoverable;
   private Boolean readOnly;
@@ -28,7 +31,6 @@ public class CreateRoom extends BaseActivity {
   private Boolean crossPod;
   private Boolean viewHistory;
   private Boolean multilateralRoom;
-  @Nullable private String subType;
 
   @JsonProperty("public")
   private Boolean isPublic;
@@ -45,4 +47,3 @@ public class CreateRoom extends BaseActivity {
     private String value;
   }
 }
-

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/CreateRoom.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/CreateRoom.java
@@ -1,7 +1,6 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
-import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
-import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
+import com.symphony.bdk.workflow.swadl.v1.activity.OboActivity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -17,12 +16,12 @@ import javax.annotation.Nullable;
  */
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class CreateRoom extends BaseActivity {
+public class CreateRoom extends OboActivity {
   @Nullable private String roomName;
   @Nullable private String roomDescription;
   @Nullable private Map<String, String> keywords;
   @Nullable private String subType;
-  @Nullable private Obo obo;
+
   private List<Long> userIds;
   private Boolean membersCanInvite;
   private Boolean discoverable;

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/DemoteRoomOwner.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/DemoteRoomOwner.java
@@ -1,7 +1,6 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
-import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
-import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
+import com.symphony.bdk.workflow.swadl.v1.activity.OboActivity;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -13,8 +12,7 @@ import java.util.List;
  */
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class DemoteRoomOwner extends BaseActivity {
+public class DemoteRoomOwner extends OboActivity {
   private String streamId;
   private List<Long> userIds = List.of();
-  private Obo obo;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/DemoteRoomOwner.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/DemoteRoomOwner.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
+import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -15,4 +16,5 @@ import java.util.List;
 public class DemoteRoomOwner extends BaseActivity {
   private String streamId;
   private List<Long> userIds = List.of();
+  private Obo obo;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/GetRoom.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/GetRoom.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
+import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -12,4 +13,5 @@ import lombok.EqualsAndHashCode;
 @Data
 public class GetRoom extends BaseActivity {
   private String streamId;
+  private Obo obo;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/GetRoom.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/GetRoom.java
@@ -1,7 +1,7 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
-import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
+import com.symphony.bdk.workflow.swadl.v1.activity.OboActivity;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -11,7 +11,6 @@ import lombok.EqualsAndHashCode;
  */
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class GetRoom extends BaseActivity {
+public class GetRoom extends OboActivity {
   private String streamId;
-  private Obo obo;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/GetRooms.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/GetRooms.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
+import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
@@ -18,6 +19,8 @@ public class GetRooms extends BaseActivity {
   private String query;
   private List<String> labels;
   private Boolean active;
+
+  private Obo obo;
 
   @JsonProperty("private")
   private Boolean isPrivate;

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/GetRooms.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/GetRooms.java
@@ -1,7 +1,6 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
-import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
-import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
+import com.symphony.bdk.workflow.swadl.v1.activity.OboActivity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
@@ -15,12 +14,10 @@ import javax.annotation.Nullable;
  */
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class GetRooms extends BaseActivity {
+public class GetRooms extends OboActivity {
   private String query;
   private List<String> labels;
   private Boolean active;
-
-  private Obo obo;
 
   @JsonProperty("private")
   private Boolean isPrivate;

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/PromoteRoomOwner.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/PromoteRoomOwner.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
+import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -15,4 +16,5 @@ import java.util.List;
 public class PromoteRoomOwner extends BaseActivity {
   private String streamId;
   private List<Long> userIds = List.of();
+  private Obo obo;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/PromoteRoomOwner.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/PromoteRoomOwner.java
@@ -1,7 +1,6 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
-import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
-import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
+import com.symphony.bdk.workflow.swadl.v1.activity.OboActivity;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -13,8 +12,7 @@ import java.util.List;
  */
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class PromoteRoomOwner extends BaseActivity {
+public class PromoteRoomOwner extends OboActivity {
   private String streamId;
   private List<Long> userIds = List.of();
-  private Obo obo;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/RemoveRoomMember.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/RemoveRoomMember.java
@@ -2,6 +2,7 @@ package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
+import com.symphony.bdk.workflow.swadl.v1.activity.OboActivity;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -14,8 +15,7 @@ import java.util.List;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class RemoveRoomMember extends BaseActivity {
+public class RemoveRoomMember extends OboActivity {
   private String streamId;
   private List<Long> userIds = List.of();
-  private Obo obo;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/RemoveRoomMember.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/RemoveRoomMember.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
+import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -16,4 +17,5 @@ import java.util.List;
 public class RemoveRoomMember extends BaseActivity {
   private String streamId;
   private List<Long> userIds = List.of();
+  private Obo obo;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/UpdateRoom.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/UpdateRoom.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
+import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
@@ -21,6 +22,7 @@ public class UpdateRoom extends BaseActivity {
   @Nullable private String roomName;
   @Nullable private String roomDescription;
   @Nullable private Map<String, String> keywords;
+  @Nullable private Obo obo;
 
   private Boolean membersCanInvite;
   private Boolean discoverable;

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/UpdateRoom.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/room/UpdateRoom.java
@@ -1,7 +1,6 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.room;
 
-import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
-import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
+import com.symphony.bdk.workflow.swadl.v1.activity.OboActivity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
@@ -16,13 +15,12 @@ import javax.annotation.Nullable;
  */
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class UpdateRoom extends BaseActivity {
+public class UpdateRoom extends OboActivity {
   private String streamId;
 
   @Nullable private String roomName;
   @Nullable private String roomDescription;
   @Nullable private Map<String, String> keywords;
-  @Nullable private Obo obo;
 
   private Boolean membersCanInvite;
   private Boolean discoverable;

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/stream/GetStream.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/stream/GetStream.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.stream;
 
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
+import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -12,4 +13,5 @@ import lombok.EqualsAndHashCode;
 @Data
 public class GetStream extends BaseActivity {
   private String streamId;
+  private Obo obo;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/stream/GetStream.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/stream/GetStream.java
@@ -2,6 +2,7 @@ package com.symphony.bdk.workflow.swadl.v1.activity.stream;
 
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
+import com.symphony.bdk.workflow.swadl.v1.activity.OboActivity;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -11,7 +12,6 @@ import lombok.EqualsAndHashCode;
  */
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class GetStream extends BaseActivity {
+public class GetStream extends OboActivity {
   private String streamId;
-  private Obo obo;
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/stream/GetUserStreams.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/stream/GetUserStreams.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.stream;
 
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
+import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -17,5 +18,6 @@ public class GetUserStreams extends BaseActivity {
   private Boolean includeInactiveStreams;
   private Integer limit;
   private Integer skip;
+  private Obo obo;
 
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/stream/GetUserStreams.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/stream/GetUserStreams.java
@@ -2,6 +2,7 @@ package com.symphony.bdk.workflow.swadl.v1.activity.stream;
 
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
+import com.symphony.bdk.workflow.swadl.v1.activity.OboActivity;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -13,11 +14,10 @@ import java.util.List;
  */
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class GetUserStreams extends BaseActivity {
+public class GetUserStreams extends OboActivity {
   private List<String> types;
   private Boolean includeInactiveStreams;
   private Integer limit;
   private Integer skip;
-  private Obo obo;
 
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/user/GetUsers.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/user/GetUsers.java
@@ -1,7 +1,6 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.user;
 
-import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
-import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
+import com.symphony.bdk.workflow.swadl.v1.activity.OboActivity;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -14,7 +13,7 @@ import javax.annotation.Nullable;
  */
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class GetUsers extends BaseActivity {
+public class GetUsers extends OboActivity {
 
   @Nullable
   private List<Long> userIds;
@@ -25,7 +24,4 @@ public class GetUsers extends BaseActivity {
 
   private Boolean local;
   private Boolean active;
-
-  private Obo obo;
-
 }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/user/GetUsers.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/user/GetUsers.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.workflow.swadl.v1.activity.user;
 
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
+import com.symphony.bdk.workflow.swadl.v1.activity.Obo;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -24,5 +25,7 @@ public class GetUsers extends BaseActivity {
 
   private Boolean local;
   private Boolean active;
+
+  private Obo obo;
 
 }

--- a/workflow-language/src/main/resources/swadl-schema-1.0.json
+++ b/workflow-language/src/main/resources/swadl-schema-1.0.json
@@ -1517,6 +1517,10 @@
                 "user-ids": {
                     "description": "User ids to add to the room.",
                     "$ref": "#/definitions/user-ids-inner"
+                },
+                "on-behalf-of": {
+                    "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
+                    "$ref": "#/definitions/on-behalf-of-inner"
                 }
             },
             "required": [
@@ -1534,6 +1538,10 @@
                 "user-ids": {
                     "description": "User ids to remove from the room.",
                     "$ref": "#/definitions/user-ids-inner"
+                },
+                "on-behalf-of": {
+                    "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
+                    "$ref": "#/definitions/on-behalf-of-inner"
                 }
             },
             "required": [
@@ -1551,6 +1559,10 @@
                 "user-ids": {
                     "description": "User ids to promote in the room.",
                     "$ref": "#/definitions/user-ids-inner"
+                },
+                "on-behalf-of": {
+                    "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
+                    "$ref": "#/definitions/on-behalf-of-inner"
                 }
             },
             "required": [
@@ -1568,6 +1580,10 @@
                 "user-ids": {
                     "description": "User ids to demote in the room.",
                     "$ref": "#/definitions/user-ids-inner"
+                },
+                "on-behalf-of": {
+                    "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
+                    "$ref": "#/definitions/on-behalf-of-inner"
                 }
             },
             "required": [
@@ -1591,6 +1607,10 @@
                     "items": {
                         "$ref": "#/definitions/attachment"
                     }
+                },
+                "on-behalf-of": {
+                    "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
+                    "$ref": "#/definitions/on-behalf-of-inner"
                 }
             },
             "required": [
@@ -2636,6 +2656,10 @@
                         "string"
                     ],
                     "description": "If true, it searches for active users only. If false, it searches for inactive users only. If not set, it searches for all users regardless of their status."
+                },
+                "on-behalf-of": {
+                    "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
+                    "$ref": "#/definitions/on-behalf-of-inner"
                 }
             },
             "oneOf": [
@@ -2660,6 +2684,10 @@
             "properties": {
                 "stream-id": {
                     "$ref": "#/definitions/stream-id-inner"
+                },
+                "on-behalf-of": {
+                    "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
+                    "$ref": "#/definitions/on-behalf-of-inner"
                 }
             },
             "required": [
@@ -2670,6 +2698,10 @@
             "properties": {
                 "stream-id": {
                     "$ref": "#/definitions/stream-id-inner"
+                },
+                "on-behalf-of": {
+                    "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
+                    "$ref": "#/definitions/on-behalf-of-inner"
                 }
             },
             "required": [
@@ -2681,6 +2713,10 @@
             "properties": {
                 "user-id": {
                     "$ref": "#/definitions/user-id"
+                },
+                "on-behalf-of": {
+                    "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
+                    "$ref": "#/definitions/on-behalf-of-inner"
                 }
             },
             "required": [
@@ -2851,6 +2887,10 @@
                 },
                 "skip": {
                     "$ref": "#/definitions/skip"
+                },
+                "on-behalf-of": {
+                    "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
+                    "$ref": "#/definitions/on-behalf-of-inner"
                 }
             }
         },
@@ -2933,6 +2973,10 @@
                 },
                 "skip": {
                     "$ref": "#/definitions/skip"
+                },
+                "on-behalf-of": {
+                    "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
+                    "$ref": "#/definitions/on-behalf-of-inner"
                 }
             },
             "required": [
@@ -2989,6 +3033,10 @@
                         "REJECTED",
                         "ALL"
                     ]
+                },
+                "on-behalf-of": {
+                    "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
+                    "$ref": "#/definitions/on-behalf-of-inner"
                 }
             }
         },
@@ -3560,6 +3608,22 @@
                 }
             ],
             "description": "Group's unique identifier."
+        },
+        "on-behalf-of-inner": {
+            "type": "object",
+            "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made.",
+            "properties": {
+                "user-id": {
+                    "$ref": "#/definitions/user-id"
+                },
+                "username": {
+                    "$ref": "#/definitions/name"
+                }
+            },
+            "anyOf": [
+                {"required":  ["user-id"]},
+                {"required":  ["username"]}
+            ]
         },
         "to": {
             "type": "object",

--- a/workflow-language/src/main/resources/swadl-schema-1.0.json
+++ b/workflow-language/src/main/resources/swadl-schema-1.0.json
@@ -1518,9 +1518,9 @@
                     "description": "User ids to add to the room.",
                     "$ref": "#/definitions/user-ids-inner"
                 },
-                "on-behalf-of": {
+                "obo": {
                     "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
-                    "$ref": "#/definitions/on-behalf-of-inner"
+                    "$ref": "#/definitions/obo-inner"
                 }
             },
             "required": [
@@ -1539,9 +1539,9 @@
                     "description": "User ids to remove from the room.",
                     "$ref": "#/definitions/user-ids-inner"
                 },
-                "on-behalf-of": {
+                "obo": {
                     "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
-                    "$ref": "#/definitions/on-behalf-of-inner"
+                    "$ref": "#/definitions/obo-inner"
                 }
             },
             "required": [
@@ -1560,9 +1560,9 @@
                     "description": "User ids to promote in the room.",
                     "$ref": "#/definitions/user-ids-inner"
                 },
-                "on-behalf-of": {
+                "obo": {
                     "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
-                    "$ref": "#/definitions/on-behalf-of-inner"
+                    "$ref": "#/definitions/obo-inner"
                 }
             },
             "required": [
@@ -1581,9 +1581,9 @@
                     "description": "User ids to demote in the room.",
                     "$ref": "#/definitions/user-ids-inner"
                 },
-                "on-behalf-of": {
+                "obo": {
                     "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
-                    "$ref": "#/definitions/on-behalf-of-inner"
+                    "$ref": "#/definitions/obo-inner"
                 }
             },
             "required": [
@@ -1608,9 +1608,9 @@
                         "$ref": "#/definitions/attachment"
                     }
                 },
-                "on-behalf-of": {
+                "obo": {
                     "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
-                    "$ref": "#/definitions/on-behalf-of-inner"
+                    "$ref": "#/definitions/obo-inner"
                 }
             },
             "required": [
@@ -2657,9 +2657,9 @@
                     ],
                     "description": "If true, it searches for active users only. If false, it searches for inactive users only. If not set, it searches for all users regardless of their status."
                 },
-                "on-behalf-of": {
+                "obo": {
                     "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
-                    "$ref": "#/definitions/on-behalf-of-inner"
+                    "$ref": "#/definitions/obo-inner"
                 }
             },
             "oneOf": [
@@ -2685,9 +2685,9 @@
                 "stream-id": {
                     "$ref": "#/definitions/stream-id-inner"
                 },
-                "on-behalf-of": {
+                "obo": {
                     "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
-                    "$ref": "#/definitions/on-behalf-of-inner"
+                    "$ref": "#/definitions/obo-inner"
                 }
             },
             "required": [
@@ -2699,9 +2699,9 @@
                 "stream-id": {
                     "$ref": "#/definitions/stream-id-inner"
                 },
-                "on-behalf-of": {
+                "obo": {
                     "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
-                    "$ref": "#/definitions/on-behalf-of-inner"
+                    "$ref": "#/definitions/obo-inner"
                 }
             },
             "required": [
@@ -2714,9 +2714,9 @@
                 "user-id": {
                     "$ref": "#/definitions/user-id"
                 },
-                "on-behalf-of": {
+                "obo": {
                     "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
-                    "$ref": "#/definitions/on-behalf-of-inner"
+                    "$ref": "#/definitions/obo-inner"
                 }
             },
             "required": [
@@ -2888,9 +2888,9 @@
                 "skip": {
                     "$ref": "#/definitions/skip"
                 },
-                "on-behalf-of": {
+                "obo": {
                     "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
-                    "$ref": "#/definitions/on-behalf-of-inner"
+                    "$ref": "#/definitions/obo-inner"
                 }
             }
         },
@@ -2974,9 +2974,9 @@
                 "skip": {
                     "$ref": "#/definitions/skip"
                 },
-                "on-behalf-of": {
+                "obo": {
                     "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
-                    "$ref": "#/definitions/on-behalf-of-inner"
+                    "$ref": "#/definitions/obo-inner"
                 }
             },
             "required": [
@@ -3034,9 +3034,9 @@
                         "ALL"
                     ]
                 },
-                "on-behalf-of": {
+                "obo": {
                     "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
-                    "$ref": "#/definitions/on-behalf-of-inner"
+                    "$ref": "#/definitions/obo-inner"
                 }
             }
         },
@@ -3609,7 +3609,7 @@
             ],
             "description": "Group's unique identifier."
         },
-        "on-behalf-of-inner": {
+        "obo-inner": {
             "type": "object",
             "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made.",
             "properties": {

--- a/workflow-language/src/main/resources/swadl-schema-1.0.json
+++ b/workflow-language/src/main/resources/swadl-schema-1.0.json
@@ -1443,6 +1443,10 @@
                 },
                 "sub-type": {
                     "$ref": "#/definitions/sub-type"
+                },
+                "obo": {
+                    "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
+                    "$ref": "#/definitions/obo-inner"
                 }
             },
             "anyOf": [

--- a/workflow-language/src/main/resources/swadl-schema-1.0.json
+++ b/workflow-language/src/main/resources/swadl-schema-1.0.json
@@ -2602,10 +2602,6 @@
             "properties": {
                 "user-id": {
                     "$ref": "#/definitions/user-id"
-                },
-                "obo": {
-                    "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
-                    "$ref": "#/definitions/obo-inner"
                 }
             },
             "required": [
@@ -2911,10 +2907,6 @@
                 },
                 "skip": {
                     "$ref": "#/definitions/skip"
-                },
-                "obo": {
-                    "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
-                    "$ref": "#/definitions/obo-inner"
                 }
             }
         },

--- a/workflow-language/src/main/resources/swadl-schema-1.0.json
+++ b/workflow-language/src/main/resources/swadl-schema-1.0.json
@@ -2602,6 +2602,10 @@
             "properties": {
                 "user-id": {
                     "$ref": "#/definitions/user-id"
+                },
+                "obo": {
+                    "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
+                    "$ref": "#/definitions/obo-inner"
                 }
             },
             "required": [

--- a/workflow-language/src/main/resources/swadl-schema-1.0.json
+++ b/workflow-language/src/main/resources/swadl-schema-1.0.json
@@ -1645,6 +1645,10 @@
             "properties": {
                 "message-id": {
                     "$ref": "#/definitions/message-id-inner"
+                },
+                "obo": {
+                    "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
+                    "$ref": "#/definitions/obo-inner"
                 }
             },
             "required": [
@@ -1656,6 +1660,10 @@
             "properties": {
                 "stream-id": {
                     "$ref": "#/definitions/stream-id-inner"
+                },
+                "obo": {
+                    "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
+                    "$ref": "#/definitions/obo-inner"
                 }
             },
             "required": [
@@ -2800,6 +2808,10 @@
                 },
                 "skip": {
                     "$ref": "#/definitions/skip"
+                },
+                "obo": {
+                    "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
+                    "$ref": "#/definitions/obo-inner"
                 }
             },
             "dependencies": {

--- a/workflow-language/src/main/resources/swadl-schema-1.0.json
+++ b/workflow-language/src/main/resources/swadl-schema-1.0.json
@@ -1508,6 +1508,10 @@
                 },
                 "active": {
                     "$ref": "#/definitions/active"
+                },
+                "obo": {
+                    "description": "Defines whether the activity will be executed on behalf of a user and the user on whose behalf the call will be made",
+                    "$ref": "#/definitions/obo-inner"
                 }
             }
         },


### PR DESCRIPTION
### Description
Closes #28 
This PR is a first take on OBO support for WDK activities.
An optional property on-behalf-of has been added in SWADL to make an activity call OBO.
In order to avoid making an authentication request for each OBO activity, we introduced a Caffeine cache to cache user obo authentication sessions. The cache is configured in application.yaml file.
For send-message activity, we throw an illegal argument exception when a blast message is done in OBO mode as the api is not obo enabled.
Only sendMessage and addRoomMember activities are supporting obo for now, the other activities will be implemented in a next commit.

### Dependencies
Added: 
- com.github.ben-manes.caffeine:caffeine:3.1.1
- org.springframework.boot:spring-boot-starter-cache

### Checklist
- [x] Referenced a ticket in the PR title or description
- [x] Filled properly the description and dependencies, if any
- [x] Unit/Integration tests updated or added
- [x] Javadoc added or updated
- [x] Updated the documentation in [docs folder](../docs)
