### PR TITLE
Add silent flag to update message activity

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -861,7 +861,8 @@ Update an existing message into a stream. Returns the new updated message.
 Key | Type | Required |
 ------------ | -------| --- |
 [message-id](#update-message-id) | String | Yes |
-[content](#content) | String/Object| Yes |
+[content](#content) | String/Object | Yes |
+[silent](#silent) | Boolean | No |
 
 Output | Type |
 ----|----|
@@ -870,7 +871,12 @@ msgId | String
 
 #### <a name="update-message-id"></a> message-id
 
-Message id of the message to be updated. Both url safe and base64 encoded urls are accepted
+Message id of the message to be updated. Both url safe and base64 encoded urls are accepted.
+
+#### <a name="silent"></a> silent
+
+Silent flag in the update message activity. The new updated message will be marked as read when the flag is set to true, unread otherwise.
+The default value is true.
 
 ### pin-message
 

--- a/workflow-bot-app/build.gradle
+++ b/workflow-bot-app/build.gradle
@@ -12,7 +12,7 @@ javadoc {
 dependencies {
     implementation project(':workflow-language')
 
-    implementation platform('org.finos.symphony.bdk:symphony-bdk-bom:2.7.0')
+    implementation platform('org.finos.symphony.bdk:symphony-bdk-bom:2.9.0')
     implementation platform('com.fasterxml.jackson:jackson-bom:2.13.2.20220328')
     implementation platform('org.springframework.boot:spring-boot-dependencies:2.6.6')
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/UpdateMessageExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/UpdateMessageExecutor.java
@@ -22,7 +22,8 @@ public class UpdateMessageExecutor implements ActivityExecutor<UpdateMessage> {
     String messageId = execution.getActivity().getMessageId();
     V4Message messageToUpdate =  execution.bdk().messages().getMessage(messageId);
     String content = extractContent(execution);
-    Message message = Message.builder().content(content).build();
+    Boolean silent = execution.getActivity().getSilent();
+    Message message = Message.builder().silent(silent).content(content).build();
     V4Message updatedMessage = execution.bdk().messages().update(messageToUpdate, message);
 
     Map<String, Object> outputs = new HashMap<>();

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/FormReplyIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/FormReplyIntegrationTest.java
@@ -275,7 +275,6 @@ class FormReplyIntegrationTest extends IntegrationTest {
       return true;
     });
 
-
     assertThat(workflow)
         .executed("init", "check");
   }

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/UpdateMessageIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/UpdateMessageIntegrationTest.java
@@ -18,6 +18,9 @@ import com.symphony.bdk.workflow.swadl.v1.Workflow;
 
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
@@ -27,10 +30,11 @@ public class UpdateMessageIntegrationTest extends IntegrationTest {
   private static final String OUTPUT_MESSAGE_ID_KEY = "%s.outputs.msgId";
   private static final String OUTPUT_MESSAGE_KEY = "%s.outputs.message";
 
-  @Test
-  void updateMessageSuccessfull() throws IOException, ProcessingException {
+  @ParameterizedTest
+  @CsvSource({"update-message.swadl.yaml, true", "update-notsilent-message.swadl.yaml, false"})
+  void updateMessageSuccessfully(String workflowFile, Boolean silent) throws IOException, ProcessingException {
     final Workflow workflow =
-        SwadlParser.fromYaml(getClass().getResourceAsStream("/message/update-message.swadl.yaml"));
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/message/" + workflowFile));
     final String msgId = "MSG_ID";
     final String content = "<messageML>Message Updated</messageML>";
     final V4Message message = message(msgId);
@@ -49,10 +53,11 @@ public class UpdateMessageIntegrationTest extends IntegrationTest {
     ArgumentCaptor<Message> messageArgumentCaptor = ArgumentCaptor.forClass(Message.class);
     verify(messageService, times(1)).update(eq(message), messageArgumentCaptor.capture());
     assertThat(messageArgumentCaptor.getValue().getContent()).isEqualTo(content);
+    assertThat(messageArgumentCaptor.getValue().getSilent()).isEqualTo(silent);
   }
 
   @Test
-  void updateMessageWithTemplateSuccessfull() throws IOException, ProcessingException {
+  void updateMessageWithTemplateSuccessfully() throws IOException, ProcessingException {
     final Workflow workflow =
         SwadlParser.fromYaml(getClass().getResourceAsStream("/message/update-message-template.swadl.yaml"));
     final String msgId = "MSG_ID";

--- a/workflow-bot-app/src/test/resources/message/update-notsilent-message.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/update-notsilent-message.swadl.yaml
@@ -1,0 +1,10 @@
+id: update-message
+activities:
+  - update-message:
+      id: updateMessage
+      on:
+        message-received:
+          content: /update-valid-message
+      message-id: MSG_ID
+      silent: false
+      content: Message Updated

--- a/workflow-language/build.gradle
+++ b/workflow-language/build.gradle
@@ -8,7 +8,7 @@ javadoc {
 }
 
 dependencies {
-    api platform('org.finos.symphony.bdk:symphony-bdk-bom:2.7.0')
+    api platform('org.finos.symphony.bdk:symphony-bdk-bom:2.9.0')
 
     api 'org.finos.symphony.bdk:symphony-bdk-core'
     api 'org.finos.symphony.bdk.ext:symphony-group-extension'

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/UpdateMessage.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/UpdateMessage.java
@@ -14,6 +14,7 @@ public class UpdateMessage extends BaseActivity {
   private String messageId;
   @Nullable private String template;
   @Nullable private String content;
+  private Boolean silent = Boolean.TRUE;
 
   @SuppressWarnings("unchecked")
   public void setContent(Object content) {

--- a/workflow-language/src/main/resources/swadl-schema-1.0.json
+++ b/workflow-language/src/main/resources/swadl-schema-1.0.json
@@ -1605,6 +1605,14 @@
                 },
                 "message-id": {
                     "$ref": "#/definitions/message-id-inner"
+                },
+                "silent": {
+                    "type": [
+                        "boolean",
+                        "string"
+                    ],
+                    "description": "If enabled, the new updated message is marked as read, otherwise is unread",
+                    "default": true
                 }
             },
             "required": [


### PR DESCRIPTION
The silent flag in the update message service was included
in the new BDK release, this commit is to support the same
in WDK.

### Description
Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced a ticket in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
