### PR TITLE
Use message component for exclusive form reply event

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/WorkflowNode.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/WorkflowNode.java
@@ -60,4 +60,8 @@ public class WorkflowNode {
   public String getIfCondition(String parentId) {
     return this.ifConditions.get(parentId);
   }
+
+  public boolean isNotExclusiveFormReply() {
+    return getElementType() == WorkflowNodeType.FORM_REPLIED_EVENT && !getEvent().getFormReplied().getExclusive();
+  }
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/BpmnBuilderHelper.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/BpmnBuilderHelper.java
@@ -1,6 +1,7 @@
 package com.symphony.bdk.workflow.engine.camunda.bpmn;
 
 import com.symphony.bdk.workflow.engine.WorkflowDirectGraph;
+import com.symphony.bdk.workflow.engine.WorkflowNode;
 import com.symphony.bdk.workflow.engine.WorkflowNodeType;
 
 import lombok.experimental.UtilityClass;
@@ -26,7 +27,11 @@ public class BpmnBuilderHelper {
       WorkflowDirectGraph.NodeChildren currentNodeChildren) {
     return currentNodeChildren.getChildren()
         .stream()
-        .noneMatch(s -> context.readWorkflowNode(s).getElementType() == WorkflowNodeType.SIGNAL_EVENT);
+        .noneMatch(s -> {
+          WorkflowNode workflowNode = context.readWorkflowNode(s);
+          return workflowNode.getElementType() == WorkflowNodeType.SIGNAL_EVENT
+              || workflowNode.getElementType() == WorkflowNodeType.FORM_REPLIED_EVENT;
+        });
   }
 
   public static boolean hasAllConditionalChildren(BuildProcessContext context,

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/CamundaBpmnBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/CamundaBpmnBuilder.java
@@ -168,16 +168,7 @@ public class CamundaBpmnBuilder {
 
   private AbstractFlowNodeBuilder<?, ?> exclusiveSubTreeNodes(String currentNodeId, WorkflowNodeType currentNodeType,
       AbstractFlowNodeBuilder<?, ?> builder, BuildProcessContext context, NodeChildren currentNodeChildren) {
-    if (currentNodeType == WorkflowNodeType.FORM_REPLIED_EVENT) {
-      log.trace("the node [{}] itself is a form replied event", currentNodeId);
-      boolean activities = hasActivitiesOnly(context, currentNodeChildren);
-      boolean conditional = hasConditionalString(context, currentNodeChildren, currentNodeId);
-      log.trace("are the children of the node [{}]'s all activities ? [{}], is there any condition in children ? [{}]",
-          currentNodeId, activities, conditional);
-      builder = addGateway(currentNodeId, builder, activities, conditional, currentNodeChildren.getChildren().size());
-      return builder;
-    }
-    if (hasFormRepliedEvent(context, currentNodeChildren)) {
+    if (hasNoExclusiveFormReplyChildren(context, currentNodeChildren)) {
       log.trace("one of [{}] children is a form replied event", currentNodeId);
       return builder;
     }
@@ -237,9 +228,10 @@ public class CamundaBpmnBuilder {
     }
   }
 
-  private boolean hasFormRepliedEvent(BuildProcessContext context, NodeChildren currentNodeChildren) {
+  private boolean hasNoExclusiveFormReplyChildren(BuildProcessContext context, NodeChildren currentNodeChildren) {
     return currentNodeChildren.getChildren()
         .stream()
-        .anyMatch(s -> context.readWorkflowNode(s).getElementType() == WorkflowNodeType.FORM_REPLIED_EVENT);
+        .map(context::readWorkflowNode)
+        .anyMatch(WorkflowNode::isNotExclusiveFormReply);
   }
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/AbstractNodeBpmnBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/AbstractNodeBpmnBuilder.java
@@ -9,6 +9,7 @@ import com.symphony.bdk.workflow.engine.camunda.bpmn.BuildProcessContext;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.camunda.bpm.model.bpmn.builder.AbstractFlowNodeBuilder;
 import org.camunda.bpm.model.bpmn.builder.AbstractGatewayBuilder;
+import org.camunda.bpm.model.bpmn.builder.SubProcessBuilder;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -35,11 +36,6 @@ public abstract class AbstractNodeBpmnBuilder implements WorkflowNodeBpmnBuilder
       // then connect the activity
       if (context.hasEventSubProcess() && context.getParents(element.getId()).size() > 1) {
         builder = endEventSubProcess(context, builder);
-        // since the sub process is ended here, and the child node is going to be connected by this ended sub process,
-        // therefore, all other branches remove their same child and are going to be ended inside the sub process.
-        List<String> parents =
-            context.getParents(element.getId()).stream().filter(k -> !k.equals(parentId)).collect(Collectors.toList());
-        parents.forEach(parent -> context.getChildren(parent).removeChild(element.getId()));
       }
       return build(element, parentId, builder, context);
     }
@@ -64,7 +60,9 @@ public abstract class AbstractNodeBpmnBuilder implements WorkflowNodeBpmnBuilder
   }
 
   protected void connectToExistingNode(String nodeId, AbstractFlowNodeBuilder<?, ?> builder) {
-    builder.connectTo(nodeId);
+    if(!(builder instanceof SubProcessBuilder)){
+      builder.connectTo(nodeId);
+    }
   }
 
   protected abstract AbstractFlowNodeBuilder<?, ?> build(WorkflowNode element, String parentId,

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/ActivityExpiredNodeBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/ActivityExpiredNodeBuilder.java
@@ -18,7 +18,7 @@ public class ActivityExpiredNodeBuilder extends ActivityNodeBuilder {
   @Override
   public AbstractFlowNodeBuilder<?, ?> build(WorkflowNode element, String parentId,
       AbstractFlowNodeBuilder<?, ?> builder, BuildProcessContext context) throws JsonProcessingException {
-    if (hasFormReplyParent(element, context)) {
+    if (hasNoExclusiveFormReplyParent(element, context)) {
       if (context.hasTimeoutSubProcess()) {
         builder = context.removeLastSubProcessTimeoutBuilder();
       } else {
@@ -37,11 +37,11 @@ public class ActivityExpiredNodeBuilder extends ActivityNodeBuilder {
     return builder;
   }
 
-  private boolean hasFormReplyParent(WorkflowNode element, BuildProcessContext context) {
+  private boolean hasNoExclusiveFormReplyParent(WorkflowNode element, BuildProcessContext context) {
     return context.getParents(element.getId())
         .stream()
         .map(context::readWorkflowNode)
-        .anyMatch(node -> node.getElementType() == WorkflowNodeType.FORM_REPLIED_EVENT);
+        .anyMatch(WorkflowNode::isNotExclusiveFormReply);
   }
 
   @Override

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/FormRepliedNodeBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/FormRepliedNodeBuilder.java
@@ -28,8 +28,9 @@ public class FormRepliedNodeBuilder extends AbstractNodeBpmnBuilder {
   @Override
   public AbstractFlowNodeBuilder<?, ?> build(WorkflowNode element, String parentId,
       AbstractFlowNodeBuilder<?, ?> builder, BuildProcessContext context) {
-    if (builder instanceof ParallelGatewayBuilder) {
+    if (builder instanceof ParallelGatewayBuilder || element.getEvent().getFormReplied().getExclusive()) {
       return builder.intermediateCatchEvent()
+          .camundaExecutionListenerClass(ExecutionListener.EVENTNAME_START, FormVariableListener.class)
           .camundaAsyncBefore()
           .name(element.getId())
           .message(element.getId());
@@ -50,7 +51,7 @@ public class FormRepliedNodeBuilder extends AbstractNodeBpmnBuilder {
           .camundaAsyncBefore()
           // run multiple instances of the sub process (i.e. multiple replies) if it's true,
           // otherwise execute only once, as exclusive
-          .interrupting(element.getEvent().getFormReplied().getExclusive())
+          .interrupting(false)
           .message(element.getId())
           .name(element.getId());
     }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/SignalNodeBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/SignalNodeBuilder.java
@@ -7,7 +7,6 @@ import com.symphony.bdk.workflow.engine.camunda.bpmn.BuildProcessContext;
 
 import org.camunda.bpm.model.bpmn.builder.AbstractCatchEventBuilder;
 import org.camunda.bpm.model.bpmn.builder.AbstractFlowNodeBuilder;
-import org.camunda.bpm.model.bpmn.builder.AbstractGatewayBuilder;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -53,10 +52,10 @@ public class SignalNodeBuilder extends AbstractNodeBpmnBuilder {
    */
   private boolean hasFormRepliedEventBrother(BuildProcessContext context, String parentId) {
     return context.readChildren(parentId) != null
-        && context.readChildren(parentId).getGateway() != WorkflowDirectGraph.Gateway.PARALLEL && context.readChildren(
-            parentId).getChildren()
-        .stream()
-        .anyMatch(s -> context.readWorkflowNode(s).getElementType() == WorkflowNodeType.FORM_REPLIED_EVENT);
+        && context.readChildren(parentId).getGateway() != WorkflowDirectGraph.Gateway.PARALLEL
+        && context.readChildren(parentId).getChildren()
+          .stream().map(context::readWorkflowNode)
+          .anyMatch(WorkflowNode::isNotExclusiveFormReply);
   }
 
   @Override

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/UpdateMessageExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/UpdateMessageExecutor.java
@@ -9,20 +9,25 @@ import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
 import com.symphony.bdk.workflow.swadl.v1.activity.message.UpdateMessage;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
 public class UpdateMessageExecutor implements ActivityExecutor<UpdateMessage> {
 
   @Override
   public void execute(ActivityExecutorContext<UpdateMessage> execution) throws IOException {
     String messageId = execution.getActivity().getMessageId();
+    log.debug("Updating message [{}]", messageId);
     V4Message messageToUpdate =  execution.bdk().messages().getMessage(messageId);
     String content = extractContent(execution);
     Boolean silent = execution.getActivity().getSilent();
+    log.debug("Updating message silently ? [{}]", silent);
     Message message = Message.builder().silent(silent).content(content).build();
     V4Message updatedMessage = execution.bdk().messages().update(messageToUpdate, message);
 

--- a/workflow-bot-app/src/main/resources/application.yaml
+++ b/workflow-bot-app/src/main/resources/application.yaml
@@ -39,7 +39,7 @@ spring:
     username: sa
     password:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:file:~/.data/process_engine;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;AUTO_SERVER=TRUE
+    url: jdbc:h2:mem:process_engine;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/FormReplyIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/FormReplyIntegrationTest.java
@@ -22,10 +22,9 @@ import com.symphony.bdk.workflow.swadl.v1.Workflow;
 
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
@@ -329,6 +328,7 @@ class FormReplyIntegrationTest extends IntegrationTest {
     // trigger workflow execution
     engine.onEvent(messageReceived("/init"));
     verify(messageService, timeout(5000)).send(anyString(), contains("form"));
+    clearInvocations(messageService);
     await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
       engine.onEvent(form("msgId", "init", Collections.singletonMap("action", "x")));
       assertThat(workflow).executed("init", "update");
@@ -353,7 +353,7 @@ class FormReplyIntegrationTest extends IntegrationTest {
     verify(messageService, timeout(5000)).send(anyString(), contains("form"));
     await().atMost(1, TimeUnit.SECONDS).untilAsserted(() -> {
       engine.onEvent(messageReceived("/hey"));
-      assertThat(workflow).executed("init", "message-received_/hey", "update");
+      assertThat(workflow).executed("init", "update");
     });
   }
 

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/MonitoringApiIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/MonitoringApiIntegrationTest.java
@@ -445,9 +445,9 @@ class MonitoringApiIntegrationTest extends IntegrationTest {
         .body("globalVariables.outputs", equalTo(Collections.EMPTY_MAP))
         .body("globalVariables.revision", equalTo(0))
         .body("globalVariables.updateTime", not(empty()))
-        .body("error.activityId",equalTo("testingWorkflow1SendMsg1"))
-        .body("error.message",equalTo("Unauthorized"))
-        .body("error.activityInstId",not(empty()));
+        .body("error.activityId", equalTo("testingWorkflow1SendMsg1"))
+        .body("error.message", equalTo("Unauthorized"))
+        .body("error.activityInstId", not(empty()));
 
     engine.undeploy(workflow.getId());
   }

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/engine/WorkflowDirectGraphBuilderTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/engine/WorkflowDirectGraphBuilderTest.java
@@ -32,7 +32,7 @@ class WorkflowDirectGraphBuilderTest {
     Workflow workflow = SwadlParser.fromYaml(getClass().getResourceAsStream("/graph/approval.swadl.yaml"));
     workflowDirectGraphBuilder = new WorkflowDirectGraphBuilder(workflow, eventMapper);
     WorkflowDirectGraph directGraph = workflowDirectGraphBuilder.build();
-    assertThat(directGraph.getDictionary()).hasSize(8);
+    assertThat(directGraph.getDictionary()).hasSize(9);
     assertThat(directGraph.getStartEvents()).hasSize(1);
   }
 
@@ -53,7 +53,7 @@ class WorkflowDirectGraphBuilderTest {
         SwadlParser.fromYaml(getClass().getResourceAsStream("/graph/connection-admin-approval.swadl.yaml"));
     workflowDirectGraphBuilder = new WorkflowDirectGraphBuilder(workflow, eventMapper);
     WorkflowDirectGraph directGraph = workflowDirectGraphBuilder.build();
-    assertThat(directGraph.getDictionary()).hasSize(8);
+    assertThat(directGraph.getDictionary()).hasSize(9);
     assertThat(directGraph.getStartEvents()).hasSize(1);
     assertThat(directGraph.getVariables()).hasSize(1);
     assertThat(directGraph.getVariables()).containsKey("administrator");


### PR DESCRIPTION
Revert back to the original solution for exclusive FormRepliedEvent. Using subprocess is too much complex to handle the form reply use cases we can have right now.

### Description
close #152 

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced a ticket in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
