### PR TITLE
Added local whitesource config

### DIFF
--- a/.whitesource.config
+++ b/.whitesource.config
@@ -1,0 +1,3 @@
+# Reference: https://whitesource.atlassian.net/wiki/spaces/WD/pages/1544880156/Unified+Agent+Configuration+Parameters
+
+gradle.ignoredConfigurations=.*test.*

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/FormReplyIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/FormReplyIntegrationTest.java
@@ -269,7 +269,12 @@ class FormReplyIntegrationTest extends IntegrationTest {
     // trigger workflow execution
     engine.onEvent(messageReceived("/run_form_outputs_preserved"));
     verify(messageService, timeout(5000)).send(eq("ABC"), contains("form"));
-    engine.onEvent(form("msgId", "init", Collections.singletonMap("action", "one")));
+
+    await().atMost(5, TimeUnit.SECONDS).ignoreExceptions().until(() -> {
+      engine.onEvent(form("msgId", "init", Collections.singletonMap("action", "one")));
+      return true;
+    });
+
 
     assertThat(workflow)
         .executed("init", "check");


### PR DESCRIPTION
Having whitesource config mode set to LOCAL, a local whitesource.config was required, otherwise the scan times out.
This configuration excludes dependencies for test configurations.
For more info: https://whitesource.atlassian.net/wiki/spaces/WD/pages/1544880156/Unified+Agent+Configuration+Parameters