### PR TITLE
#149: Fix bug when on request-received event is added with a subsequent activity having form-replied event.

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/BpmnBuilderHelper.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/BpmnBuilderHelper.java
@@ -49,9 +49,9 @@ public class BpmnBuilderHelper {
   }
 
   public static boolean hasLoopAfterSubProcess(BuildProcessContext context,
-      WorkflowDirectGraph.NodeChildren currentNodeChildren) {
-    return context.hasEventSubProcess() && currentNodeChildren.getChildren()
-        .stream()
-        .anyMatch(context::isAlreadyBuilt);
+      WorkflowDirectGraph.NodeChildren currentNodeChildren,
+      WorkflowNodeType currentNodeType) {
+    return currentNodeType == WorkflowNodeType.ACTIVITY_COMPLETED_EVENT && context.hasEventSubProcess()
+        && currentNodeChildren.getChildren().stream().anyMatch(context::isAlreadyBuilt);
   }
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/CamundaBpmnBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/CamundaBpmnBuilder.java
@@ -180,9 +180,11 @@ public class CamundaBpmnBuilder {
       builder.endEvent();
       return builder;
     }
-    if (hasLoopAfterSubProcess(context, currentNodeChildren)) {
+
+    if (hasLoopAfterSubProcess(context, currentNodeChildren, currentNodeType)) {
       builder = BpmnBuilderHelper.endEventSubProcess(context, builder);
     }
+
     boolean activities = hasActivitiesOnly(context, currentNodeChildren);
     // either child or current node is conditional, since the condition can be defined
     // at parent event or activity itself

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/FormRepliedNodeBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/FormRepliedNodeBuilder.java
@@ -39,7 +39,7 @@ public class FormRepliedNodeBuilder extends AbstractNodeBpmnBuilder {
       SubProcessBuilder subProcess = builder.subProcess();
       context.cacheSubProcess(subProcess);
 
-      timeoutFlow(element, subProcess, context);
+      timeoutFlow(element, subProcess);
       // we add the form reply event sub process inside the subprocess
       EventSubProcessBuilder subProcessBuilder = subProcess.camundaAsyncBefore().embeddedSubProcess().eventSubProcess();
       // cache the sub process builder, so to terminate it later
@@ -56,7 +56,7 @@ public class FormRepliedNodeBuilder extends AbstractNodeBpmnBuilder {
     }
   }
 
-  private void timeoutFlow(WorkflowNode element, SubProcessBuilder subProcess, BuildProcessContext context) {
+  private void timeoutFlow(WorkflowNode element, SubProcessBuilder subProcess) {
     String timeout = readTimeout(element);
     subProcess.embeddedSubProcess()
         .startEvent()

--- a/workflow-bot-app/src/test/resources/event/request-received-in-one-of-with-form-replied-activity.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/event/request-received-in-one-of-with-form-replied-activity.swadl.yaml
@@ -1,0 +1,23 @@
+id: request-received-in-one-of-with-form-replied-activity
+activities:
+  - send-message:
+      id: formActivity
+      to:
+        stream-id: "123"
+      on:
+        one-of:
+          - message-received:
+              content: /request-received-in-one-of-with-form-replied-activity
+          - request-received:
+              token: myToken
+      content: |
+        <form id="formActivity"><button type="action" name="one">One</button></form>
+
+  - send-message:
+      id: act
+      content: <messageML>Hello!</messageML>
+      on:
+        form-replied:
+          form-id: formActivity
+      to:
+        stream-id: "123"

--- a/workflow-bot-app/src/test/resources/event/request-received-in-one-of.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/event/request-received-in-one-of.swadl.yaml
@@ -1,0 +1,13 @@
+id: request-received-in-one-of
+activities:
+  - send-message:
+      id: sendmsg
+      to:
+        stream-id: "123"
+      content: ${event.args.content}
+      on:
+        one-of:
+          - message-received:
+              content: /request-received-in-one-of
+          - request-received:
+              token: myToken


### PR DESCRIPTION
### Description
#149 
The issue happens when the workflow has an activity with triggering event request-received within one-of property that sends a form, and a subsequent activity executed on that form replied. The workflow being built has this request-received event attached to an endEvent which makes the workflow completes once the request is received without executing the activities. The issue comes from an incomplete condition checking if the activity is in a loop. We enriched this condition by checking if the current activity is of type ACTIVITY_COMPLETED_EVENT.

**Before the fix:**
<img width="865" alt="Screenshot 2022-09-26 at 20 12 24" src="https://user-images.githubusercontent.com/52406574/192569315-dc8be5bc-0e0e-4d2b-a5cd-3572780ed9c9.png">

**After the fix:**
<img width="1012" alt="Screenshot 2022-09-27 at 17 28 12" src="https://user-images.githubusercontent.com/52406574/192569340-112a68f5-bc4b-48e0-b853-4ba3ecf173f9.png">
