### PR TITLE
Fix NPE bug in a definition having a FormRepliedEvent

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/WorkflowDirectGraphBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/WorkflowDirectGraphBuilder.java
@@ -16,6 +16,7 @@ import com.symphony.bdk.workflow.swadl.v1.Workflow;
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 import com.symphony.bdk.workflow.swadl.v1.activity.RelationalEvents;
 import com.symphony.bdk.workflow.swadl.v1.event.ActivityCompletedEvent;
+import com.symphony.bdk.workflow.swadl.v1.event.ActivityExpiredEvent;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -217,6 +218,7 @@ public class WorkflowDirectGraphBuilder {
     if (!directGraph.isRegistered(timeoutEventId)) {
       EventWithTimeout timeoutEvent = new EventWithTimeout();
       timeoutEvent.setTimeout(timeoutValue);
+      timeoutEvent.setActivityExpired(new ActivityExpiredEvent());
       directGraph.registerToDictionary(timeoutEventId, new WorkflowNode().id(timeoutEventId)
           .event(timeoutEvent)
           .elementType(WorkflowNodeType.ACTIVITY_EXPIRED_EVENT));

--- a/workflow-bot-app/src/test/resources/monitoring/testing-workflow-definition.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/monitoring/testing-workflow-definition.swadl.yaml
@@ -1,0 +1,23 @@
+id: testingWorkflow1
+activities:
+  - send-message:
+      id: testingWorkflow1SendMsg1
+      on:
+        message-received:
+          content: "/testingWorkflow1"
+      to:
+        stream-id: "123"
+      content: <messageML>Hello!</messageML>
+
+  - send-message:
+      id: sendForm
+      to:
+        stream-id: "123"
+      content: <form id="sendForm"><button type="action" name="x">Hi</button></form>
+
+  - send-message:
+      id: receiveForm
+      on:
+        form-replied:
+          form-id: sendForm
+      content: Hi Again


### PR DESCRIPTION
The bug is a regression following the change, in which we reverted the solution for an exclusive FormRepliedEvent not using camunda subprocess.

The NPE happens on the timeout event coming along with a form reply event, this extra event is automatically generated and was mising the event type.

The fix is to set the event type when this event is created.

### Description
Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced a ticket in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
