### PR TITLE
Make FormRepliedEvent as a start event

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/WorkflowValidator.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/WorkflowValidator.java
@@ -21,8 +21,7 @@ public class WorkflowValidator {
     }
     if (event instanceof EventWithTimeout && StringUtils.isNotEmpty(((EventWithTimeout) event).getTimeout())) {
       throw new InvalidActivityException(workflowId,
-          String.format("Workflow's starting activity %s must not have timeout",
-              activity.getId()));
+          String.format("Workflow's starting activity %s must not have timeout", activity.getId()));
     }
     // the given event might be a event from oneOf list, if so the following checked activities are acceptable.
     // here we want to forbidden having these activities from "on" section only
@@ -50,9 +49,4 @@ public class WorkflowValidator {
       throw new ActivityNotFoundException(workflowId, currentNodeId, activityId);
     }
   }
-
-  public Void returnVoid() {
-    return null;
-  }
-
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/WorkflowDirectGraphBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/WorkflowDirectGraphBuilder.java
@@ -140,11 +140,8 @@ public class WorkflowDirectGraphBuilder {
           condition.ifPresent(c -> directGraph.readWorkflowNode(activityId).addIfCondition(finalNodeId, c));
         }
       }
-      if (!(onEvents.isParallel() && (event.getActivityCompleted() != null || event.getActivityFailed() != null
-          || event.getActivityExpired() != null))) {
-        directGraph.getChildren(eventNodeId).addChild(activityId);
-        directGraph.addParent(activityId, eventNodeId);
-      }
+      directGraph.getChildren(eventNodeId).addChild(activityId);
+      directGraph.addParent(activityId, eventNodeId);
     }
   }
 
@@ -171,13 +168,15 @@ public class WorkflowDirectGraphBuilder {
       signalEvent.elementType(WorkflowNodeType.SIGNAL_EVENT);
 
       if (isFormRepliedEvent(event)) {
-        validateExistingNodeId(eventNodeId.substring(WorkflowEventToCamundaEvent.FORM_REPLY_PREFIX.length()),
-            activityId,
-            workflow.getId(), directGraph);
         signalEvent.elementType(WorkflowNodeType.FORM_REPLIED_EVENT);
 
-        if (!onEvents.isParallel() && StringUtils.isEmpty(timeout)) {
-          timeout = DEFAULT_FORM_REPLIED_EVENT_TIMEOUT;
+        if (activityIndex > 0) {
+          validateExistingNodeId(eventNodeId.substring(WorkflowEventToCamundaEvent.FORM_REPLY_PREFIX.length()),
+              activityId,
+              workflow.getId(), directGraph);
+          if (!onEvents.isParallel() && StringUtils.isEmpty(timeout)) {
+            timeout = DEFAULT_FORM_REPLIED_EVENT_TIMEOUT;
+          }
         }
       }
       if ((event instanceof EventWithTimeout && StringUtils.isNotEmpty(((EventWithTimeout) event).getTimeout()))

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/FormRepliedNodeBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/FormRepliedNodeBuilder.java
@@ -13,6 +13,7 @@ import org.camunda.bpm.engine.delegate.ExecutionListener;
 import org.camunda.bpm.model.bpmn.builder.AbstractFlowNodeBuilder;
 import org.camunda.bpm.model.bpmn.builder.EventSubProcessBuilder;
 import org.camunda.bpm.model.bpmn.builder.ParallelGatewayBuilder;
+import org.camunda.bpm.model.bpmn.builder.StartEventBuilder;
 import org.camunda.bpm.model.bpmn.builder.SubProcessBuilder;
 import org.springframework.stereotype.Component;
 
@@ -29,6 +30,13 @@ public class FormRepliedNodeBuilder extends AbstractNodeBpmnBuilder {
   public AbstractFlowNodeBuilder<?, ?> build(WorkflowNode element, String parentId,
       AbstractFlowNodeBuilder<?, ?> builder, BuildProcessContext context) {
     if (builder instanceof ParallelGatewayBuilder || element.getEvent().getFormReplied().getExclusive()) {
+      if (builder instanceof StartEventBuilder) {
+        return ((StartEventBuilder) builder).camundaExecutionListenerClass(ExecutionListener.EVENTNAME_START,
+                FormVariableListener.class)
+            .camundaAsyncBefore()
+            .name(element.getId())
+            .message(element.getId());
+      }
       return builder.intermediateCatchEvent()
           .camundaExecutionListenerClass(ExecutionListener.EVENTNAME_START, FormVariableListener.class)
           .camundaAsyncBefore()

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/variable/FormVariableListener.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/variable/FormVariableListener.java
@@ -31,7 +31,9 @@ public class FormVariableListener implements ExecutionListener {
       // there should be only one form.FORM_ID entry
       for (Map.Entry<String, Map<String, Object>> entry : form.entrySet()) {
         Object activityVariable = execution.getVariable(entry.getKey());
-        if (activityVariable instanceof Map) {
+        if (activityVariable == null) {
+          execution.setVariable(entry.getKey(), entry.getValue());
+        } else if (activityVariable instanceof Map) {
           // merge form.FORM_ID.FORM_REPLY_DATA into ACTIVITY_ID...
           // FORM_ID = ACTIVITY_ID
           // in the end we have ACTIVITY_ID.outputs... and ACTIVITY_ID.FORM_REPLY_DATA in the same variable

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/JoinIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/JoinIntegrationTest.java
@@ -1,14 +1,12 @@
 package com.symphony.bdk.workflow;
 
 import static com.symphony.bdk.workflow.custom.assertion.WorkflowAssert.assertThat;
-import static com.symphony.bdk.workflow.custom.assertion.WorkflowAssert.contains;
 import static com.symphony.bdk.workflow.custom.assertion.WorkflowAssert.content;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -48,7 +46,7 @@ public class JoinIntegrationTest extends IntegrationTest {
     Thread.sleep(1000);
     verify(messageService).send(eq(streamId), content("end join"));
     assertThat(workflow).executed("start", "scriptTrue", "scriptTrue_fork_gateway", "endMessage_join_gateway",
-        "endMessage_join_gateway", "endMessage");
+        "endMessage_join_gateway", "endMessage_join_gateway", "endMessage");
   }
 
   @SneakyThrows

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/MonitoringApiIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/MonitoringApiIntegrationTest.java
@@ -876,14 +876,6 @@ class MonitoringApiIntegrationTest extends IntegrationTest {
         .type(TaskTypeEnum.SEND_MESSAGE_ACTIVITY.toType())
         .group(TaskTypeEnum.SEND_MESSAGE_ACTIVITY.toGroup())
         .parents(Collections.singletonList("testingWorkflow1SendMsg1"))
-        .children(List.of(ChildView.of("sendForm_gateway")))
-        .build();
-
-    NodeDefinitionView expectedGateway = builder()
-        .nodeId("sendForm_gateway")
-        .type(TaskTypeEnum.GATEWAY_ONE_OF)
-        .group(TaskTypeEnum.GATEWAY)
-        .parents(Collections.singletonList("sendForm"))
         .children(List.of(ChildView.of("form-reply_sendForm"), ChildView.of("form-reply_sendForm_timeout", "expired")))
         .build();
 
@@ -899,7 +891,7 @@ class MonitoringApiIntegrationTest extends IntegrationTest {
         .nodeId("form-reply_sendForm")
         .type(TaskTypeEnum.FORM_REPLIED_EVENT.toType())
         .group(TaskTypeEnum.FORM_REPLIED_EVENT.toGroup())
-        .parents(Collections.singletonList("sendForm_gateway"))
+        .parents(Collections.singletonList("sendForm"))
         .children(Collections.singletonList(ChildView.of("receiveForm")))
         .build();
 
@@ -907,7 +899,7 @@ class MonitoringApiIntegrationTest extends IntegrationTest {
         .nodeId("form-reply_sendForm_timeout")
         .type(TaskTypeEnum.ACTIVITY_EXPIRED_EVENT.toType())
         .group(TaskTypeEnum.ACTIVITY_EXPIRED_EVENT.toGroup())
-        .parents(Collections.singletonList("sendForm_gateway"))
+        .parents(Collections.singletonList("sendForm"))
         .children(Collections.emptyList())
         .build();
 
@@ -920,7 +912,7 @@ class MonitoringApiIntegrationTest extends IntegrationTest {
         .build();
 
     List<NodeDefinitionView> expectedTaskDefinitions =
-        Arrays.asList(expectedSendMessageActivity1, expectedSendMessageActivity2, expectedGateway,
+        Arrays.asList(expectedSendMessageActivity1, expectedSendMessageActivity2,
             expectedMessageReceivedEventTask, expectedFormRepliedEventTask, expectedFormRepliedTimeoutEventTask,
             expectedReceiveFormTask);
 
@@ -974,14 +966,6 @@ class MonitoringApiIntegrationTest extends IntegrationTest {
         .type(TaskTypeEnum.SEND_MESSAGE_ACTIVITY.toType())
         .group(TaskTypeEnum.SEND_MESSAGE_ACTIVITY.toGroup())
         .parents(Collections.singletonList("message-received_/failure"))
-        .children(List.of(ChildView.of("first_gateway")))
-        .build();
-
-    NodeDefinitionView expectedGateway = builder()
-        .nodeId("first_gateway")
-        .type(TaskTypeEnum.GATEWAY_ONE_OF)
-        .group(TaskTypeEnum.GATEWAY)
-        .parents(Collections.singletonList("first"))
         .children(List.of(ChildView.of("second"), ChildView.of("fallback", "failed")))
         .build();
 
@@ -989,7 +973,7 @@ class MonitoringApiIntegrationTest extends IntegrationTest {
         .nodeId("second")
         .type(TaskTypeEnum.SEND_MESSAGE_ACTIVITY.toType())
         .group(TaskTypeEnum.SEND_MESSAGE_ACTIVITY.toGroup())
-        .parents(Collections.singletonList("first_gateway"))
+        .parents(Collections.singletonList("first"))
         .children(List.of(ChildView.of("fallback", "failed")))
         .build();
 
@@ -997,7 +981,7 @@ class MonitoringApiIntegrationTest extends IntegrationTest {
         .nodeId("fallback")
         .type(TaskTypeEnum.SEND_MESSAGE_ACTIVITY.toType())
         .group(TaskTypeEnum.SEND_MESSAGE_ACTIVITY.toGroup())
-        .parents(List.of("first_gateway", "second"))
+        .parents(List.of("first", "second"))
         .children(Collections.emptyList())
         .build();
 
@@ -1010,7 +994,7 @@ class MonitoringApiIntegrationTest extends IntegrationTest {
         .build();
 
     List<NodeDefinitionView> expectedTaskDefinitions =
-        Arrays.asList(expectedSendMessageActivity1, expectedGateway, expectedSendMessageActivity2,
+        Arrays.asList(expectedSendMessageActivity1, expectedSendMessageActivity2,
             expectedSendMessageFallback,
             expectedMessageReceivedEventTask);
 
@@ -1064,14 +1048,6 @@ class MonitoringApiIntegrationTest extends IntegrationTest {
         .type(TaskTypeEnum.SEND_MESSAGE_ACTIVITY.toType())
         .group(TaskTypeEnum.SEND_MESSAGE_ACTIVITY.toGroup())
         .parents(Collections.singletonList("message-received_/start"))
-        .children(List.of(ChildView.of("start_gateway")))
-        .build();
-
-    NodeDefinitionView expectedGateway = builder()
-        .nodeId("start_gateway")
-        .type(TaskTypeEnum.GATEWAY_ONE_OF)
-        .group(TaskTypeEnum.GATEWAY)
-        .parents(Collections.singletonList("start"))
         .children(List.of(ChildView.of("scriptTrue", "${variables.allOf == true}"), ChildView.of("scriptFalse")))
         .build();
 
@@ -1079,15 +1055,16 @@ class MonitoringApiIntegrationTest extends IntegrationTest {
         .nodeId("scriptTrue")
         .type(TaskTypeEnum.EXECUTE_SCRIPT_ACTIVITY.toType())
         .group(TaskTypeEnum.EXECUTE_SCRIPT_ACTIVITY.toGroup())
-        .parents(Collections.singletonList("start_gateway"))
-        .children(List.of(ChildView.of("scriptTrue_gateway")))
+        .parents(Collections.singletonList("start"))
+        .children(List.of(ChildView.of("message-received_/message"), ChildView.of("user-joined-room"),
+            ChildView.of("endMessage_join_gateway")))
         .build();
 
     NodeDefinitionView expectedScriptFalse = builder()
         .nodeId("scriptFalse")
         .type(TaskTypeEnum.EXECUTE_SCRIPT_ACTIVITY.toType())
         .group(TaskTypeEnum.EXECUTE_SCRIPT_ACTIVITY.toGroup())
-        .parents(List.of("start_gateway"))
+        .parents(List.of("start"))
         .children(Collections.emptyList())
         .build();
 
@@ -1099,19 +1076,11 @@ class MonitoringApiIntegrationTest extends IntegrationTest {
         .children(Collections.singletonList(ChildView.of("start")))
         .build();
 
-    NodeDefinitionView expectedForkGateway = builder()
-        .nodeId("scriptTrue_gateway")
-        .type(TaskTypeEnum.GATEWAY_ALL_OF)
-        .group(TaskTypeEnum.GATEWAY)
-        .parents(Collections.singletonList("scriptTrue"))
-        .children(List.of(ChildView.of("message-received_/message"), ChildView.of("user-joined-room")))
-        .build();
-
     NodeDefinitionView expectedReceiveMessageEnd = builder()
         .nodeId("message-received_/message")
         .type(TaskTypeEnum.MESSAGE_RECEIVED_EVENT.toType())
         .group(TaskTypeEnum.MESSAGE_RECEIVED_EVENT.toGroup())
-        .parents(List.of("scriptTrue_gateway"))
+        .parents(List.of("scriptTrue"))
         .children(List.of(ChildView.of("endMessage_join_gateway")))
         .build();
 
@@ -1119,7 +1088,7 @@ class MonitoringApiIntegrationTest extends IntegrationTest {
         .nodeId("user-joined-room")
         .type(TaskTypeEnum.USER_JOINED_ROOM_EVENT.toType())
         .group(TaskTypeEnum.USER_JOINED_ROOM_EVENT.toGroup())
-        .parents(Collections.singletonList("scriptTrue_gateway"))
+        .parents(Collections.singletonList("scriptTrue"))
         .children(List.of(ChildView.of("endMessage_join_gateway")))
         .build();
 
@@ -1127,7 +1096,7 @@ class MonitoringApiIntegrationTest extends IntegrationTest {
         .nodeId("endMessage_join_gateway")
         .type(TaskTypeEnum.GATEWAY_JOIN)
         .group(TaskTypeEnum.GATEWAY)
-        .parents(List.of("message-received_/message", "user-joined-room"))
+        .parents(List.of("message-received_/message", "user-joined-room", "scriptTrue"))
         .children(List.of(ChildView.of("endMessage")))
         .build();
 
@@ -1140,14 +1109,109 @@ class MonitoringApiIntegrationTest extends IntegrationTest {
         .build();
 
     List<NodeDefinitionView> expectedTaskDefinitions =
-        Arrays.asList(expectedMessageReceivedEventTask, expectedSendMessageStart, expectedGateway, expectedScriptTrue,
-            expectedScriptFalse,
-            expectedForkGateway, expectedReceiveMessageEnd, expectedUserJoinedGateway, expectedJoinGateway,
+        Arrays.asList(expectedMessageReceivedEventTask, expectedSendMessageStart, expectedScriptTrue,
+            expectedScriptFalse, expectedReceiveMessageEnd, expectedUserJoinedGateway, expectedJoinGateway,
             expectedSendMessageEnd);
 
     assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     assertThat(response.body().jsonPath().getString("workflowId")).isEqualTo("all-of-messages-received");
     assertThat(response.body().jsonPath().getMap("variables")).hasSize(1);
+
+    assertThat(nodeDefinitionViews)
+        .hasSameSizeAs(expectedTaskDefinitions)
+        .hasSameElementsAs(expectedTaskDefinitions);
+
+    engine.undeploy(workflow.getId());
+  }
+
+  @Test
+  void listWorkflow_allOf_onActivities_definitions() throws Exception {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/monitoring/allof-on-activities-definition.swadl.yaml"));
+
+    engine.undeploy(workflow.getId()); // clean any old running instance
+    engine.deploy(workflow);
+
+    // Wait for the workflow to get executed
+    Thread.sleep(1000);
+
+    Response response = given()
+        .header(X_MONITORING_TOKEN_HEADER_KEY, X_MONITORING_TOKEN_HEADER_VALUE)
+        .contentType(ContentType.JSON)
+        .when()
+        .get(String.format(LIST_WORKFLOW_DEFINITIONS_PATH, "diagram-test"))
+        .thenReturn();
+
+    // actual flow nodes
+    ObjectMapper objectMapper = new ObjectMapper();
+    List<NodeDefinitionView> nodeDefinitionViews = new ArrayList<>();
+    List<Object> flowNodes = response.body().jsonPath().getList("flowNodes");
+
+    flowNodes.forEach(flowNode -> {
+      try {
+        nodeDefinitionViews.add(
+            objectMapper.readValue(objectMapper.writeValueAsString(flowNode), NodeDefinitionView.class));
+      } catch (JsonProcessingException e) {
+        e.printStackTrace();
+        fail("Unexpected error when converting api response to TaskDefinitionView class");
+      }
+    });
+
+    NodeDefinitionView messageReceived = builder()
+        .nodeId("message-received_diagram")
+        .type(TaskTypeEnum.MESSAGE_RECEIVED_EVENT.toType())
+        .group(TaskTypeEnum.MESSAGE_RECEIVED_EVENT.toGroup())
+        .parents(Collections.emptyList())
+        .children(List.of(ChildView.of("init")))
+        .build();
+
+    // expected flow nodes
+    NodeDefinitionView expectedSendMessageStart = builder()
+        .nodeId("init")
+        .type(TaskTypeEnum.SEND_MESSAGE_ACTIVITY.toType())
+        .group(TaskTypeEnum.SEND_MESSAGE_ACTIVITY.toGroup())
+        .parents(Collections.singletonList("message-received_diagram"))
+        .children(List.of(ChildView.of("abc"), ChildView.of("def")))
+        .build();
+
+    NodeDefinitionView abc = builder()
+        .nodeId("abc")
+        .type(TaskTypeEnum.EXECUTE_SCRIPT_ACTIVITY.toType())
+        .group(TaskTypeEnum.EXECUTE_SCRIPT_ACTIVITY.toGroup())
+        .parents(Collections.singletonList("init"))
+        .children(List.of(ChildView.of("completed_join_gateway")))
+        .build();
+
+    NodeDefinitionView def = builder()
+        .nodeId("def")
+        .type(TaskTypeEnum.EXECUTE_SCRIPT_ACTIVITY.toType())
+        .group(TaskTypeEnum.EXECUTE_SCRIPT_ACTIVITY.toGroup())
+        .parents(Collections.singletonList("init"))
+        .children(List.of(ChildView.of("completed_join_gateway")))
+        .build();
+
+    NodeDefinitionView gateway = builder()
+        .nodeId("completed_join_gateway")
+        .type(TaskTypeEnum.GATEWAY_JOIN)
+        .group(TaskTypeEnum.GATEWAY)
+        .parents(List.of("abc", "def"))
+        .children(Collections.singletonList(ChildView.of("completed")))
+        .build();
+
+    NodeDefinitionView expectedSendMessageEnd = builder()
+        .nodeId("completed")
+        .type(TaskTypeEnum.SEND_MESSAGE_ACTIVITY.toType())
+        .group(TaskTypeEnum.SEND_MESSAGE_ACTIVITY.toGroup())
+        .parents(List.of("completed_join_gateway"))
+        .children(Collections.emptyList())
+        .build();
+
+    List<NodeDefinitionView> expectedTaskDefinitions =
+        Arrays.asList(messageReceived, expectedSendMessageStart, abc, def, gateway, expectedSendMessageEnd);
+
+    assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    assertThat(response.body().jsonPath().getString("workflowId")).isEqualTo("diagram-test");
+    assertThat(response.body().jsonPath().getMap("variables")).isEmpty();
 
     assertThat(nodeDefinitionViews)
         .hasSameSizeAs(expectedTaskDefinitions)

--- a/workflow-bot-app/src/test/resources/monitoring/allof-on-activities-definition.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/monitoring/allof-on-activities-definition.swadl.yaml
@@ -1,0 +1,30 @@
+id: diagram-test
+activities:
+  - send-message:
+      id: init
+      on:
+        message-received:
+          content: diagram
+      content: hello
+  - execute-script:
+      id: abc
+      on:
+        activity-completed:
+          activity-id: init
+      script: variables.abc = 'abc'
+  - execute-script:
+      id: def
+      on:
+        activity-completed:
+          activity-id: init
+      script: variables.def = 'def'
+
+  - send-message:
+      id: completed
+      on:
+        all-of:
+          - activity-completed:
+              activity-id: abc
+          - activity-completed:
+              activity-id: def
+      content: Done!


### PR DESCRIPTION
A FormRepliedEvent was not allowed to be start event in a workflow. With this commit, this becomes possible, if user has already a form defined in the room, the workflow is now able to catch the form reply to start a  workflow instance.

### Description
Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced a ticket in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
