### PR TITLE
Set whitesource config mode to AUTO.

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,6 +1,6 @@
 {
   "scanSettings": {
-    "configMode": "LOCAL",
+    "configMode": "AUTO",
     "configExternalURL": "",
     "projectToken": "",
     "baseBranches": []

--- a/.whitesource.config
+++ b/.whitesource.config
@@ -1,3 +1,0 @@
-# Reference: https://whitesource.atlassian.net/wiki/spaces/WD/pages/1544880156/Unified+Agent+Configuration+Parameters
-
-gradle.ignoredConfigurations=.*test.*


### PR DESCRIPTION
Set whitesource config mode to AUTO. LOCAL mode does not work even with a local whitesource config file.