### PR TITLE
Skip deployment attempts of empty SWADL files

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/configuration/WorkflowFolderWatcher.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/configuration/WorkflowFolderWatcher.java
@@ -135,6 +135,9 @@ public class WorkflowFolderWatcher {
   }
 
   private void addWorkflow(Path workflowFile) throws IOException, ProcessingException {
+    if (workflowFile.toFile().length() == 0) {
+      return;
+    }
     Workflow workflow = SwadlParser.fromYaml(workflowFile.toFile());
     workflowEngine.deploy(workflow);
     deployedWorkflows.put(workflowFile, workflow.getId());


### PR DESCRIPTION
### Description
Closes #100

In certain environments, the file watcher produces 2 events on a file save: the first event empties the contents of the file before the second event replaces it with the new contents. In such scenarios, WDK attempts to deploy twice with the first attempt failing validation since the string is empty and a NPE is thrown. This is immediately followed by a successful second attempt deployment. This change ignores scenarios where deployment is attempted on a 0-sized file.