### PR TITLE
Split current workflow node type into type and group

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/api/v1/dto/TaskDefinitionView.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/api/v1/dto/TaskDefinitionView.java
@@ -13,7 +13,8 @@ import java.util.List;
 @NoArgsConstructor
 public class TaskDefinitionView {
   private String nodeId;
-  private TaskTypeEnum type;
+  private String type;
+  private String group;
   private List<String> parents;
   private List<String> children;
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/api/v1/dto/TaskTypeEnum.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/api/v1/dto/TaskTypeEnum.java
@@ -76,7 +76,24 @@ public enum TaskTypeEnum {
 
   private final String text;
 
+  private final static String EVENT = "EVENT";
+  private final static String ACTIVITY = "ACTIVITY";
+
   public static TaskTypeEnum findByAbbr(final String abbr) {
     return Arrays.stream(values()).filter(value -> value.text.equals(abbr)).findFirst().orElse(null);
+  }
+
+  public String toType() {
+    if (name().endsWith("_EVENT")) {
+      return name().substring(0, name().length() - 6);
+    }
+    return name().substring(0, name().length() - 9);
+  }
+
+  public String toGroup() {
+    if (name().endsWith("_EVENT")) {
+      return EVENT;
+    }
+    return ACTIVITY;
   }
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/monitoring/service/MonitoringService.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/monitoring/service/MonitoringService.java
@@ -119,11 +119,13 @@ public class MonitoringService {
               .children(directGraph.getChildren(workflowNode.getId()).getChildren());
 
       if (workflowNode.getActivity() != null) {
-        taskDefinitionViewBuilder.type(
-            TaskTypeEnum.findByAbbr(workflowNode.getActivity().getClass().getSimpleName()));
+        TaskTypeEnum taskTypeEnum = TaskTypeEnum.findByAbbr(workflowNode.getActivity().getClass().getSimpleName());
+        taskDefinitionViewBuilder.type(taskTypeEnum.toType());
+        taskDefinitionViewBuilder.group(taskTypeEnum.toGroup());
       } else if (workflowNode.getEvent() != null) {
-        taskDefinitionViewBuilder.type(
-            TaskTypeEnum.findByAbbr(workflowNode.getEvent().getEventType()));
+        TaskTypeEnum taskTypeEnum = TaskTypeEnum.findByAbbr(workflowNode.getEvent().getEventType());
+        taskDefinitionViewBuilder.type(taskTypeEnum.toType());
+        taskDefinitionViewBuilder.group(taskTypeEnum.toGroup());
       }
 
       activities.add(taskDefinitionViewBuilder.build());

--- a/workflow-bot-app/src/main/resources/application.yaml
+++ b/workflow-bot-app/src/main/resources/application.yaml
@@ -39,7 +39,7 @@ spring:
     username: sa
     password:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:file:~/.data/process_engine;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;AUTO_SERVER=TRUE
+    url: jdbc:h2:mem:process_engine;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/MonitoringApiIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/MonitoringApiIntegrationTest.java
@@ -2,7 +2,6 @@ package com.symphony.bdk.workflow;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -12,7 +11,6 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.when;
 
 import com.symphony.bdk.core.service.message.model.Message;
@@ -445,9 +443,9 @@ class MonitoringApiIntegrationTest extends IntegrationTest {
         .body("globalVariables.outputs", equalTo(Collections.EMPTY_MAP))
         .body("globalVariables.revision", equalTo(0))
         .body("globalVariables.updateTime", not(empty()))
-        .body("error.activityId",equalTo("testingWorkflow1SendMsg1"))
-        .body("error.message",equalTo("Unauthorized"))
-        .body("error.activityInstId",not(empty()));
+        .body("error.activityId", equalTo("testingWorkflow1SendMsg1"))
+        .body("error.message", equalTo("Unauthorized"))
+        .body("error.activityInstId", not(empty()));
 
     engine.undeploy(workflow.getId());
   }
@@ -865,21 +863,24 @@ class MonitoringApiIntegrationTest extends IntegrationTest {
     // expected flow nodes
     TaskDefinitionView expectedSendMessageActivity1 = TaskDefinitionView.builder()
         .nodeId("testingWorkflow1SendMsg1")
-        .type(TaskTypeEnum.SEND_MESSAGE_ACTIVITY)
+        .type(TaskTypeEnum.SEND_MESSAGE_ACTIVITY.toType())
+        .group(TaskTypeEnum.SEND_MESSAGE_ACTIVITY.toGroup())
         .parents(Collections.singletonList("message-received_/testingWorkflow1"))
         .children(Collections.singletonList("testingWorkflow1SendMsg2"))
         .build();
 
     TaskDefinitionView expectedSendMessageActivity2 = TaskDefinitionView.builder()
         .nodeId("testingWorkflow1SendMsg2")
-        .type(TaskTypeEnum.SEND_MESSAGE_ACTIVITY)
+        .type(TaskTypeEnum.SEND_MESSAGE_ACTIVITY.toType())
+        .group(TaskTypeEnum.SEND_MESSAGE_ACTIVITY.toGroup())
         .parents(Collections.singletonList("testingWorkflow1SendMsg1"))
         .children(Collections.emptyList())
         .build();
 
     TaskDefinitionView expectedMessageReceivedEventTask = TaskDefinitionView.builder()
         .nodeId("message-received_/testingWorkflow1")
-        .type(TaskTypeEnum.MESSAGE_RECEIVED_EVENT)
+        .type(TaskTypeEnum.MESSAGE_RECEIVED_EVENT.toType())
+        .group(TaskTypeEnum.MESSAGE_RECEIVED_EVENT.toGroup())
         .parents(Collections.emptyList())
         .children(Collections.singletonList("testingWorkflow1SendMsg1"))
         .build();

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/api/v1/WorkflowsApiControllerTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/api/v1/WorkflowsApiControllerTest.java
@@ -265,15 +265,18 @@ class WorkflowsApiControllerTest {
     final String workflowId = "testWorkflowId";
 
     TaskDefinitionView activity0 =
-        new TaskDefinitionView("activity0", TaskTypeEnum.SEND_MESSAGE_ACTIVITY, Collections.emptyList(),
+        new TaskDefinitionView("activity0", TaskTypeEnum.SEND_MESSAGE_ACTIVITY.toType(),
+            TaskTypeEnum.SEND_MESSAGE_ACTIVITY.toGroup(), Collections.emptyList(),
             Collections.singletonList("event0"));
 
     TaskDefinitionView event =
-        new TaskDefinitionView("event0", TaskTypeEnum.ROOM_UPDATED_EVENT, Collections.singletonList("activity0"),
+        new TaskDefinitionView("event0", TaskTypeEnum.ROOM_UPDATED_EVENT.toType(),
+            TaskTypeEnum.ROOM_UPDATED_EVENT.toGroup(), Collections.singletonList("activity0"),
             Collections.singletonList("activity1"));
 
     TaskDefinitionView activity1 =
-        new TaskDefinitionView("activity1", TaskTypeEnum.SEND_MESSAGE_ACTIVITY, Collections.singletonList("event0"),
+        new TaskDefinitionView("activity1", TaskTypeEnum.SEND_MESSAGE_ACTIVITY.toType(),
+            TaskTypeEnum.SEND_MESSAGE_ACTIVITY.toGroup(), Collections.singletonList("event0"),
             Collections.emptyList());
 
     WorkflowDefinitionView workflowDefinitionView = WorkflowDefinitionView.builder()
@@ -293,17 +296,20 @@ class WorkflowsApiControllerTest {
         .andExpect(jsonPath("$.variables").isEmpty())
 
         .andExpect(jsonPath("$.flowNodes[0].nodeId").value("activity0"))
-        .andExpect(jsonPath("$.flowNodes[0].type").value("SEND_MESSAGE_ACTIVITY"))
+        .andExpect(jsonPath("$.flowNodes[0].type").value("SEND_MESSAGE"))
+        .andExpect(jsonPath("$.flowNodes[0].group").value("ACTIVITY"))
         .andExpect(jsonPath("$.flowNodes[0].parents").isEmpty())
         .andExpect(jsonPath("$.flowNodes[0].children[0]").value("event0"))
 
         .andExpect(jsonPath("$.flowNodes[1].nodeId").value("event0"))
-        .andExpect(jsonPath("$.flowNodes[1].type").value("ROOM_UPDATED_EVENT"))
+        .andExpect(jsonPath("$.flowNodes[1].type").value("ROOM_UPDATED"))
+        .andExpect(jsonPath("$.flowNodes[1].group").value("EVENT"))
         .andExpect(jsonPath("$.flowNodes[1].parents[0]").value("activity0"))
         .andExpect(jsonPath("$.flowNodes[1].children[0]").value("activity1"))
 
         .andExpect(jsonPath("$.flowNodes[2].nodeId").value("activity1"))
-        .andExpect(jsonPath("$.flowNodes[2].type").value("SEND_MESSAGE_ACTIVITY"))
+        .andExpect(jsonPath("$.flowNodes[2].type").value("SEND_MESSAGE"))
+        .andExpect(jsonPath("$.flowNodes[2].group").value("ACTIVITY"))
         .andExpect(jsonPath("$.flowNodes[2].parents[0]").value("event0"))
         .andExpect(jsonPath("$.flowNodes[2].children").isEmpty());
   }

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/monitoring/service/MonitoringServiceTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/monitoring/service/MonitoringServiceTest.java
@@ -245,7 +245,8 @@ class MonitoringServiceTest {
     assertThat(definitionView.getFlowNodes()).hasSize(2);
     assertThat(definitionView.getFlowNodes().get(0).getChildren()).hasSize(1);
     assertThat(definitionView.getFlowNodes().get(1).getParents()).hasSize(1);
-    assertThat(definitionView.getFlowNodes().get(0).getType()).isEqualTo(TaskTypeEnum.SEND_MESSAGE_ACTIVITY);
+    assertThat(definitionView.getFlowNodes().get(0).getType()).isEqualTo("SEND_MESSAGE");
+    assertThat(definitionView.getFlowNodes().get(0).getGroup()).isEqualTo("ACTIVITY");
   }
 
   @Test


### PR DESCRIPTION
This split make it easier to distinguish the workflow node's type and group for UI to build up the component for nodes.

### Description
close #165 

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced a ticket in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
