### PR TITLE
Add data field to SendMessage activity

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -718,6 +718,7 @@ Key | Type | Required |
 [to](#to) | Map | No |
 [content](#send-message-content) | String/Object | Yes |
 [attachments](#attachments) | List | No |
+[data](#data) | String | No |
 
 Output | Type |
 ----|----|
@@ -870,6 +871,87 @@ encoded urls are accepted.
 ##### content-path
 
 Path to the file to be attached to the message. The path is relative to the workflows folder.
+
+#### data
+
+A [structured object](https://docs.developers.symphony.com/building-bots-on-symphony/messages/overview-of-messageml/entities/structured-objects) 
+can be sent as part of a message in this field. It must be a json string.
+
+
+Example:
+
+```yaml
+activities:
+  - send-message:
+      id: echo
+      on:
+        message-received:
+          content: /echo
+      content:
+        ${text(event.source.message.message)}
+      data: "{
+                  \"object001\":
+                  {
+                    \"type\":     \"org.symphonyoss.fin.security\",
+                    \"version\":  \"1.0\",
+                    \"id\":
+                      [
+                        {
+                          \"type\":     \"org.symphonyoss.fin.security.id.ticker\",
+                          \"value\":    \"IBM\"
+                        },
+                        {
+                          \"type\":     \"org.symphonyoss.fin.security.id.isin\",
+                          \"value\":    \"US0378331005\"
+                        },
+                        {
+                          \"type\":     \"org.symphonyoss.fin.security.id.cusip\",
+                          \"value\":    \"037833100\"
+                        }
+                      ]
+                  }
+              }"
+```
+
+One could also use [Utility function](#utility-functions) to escape the data json string, the same example 
+above can be done like
+
+Example
+
+```yaml
+variables:
+  data: {
+          "object001":
+            {
+              "type":     "org.symphonyoss.fin.security",
+              "version":  "1.0",
+              "id":
+                [
+                  {
+                    "type":     "org.symphonyoss.fin.security.id.ticker",
+                    "value":    "IBM"
+                  },
+                  {
+                    "type":     "org.symphonyoss.fin.security.id.isin",
+                    "value":    "US0378331005"
+                  },
+                  {
+                    "type":     "org.symphonyoss.fin.security.id.cusip",
+                    "value":    "037833100"
+                  }
+                ]
+            }
+        }
+activities:
+  - send-message:
+      id: echo
+      on:
+        message-received:
+          content: /echo
+      content:
+        ${text(event.source.message.message)}
+      data: ${escape(variables.data)}
+```
 
 ### update-message
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/api/v1/dto/WorkflowActivitiesView.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/api/v1/dto/WorkflowActivitiesView.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class WorkflowActivitiesView {
   private List<ActivityInstanceView> activities;
   private VariableView globalVariables;
+  private Map<String, Object> error;
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/api/v1/dto/WorkflowDefinitionView.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/api/v1/dto/WorkflowDefinitionView.java
@@ -10,6 +10,6 @@ import java.util.Map;
 @Builder
 public class WorkflowDefinitionView {
   private String workflowId;
-  private List<Map<String, String>> variables;
+  private Map<String, Object> variables;
   private List<TaskDefinitionView> flowNodes;
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/WorkflowDirectGraph.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/WorkflowDirectGraph.java
@@ -9,6 +9,7 @@ import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.Cacheable;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -43,6 +44,9 @@ public class WorkflowDirectGraph {
    */
   @Getter
   private final List<String> startEvents = new ArrayList<>();
+
+  @Getter
+  private final Map<String, Object> variables = new HashMap<>();
 
   public void addParent(String id, String parent) {
     parents.computeIfAbsent(id, k -> new HashSet<>()).add(parent);

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/WorkflowDirectGraphBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/WorkflowDirectGraphBuilder.java
@@ -55,6 +55,7 @@ public class WorkflowDirectGraphBuilder {
       String activityId = computeParallelJoinGateway(directGraph, activity);
       computeEvents(i, activityId, activities, directGraph);
     }
+    directGraph.getVariables().putAll(workflow.getVariables());
     return directGraph;
   }
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaExecutor.java
@@ -106,7 +106,8 @@ public class CamundaExecutor implements JavaDelegate {
 
     // escape break line and new lin characters
     String activityAsJsonString = ((String) execution.getVariable(ACTIVITY)).replaceAll("(\\r|\\n|\\r\\n)+", "\\\\n");
-    Object activity = OBJECT_MAPPER.readValue(activityAsJsonString, Class.forName(type.getTypeName()));
+    BaseActivity activity =
+        (BaseActivity) OBJECT_MAPPER.readValue(activityAsJsonString, Class.forName(type.getTypeName()));
 
     EventHolder event = (EventHolder) execution.getVariable(ActivityExecutorContext.EVENT);
 
@@ -114,14 +115,27 @@ public class CamundaExecutor implements JavaDelegate {
       setMdc(execution);
       auditTrailLogger.execute(execution, activity.getClass().getSimpleName());
       executor.execute(
-          new CamundaActivityExecutorContext(execution, (BaseActivity) activity, event, resourceLoader, bdk));
+          new CamundaActivityExecutorContext(execution, activity, event, resourceLoader, bdk));
     } catch (Exception e) {
-      log.error(String.format("Activity %s from workflow %s failed",
-          execution.getActivityInstanceId(), execution.getProcessInstanceId()), e);
+      log.error(String.format("Activity from workflow %s failed", execution.getProcessDefinitionId()), e);
+      logErrorVariables(execution, activity, e);
       throw new BpmnError("FAILURE", e);
     } finally {
       clearMdc();
     }
+  }
+
+  private static void logErrorVariables(DelegateExecution execution, BaseActivity activity, Exception e) {
+    Map<String, Object> innerMap = new HashMap<>();
+    innerMap.put("message", e.getCause() == null ? e.getMessage() : e.getCause().getMessage());
+    innerMap.put("activityInstId", execution.getActivityInstanceId());
+    innerMap.put("activityId", activity.getId());
+    ObjectValue objectValue = Variables.objectValue(innerMap)
+        .serializationDataFormat(Variables.SerializationDataFormats.JSON)
+        .create();
+    execution.getProcessEngineServices()
+        .getRuntimeService()
+        .setVariable(execution.getId(), ActivityExecutorContext.ERROR, objectValue);
   }
 
   private void setMdc(DelegateExecution execution) {

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/monitoring/repository/VariableCmdaApiQueryRepository.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/monitoring/repository/VariableCmdaApiQueryRepository.java
@@ -28,11 +28,11 @@ public class VariableCmdaApiQueryRepository extends CamundaAbstractQueryReposito
   }
 
   @Override
-  public VariablesDomain findGlobalVarsByWorkflowInstanceId(String id) {
+  public VariablesDomain findVarsByWorkflowInstanceIdAndVarName(String id, String name) {
     HistoricVariableInstanceEntity variables =
         (HistoricVariableInstanceEntity) historyService.createHistoricVariableInstanceQuery()
             .processInstanceId(id)
-            .variableName("variables")
+            .variableName(name)
             .singleResult();
     VariablesDomain variablesDomain = new VariablesDomain();
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/SendMessageExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/SendMessageExecutor.java
@@ -21,6 +21,7 @@ import com.symphony.bdk.workflow.engine.executor.obo.OboExecutor;
 import com.symphony.bdk.workflow.swadl.v1.activity.message.SendMessage;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 import java.io.ByteArrayInputStream;
@@ -141,6 +142,9 @@ public class SendMessageExecutor extends OboExecutor<SendMessage, V4Message>
 
   private Message buildMessage(ActivityExecutorContext<SendMessage> execution) throws IOException {
     Message.MessageBuilder builder = Message.builder().content(extractContent(execution));
+    if (StringUtils.isNotBlank(execution.getActivity().getData())) {
+      builder.data(execution.getActivity().getData());
+    }
     if (execution.getActivity().getAttachments() != null) {
       for (SendMessage.Attachment attachment : execution.getActivity().getAttachments()) {
         this.handleFileAttachment(builder, attachment, execution);

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/monitoring/repository/VariableQueryRepository.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/monitoring/repository/VariableQueryRepository.java
@@ -6,7 +6,7 @@ import java.time.Instant;
 import java.util.List;
 
 public interface VariableQueryRepository extends QueryRepository<VariablesDomain, String> {
-  VariablesDomain findGlobalVarsByWorkflowInstanceId(String id);
+  VariablesDomain findVarsByWorkflowInstanceIdAndVarName(String id, String name);
 
   List<VariablesDomain> findGlobalVarsHistoryByWorkflowInstId(String id, Instant occurredBefore, Instant occurredAfter);
 }

--- a/workflow-bot-app/src/main/resources/application-local.yaml
+++ b/workflow-bot-app/src/main/resources/application-local.yaml
@@ -3,15 +3,19 @@ wdk:
   workflows:
     path: ./workflows
   properties:
-    monitoring-token: ${wdk.monitoring.token:} # The default value is an empty String
+    monitoring-token: token # The default value is an empty String
 
 # BDK configuration for local development
 bdk:
-  host: xxx
-  bot:
-    username: xxx
+  host: develop.symphony.com
+  app:
+    appId: appsoufiane
     privateKey:
-      path: xxx
+      path: /Users/yinan.liu/Projects/certs/appSoufianneprivatekey.pem
+  bot:
+    username: wdkbot
+    privateKey:
+      path: /Users/yinan.liu/Projects/certs/privatekey.pem
 
 logging:
   level:

--- a/workflow-bot-app/src/main/resources/application.yaml
+++ b/workflow-bot-app/src/main/resources/application.yaml
@@ -39,7 +39,7 @@ spring:
     username: sa
     password:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:process_engine;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:file:~/.data/process_engine;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;AUTO_SERVER=TRUE
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/IntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/IntegrationTest.java
@@ -45,6 +45,7 @@ import org.camunda.bpm.engine.HistoryService;
 import org.camunda.bpm.engine.RepositoryService;
 import org.camunda.bpm.engine.history.HistoricActivityInstance;
 import org.camunda.bpm.engine.history.HistoricProcessInstance;
+import org.camunda.bpm.engine.history.HistoricVariableInstance;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,6 +59,7 @@ import org.springframework.test.context.ContextConfiguration;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -263,6 +265,18 @@ public abstract class IntegrationTest {
       return processInstance.getState().equals("COMPLETED");
     }
     return false;
+  }
+
+  public static Map<String, Object> getVariable(String processId, String name) {
+    HistoricVariableInstance var = historyService.createHistoricVariableInstanceQuery()
+        .processInstanceId(processId)
+        .variableName(name)
+        .singleResult();
+    if (var == null) {
+      return Collections.emptyMap();
+    } else {
+      return new HashMap<>((Map<String, Object>) var.getValue());
+    }
   }
 
   public static Optional<String> lastProcess() {

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/SendMessageIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/SendMessageIntegrationTest.java
@@ -54,7 +54,10 @@ class SendMessageIntegrationTest extends IntegrationTest {
     engine.deploy(workflow);
     engine.onEvent(messageReceived("/message"));
 
-    verify(messageService, timeout(5000)).send(anyString(), any(Message.class));
+    ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);
+    verify(messageService, timeout(5000)).send(anyString(), captor.capture());
+    Message sent = captor.getValue();
+    assertThat(sent.getData()).contains("id", "123456");
 
     assertThat(workflow).isExecuted()
         .hasOutput(String.format(OUTPUTS_MSG_KEY, "sendMessage1"), message)

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/api/v1/WorkflowsApiControllerTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/api/v1/WorkflowsApiControllerTest.java
@@ -278,7 +278,7 @@ class WorkflowsApiControllerTest {
 
     WorkflowDefinitionView workflowDefinitionView = WorkflowDefinitionView.builder()
         .workflowId(workflowId)
-        .variables(Collections.emptyList())
+        .variables(Collections.emptyMap())
         .flowNodes(Arrays.asList(activity0, event, activity1))
         .build();
 

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/engine/WorkflowDirectGraphBuilderTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/engine/WorkflowDirectGraphBuilderTest.java
@@ -55,6 +55,8 @@ class WorkflowDirectGraphBuilderTest {
     WorkflowDirectGraph directGraph = workflowDirectGraphBuilder.build();
     assertThat(directGraph.getDictionary()).hasSize(8);
     assertThat(directGraph.getStartEvents()).hasSize(1);
+    assertThat(directGraph.getVariables()).hasSize(1);
+    assertThat(directGraph.getVariables()).containsKey("administrator");
   }
 
   @Test
@@ -66,5 +68,6 @@ class WorkflowDirectGraphBuilderTest {
     assertThat(directGraph.getDictionary()).hasSize(8);
     assertThat(directGraph.readChildren("scriptTrue").getGateway()).isEqualTo(WorkflowDirectGraph.Gateway.PARALLEL);
     assertThat(directGraph.getStartEvents()).hasSize(1);
+    assertThat(directGraph.getVariables()).containsKey("allOf");
   }
 }

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/engine/camunda/monitoring/repository/VariableCmdaApiQueryRepositoryTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/engine/camunda/monitoring/repository/VariableCmdaApiQueryRepositoryTest.java
@@ -39,7 +39,7 @@ class VariableCmdaApiQueryRepositoryTest {
     when(variables.getRevision()).thenReturn(1);
     when(variables.getCreateTime()).thenReturn(new Date());
     // when
-    VariablesDomain global = queryRepository.findGlobalVarsByWorkflowInstanceId("id");
+    VariablesDomain global = queryRepository.findVarsByWorkflowInstanceIdAndVarName("id", "variables");
     // then
     assertThat(global.getOutputs()).hasSize(1);
     assertThat(global.getOutputs().get("key")).isEqualTo("value");

--- a/workflow-bot-app/src/test/resources/message/send-message-on-message.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/send-message-on-message.swadl.yaml
@@ -8,3 +8,4 @@ activities:
       to:
         stream-id: "123"
       content: <messageML>Hello!</messageML>
+      data: "{ \"id\": \"123456\"}"

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/engine/executor/ActivityExecutorContext.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/engine/executor/ActivityExecutorContext.java
@@ -13,6 +13,8 @@ public interface ActivityExecutorContext<T> {
    */
   String OUTPUTS = "outputs";
 
+  String ERROR = "error";
+
   /**
    * ${variables.myVariable}
    */

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/SendMessage.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/SendMessage.java
@@ -17,6 +17,7 @@ public class SendMessage extends OboActivity {
   @Nullable private String content;
   @Nullable private To to;
   @Nullable private List<Attachment> attachments;
+  @Nullable private String data;
 
   @SuppressWarnings("unchecked")
   public void setContent(Object content) {

--- a/workflow-language/src/main/resources/swadl-schema-1.0.json
+++ b/workflow-language/src/main/resources/swadl-schema-1.0.json
@@ -1701,6 +1701,10 @@
                 "content": {
                     "$ref": "#/definitions/content-inner"
                 },
+                "data": {
+                    "description": "Message data, which is a Json string and sent along with message.",
+                    "type": "string"
+                },
                 "attachments": {
                     "description": "One or more attachments to be sent along with the message.",
                     "type": "array",


### PR DESCRIPTION
 - Add a new data field to SendMessage activity to support interative templates

 - Add errors field to activity API, show error message if the process fails due to un-handled exception

### Description
close #150

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced a ticket in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
