### PR TITLE
Fix bug when form reply event in allOf list

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/WorkflowEventToCamundaEvent.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/WorkflowEventToCamundaEvent.java
@@ -58,7 +58,7 @@ public class WorkflowEventToCamundaEvent {
   private static final String MESSAGE_SUPPRESSED = "message-suppressed";
   private static final String POST_SHARED = "post-shared";
   private static final String IM_CREATED = "im-created";
-  public static final String FORM_REPLY_PREFIX = "formReply_";
+  public static final String FORM_REPLY_PREFIX = "form-reply_";
   private static final String ROOM_CREATED = "room-created";
   private static final String ROOM_UPDATED = "room-updated";
   private static final String ROOM_DEACTIVATED = "room-deactivated";

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/FormRepliedNodeBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/FormRepliedNodeBuilder.java
@@ -29,15 +29,10 @@ public class FormRepliedNodeBuilder extends AbstractNodeBpmnBuilder {
   public AbstractFlowNodeBuilder<?, ?> build(WorkflowNode element, String parentId,
       AbstractFlowNodeBuilder<?, ?> builder, BuildProcessContext context) {
     if (builder instanceof ParallelGatewayBuilder) {
-      return builder.exclusiveGateway()
-          .intermediateCatchEvent()
-          .timerWithDuration(readTimeout(element))
-          .connectTo(parentId + "_join_gateway")
-          .moveToLastGateway()
-          .intermediateCatchEvent()
+      return builder.intermediateCatchEvent()
           .camundaAsyncBefore()
-          .signal(element.getId())
-          .name(element.getId());
+          .name(element.getId())
+          .message(element.getId());
     } else {
       // cache the sub process builder, the form reply might have a brother event, which is going to use this cached builder
       SubProcessBuilder subProcess = builder.subProcess();

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/JoinActivityNodeBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/JoinActivityNodeBuilder.java
@@ -3,8 +3,10 @@ package com.symphony.bdk.workflow.engine.camunda.bpmn.builder;
 import com.symphony.bdk.workflow.engine.WorkflowNode;
 import com.symphony.bdk.workflow.engine.WorkflowNodeType;
 import com.symphony.bdk.workflow.engine.camunda.bpmn.BuildProcessContext;
+import com.symphony.bdk.workflow.engine.camunda.variable.FormVariableListener;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.camunda.bpm.engine.delegate.ExecutionListener;
 import org.camunda.bpm.model.bpmn.builder.AbstractFlowNodeBuilder;
 import org.springframework.stereotype.Component;
 
@@ -13,7 +15,8 @@ public class JoinActivityNodeBuilder extends AbstractNodeBpmnBuilder {
   @Override
   protected AbstractFlowNodeBuilder<?, ?> build(WorkflowNode element, String parentId,
       AbstractFlowNodeBuilder<?, ?> builder, BuildProcessContext context) throws JsonProcessingException {
-    return builder.parallelGateway(element.getId());
+    return builder.parallelGateway(element.getId())
+        .camundaExecutionListenerClass(ExecutionListener.EVENTNAME_START, FormVariableListener.class);
   }
 
   @Override

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/SignalNodeBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/SignalNodeBuilder.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.workflow.engine.camunda.bpmn.builder;
 
+import com.symphony.bdk.workflow.engine.WorkflowDirectGraph;
 import com.symphony.bdk.workflow.engine.WorkflowNode;
 import com.symphony.bdk.workflow.engine.WorkflowNodeType;
 import com.symphony.bdk.workflow.engine.camunda.bpmn.BuildProcessContext;
@@ -7,7 +8,6 @@ import com.symphony.bdk.workflow.engine.camunda.bpmn.BuildProcessContext;
 import org.camunda.bpm.model.bpmn.builder.AbstractCatchEventBuilder;
 import org.camunda.bpm.model.bpmn.builder.AbstractFlowNodeBuilder;
 import org.camunda.bpm.model.bpmn.builder.AbstractGatewayBuilder;
-import org.camunda.bpm.model.bpmn.builder.ParallelGatewayBuilder;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -51,7 +51,9 @@ public class SignalNodeBuilder extends AbstractNodeBpmnBuilder {
    *  @formatter:on
    */
   private boolean hasFormRepliedEventBrother(BuildProcessContext context, String parentId) {
-    return context.readChildren(parentId) != null && context.readChildren(parentId).getChildren()
+    return context.readChildren(parentId) != null
+        && context.readChildren(parentId).getGateway() != WorkflowDirectGraph.Gateway.PARALLEL && context.readChildren(
+            parentId).getChildren()
         .stream()
         .anyMatch(s -> context.readWorkflowNode(s).getElementType() == WorkflowNodeType.FORM_REPLIED_EVENT);
   }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/variable/FormVariableListener.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/variable/FormVariableListener.java
@@ -25,6 +25,7 @@ public class FormVariableListener implements ExecutionListener {
   public void notify(DelegateExecution execution) {
     Object formVariable = execution.getVariable(FORM_VARIABLES);
     // do we have a form variable in the current process?
+    log.debug("receive a form, checking the form variables");
     if (formVariable instanceof Map) {
       Map<String, Map<String, Object>> form = (Map<String, Map<String, Object>>) formVariable;
       // there should be only one form.FORM_ID entry

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/SendMessageExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/SendMessageExecutor.java
@@ -1,7 +1,5 @@
 package com.symphony.bdk.workflow.engine.executor.message;
 
-import static java.util.Collections.singletonList;
-
 import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.core.service.message.MessageService;
 import com.symphony.bdk.core.service.message.OboMessageService;
@@ -19,7 +17,6 @@ import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
 import com.symphony.bdk.workflow.engine.executor.obo.OboExecutor;
 import com.symphony.bdk.workflow.swadl.v1.activity.message.SendMessage;
-import com.symphony.bdk.workflow.swadl.v1.event.UserJoinedRoomEvent;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -33,6 +30,8 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static java.util.Collections.singletonList;
 
 @Slf4j
 @Component
@@ -105,31 +104,30 @@ public class SendMessageExecutor extends OboExecutor<SendMessage, V4Message>
     if (activity.getTo() != null && activity.getTo().getStreamId() != null) {
       // either the stream id is set explicitly in the workflow
       return singletonList(activity.getTo().getStreamId());
-
     } else if (activity.getTo() != null && activity.getTo().getStreamIds() != null) {
       return activity.getTo().getStreamIds();
-
     } else if (activity.getTo() != null && activity.getTo().getUserIds() != null) {
       // or the user ids are set explicitly in the workflow
       return singletonList(this.createOrGetStreamId(activity.getTo().getUserIds(), streamService));
-
     } else if (execution.getEvent() != null
         && execution.getEvent().getSource() instanceof V4MessageSent) {
       // or retrieved from the current even
       V4MessageSent event = (V4MessageSent) execution.getEvent().getSource();
       return singletonList(event.getMessage().getStream().getStreamId());
-
     } else if (execution.getEvent() != null
         && execution.getEvent().getSource() instanceof V4SymphonyElementsAction) {
       V4SymphonyElementsAction event = (V4SymphonyElementsAction) execution.getEvent().getSource();
       return singletonList(event.getStream().getStreamId());
-
     } else if (execution.getEvent() != null
         && execution.getEvent().getSource() instanceof V4UserJoinedRoom) {
       // or retrieved from the current even
       V4UserJoinedRoom event = (V4UserJoinedRoom) execution.getEvent().getSource();
       return singletonList(event.getStream().getStreamId());
-
+    } else if (execution.getEvent() != null
+        && execution.getEvent().getSource() instanceof V4SymphonyElementsAction) {
+      // or retrieved from the current even
+      V4SymphonyElementsAction event = (V4SymphonyElementsAction) execution.getEvent().getSource();
+      return singletonList(event.getStream().getStreamId());
     } else {
       throw new IllegalArgumentException(
           String.format("No stream id set to send a message in activity %s", activity.getId()));

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/IntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/IntegrationTest.java
@@ -231,7 +231,7 @@ public abstract class IntegrationTest {
     elementsAction.setFormMessageId(messageId);
     elementsAction.setFormId(formId);
     elementsAction.setFormValues(formReplies);
-    elementsAction.setStream(new V4Stream());
+    elementsAction.setStream(new V4Stream().streamId("123"));
     return new RealTimeEvent<>(initiator, elementsAction);
   }
 

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/JoinIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/JoinIntegrationTest.java
@@ -3,6 +3,7 @@ package com.symphony.bdk.workflow;
 import static com.symphony.bdk.workflow.custom.assertion.WorkflowAssert.assertThat;
 import static com.symphony.bdk.workflow.custom.assertion.WorkflowAssert.content;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -16,6 +17,8 @@ import com.symphony.bdk.workflow.swadl.v1.Workflow;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
 
 public class JoinIntegrationTest extends IntegrationTest {
 
@@ -40,7 +43,28 @@ public class JoinIntegrationTest extends IntegrationTest {
     engine.onEvent(userJoined());
     Thread.sleep(1000);
     verify(messageService).send(eq(streamId), content("end join"));
-    assertThat(workflow).executed("start", "scriptTrue", "scriptTrue_fork_gateway",  "endMessage_join_gateway",
+    assertThat(workflow).executed("start", "scriptTrue", "scriptTrue_fork_gateway", "endMessage_join_gateway",
+        "endMessage_join_gateway", "endMessage");
+  }
+
+  @SneakyThrows
+  @Test
+  @DisplayName("Form reply join operations")
+  void test_parallel_join_with_form_reply_flow() {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/graph/form-reply-all-of.swadl.yaml"));
+    when(messageService.send(anyString(), any(Message.class))).thenReturn(message("msgId"));
+
+    engine.deploy(workflow);
+    engine.onEvent(messageReceived("/start"));
+    Thread.sleep(1000);
+    engine.onEvent(messageReceived("/done"));
+    Thread.sleep(1000);
+    verify(messageService, never()).send(anyString(), content("end join"));
+    engine.onEvent(form("msgId", "sendForm", Collections.singletonMap("action", "approve")));
+    Thread.sleep(1000);
+    verify(messageService).send(anyString(), content("end join"));
+    assertThat(workflow).executed("sendForm", "sendForm_fork_gateway", "endMessage_join_gateway",
         "endMessage_join_gateway", "endMessage");
   }
 }

--- a/workflow-bot-app/src/test/resources/graph/form-reply-all-of.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/graph/form-reply-all-of.swadl.yaml
@@ -1,0 +1,26 @@
+id: formreply-all-of
+activities:
+  - send-message:
+      id: sendForm
+      on:
+        message-received:
+          content: /start
+      content: |
+        <messageML>
+          <p>Do you approve the action?</p>
+          <form id="sendForm">
+            <button name="approve" type="action">Approve</button>
+            <button name="reject" type="action">Reject</button>
+          </form>
+        </messageML>
+
+  - send-message:
+      id: endMessage
+      on:
+        all-of:
+          - message-received:
+              content: /done
+          - form-replied:
+              form-id: sendForm
+              exclusive: true
+      content: end join


### PR DESCRIPTION
Form reply event in a all-of list is construct as a message
element and it must be exclusive without having a timeout constrait,
otherwise it does not make sense in this particular use case.

### Description
Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced a ticket in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
