### PR TITLE
Support timeout in monitoring api instances endpoints

### DIFF
--- a/postman/Symphony Workflow Developer Kit (WDK) APIs.postman_collection.json
+++ b/postman/Symphony Workflow Developer Kit (WDK) APIs.postman_collection.json
@@ -19,7 +19,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n  \"args\": {\n    \"content\": \"HELLO EVERYONE\",\n    \"streamId\": \"STREAM_ID\"\n  }\n}\n",
+					"raw": "{\n  \"args\": {\n    \"argKey1\": \"value\",\n    \"argkey2\": \"value\"\n  }\n}\n",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -62,7 +62,7 @@
 					}
 				],
 				"url": {
-					"raw": "http://localhost:8080/wdk/v1/workflows/:workflowId/instances?status=completed",
+					"raw": "http://localhost:8080/wdk/v1/workflows/:workflowId/instances?status=pending",
 					"protocol": "http",
 					"host": [
 						"localhost"
@@ -78,7 +78,7 @@
 					"query": [
 						{
 							"key": "status",
-							"value": "completed"
+							"value": "pending"
 						}
 					],
 					"variable": [
@@ -129,7 +129,7 @@
 				"header": [
 					{
 						"key": "X-Monitoring-Token",
-						"value": "",
+						"value": "myBestToken",
 						"type": "text"
 					}
 				],
@@ -143,7 +143,7 @@
 					}
 				},
 				"url": {
-					"raw": "http://localhost:8080/wdk/v1/workflows/:workflowId/instances/:instanceId/activities?started_before=2022-09-21T15:47:00Z&started_after=2022-09-21T15:46:00.939Z&finished_before=2022-09-21T15:46:00.939Z&finished_after=2022-09-21T15:46:00.939Z",
+					"raw": "http://localhost:8080/wdk/v1/workflows/:workflowId/instances/:instanceId/states?started_before=2022-09-21T15:47:00Z&started_after=2022-09-26T16:29:57.512Z&finished_before=2022-09-21T15:46:00.939Z&finished_after=2022-09-21T15:46:00.939Z",
 					"protocol": "http",
 					"host": [
 						"localhost"
@@ -156,7 +156,7 @@
 						":workflowId",
 						"instances",
 						":instanceId",
-						"activities"
+						"states"
 					],
 					"query": [
 						{
@@ -165,7 +165,7 @@
 						},
 						{
 							"key": "started_after",
-							"value": "2022-09-21T15:46:00.939Z"
+							"value": "2022-09-26T16:29:57.512Z"
 						},
 						{
 							"key": "finished_before",
@@ -237,7 +237,7 @@
 					}
 				],
 				"url": {
-					"raw": "http://localhost:8080/wdk/v1/workflows/:workflowId/instances/:instanceId/variables",
+					"raw": "http://localhost:8080/wdk/v1/workflows/:workflowId/instances/:instanceId/variables?updated_before=2022-09-26T16:31:13.505Z&updated_after=2022-09-26T16:30:01.303Z",
 					"protocol": "http",
 					"host": [
 						"localhost"
@@ -255,13 +255,11 @@
 					"query": [
 						{
 							"key": "updated_before",
-							"value": "2022-09-21T15:43:24.969Z",
-							"disabled": true
+							"value": "2022-09-26T16:31:13.505Z"
 						},
 						{
 							"key": "updated_after",
-							"value": "2022-09-21T15:43:24.969Z",
-							"disabled": true
+							"value": "2022-09-26T16:30:01.303Z"
 						}
 					],
 					"variable": [

--- a/workflow-bot-app/build.gradle
+++ b/workflow-bot-app/build.gradle
@@ -12,7 +12,7 @@ javadoc {
 dependencies {
     implementation project(':workflow-language')
 
-    implementation platform('org.finos.symphony.bdk:symphony-bdk-bom:2.9.0') {
+    implementation platform('org.finos.symphony.bdk:symphony-bdk-bom:2.10.0') {
         exclude group: 'org.slf4j', module: 'slf4j-api'
     }
     implementation platform('com.fasterxml.jackson:jackson-bom:2.13.4')
@@ -30,7 +30,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-cache'
 
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
-    runtimeOnly 'com.h2database:h2'
+    runtimeOnly ('com.h2database:h2') {
+        version {
+            strictly '1.4.200'
+        }
+    }
 
     implementation 'org.slf4j:slf4j-api:1.7.36'
     implementation 'ch.qos.logback:logback-classic:1.2.11'

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/WorkflowDirectGraphBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/WorkflowDirectGraphBuilder.java
@@ -205,7 +205,7 @@ public class WorkflowDirectGraphBuilder {
       // every event in the onfOf list, check if it is already registered, avoid repeating multiple of them
       String newTimeoutEventId = signalEvent.getId() + TIMEOUT_SUFFIX;
       String parentId = directGraph.getParents(signalEvent.getId()).get(0);
-      registerTimeoutEvent(directGraph, newTimeoutEventId, parentId, timeout);
+      registerTimeoutEvent(directGraph, newTimeoutEventId, signalEvent.getWrappedType(), parentId, timeout);
     }
   }
 
@@ -233,21 +233,22 @@ public class WorkflowDirectGraphBuilder {
     } else {
       String newTimeoutEvent = parentActivity + TIMEOUT_SUFFIX;
       String timeout = ((EventWithTimeout) parentNode.getEvent()).getTimeout();
-      registerTimeoutEvent(directGraph, newTimeoutEvent, grandParentId,
+      registerTimeoutEvent(directGraph, newTimeoutEvent, null, grandParentId,
           Optional.ofNullable(timeout).orElse(DEFAULT_FORM_REPLIED_EVENT_TIMEOUT));
       return newTimeoutEvent;
     }
   }
 
-  private void registerTimeoutEvent(WorkflowDirectGraph directGraph, String timeoutEventId, String parentId,
-      String timeoutValue) {
+  private void registerTimeoutEvent(WorkflowDirectGraph directGraph, String timeoutEventId, Class<?> nodeWrappedType,
+      String parentId, String timeoutValue) {
     if (!directGraph.isRegistered(timeoutEventId)) {
       EventWithTimeout timeoutEvent = new EventWithTimeout();
       timeoutEvent.setTimeout(timeoutValue);
       timeoutEvent.setActivityExpired(new ActivityExpiredEvent());
       directGraph.registerToDictionary(timeoutEventId, new WorkflowNode().id(timeoutEventId).eventId(timeoutEventId)
           .event(timeoutEvent)
-          .elementType(WorkflowNodeType.ACTIVITY_EXPIRED_EVENT));
+          .elementType(WorkflowNodeType.ACTIVITY_EXPIRED_EVENT)
+          .wrappedType(nodeWrappedType));
       directGraph.addParent(timeoutEventId, parentId);
       directGraph.getChildren(parentId).gateway(Gateway.EVENT_BASED).addChild(timeoutEventId);
     }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/monitoring/service/MonitoringService.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/monitoring/service/MonitoringService.java
@@ -48,7 +48,6 @@ public class MonitoringService {
   private final VariableQueryRepository variableQueryRepository;
   private final ObjectConverter objectConverter;
 
-  private static final String GATEWAY_SUFFIX = "_gateway";
 
   public List<WorkflowView> listAllWorkflows() {
     return objectConverter.convertCollection(workflowQueryRepository.findAll(), WorkflowView.class);

--- a/workflow-bot-app/src/test/resources/monitoring/testing-workflow-with-timeout.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/monitoring/testing-workflow-with-timeout.swadl.yaml
@@ -1,0 +1,19 @@
+id: testingWorkflowWithTimeout
+activities:
+  - send-message:
+      id: formid
+      on:
+        message-received:
+          content: "/sendForm"
+      to:
+        stream-id: "123"
+      content: <form id="formid"><button type="action" name="one">One</button></form>
+
+  - execute-script:
+      id: script
+      on:
+        form-replied:
+          form-id: formid
+        timeout: PT0.2S
+      script: |
+        println "____________________EXPIRED____________________"

--- a/workflow-language/build.gradle
+++ b/workflow-language/build.gradle
@@ -8,7 +8,7 @@ javadoc {
 }
 
 dependencies {
-    api platform('org.finos.symphony.bdk:symphony-bdk-bom:2.9.0')
+    api platform('org.finos.symphony.bdk:symphony-bdk-bom:2.10.0')
 
     api 'org.finos.symphony.bdk:symphony-bdk-core'
     api 'org.finos.symphony.bdk.ext:symphony-group-extension'


### PR DESCRIPTION
**Support timeout in monitoring api**
In this PR we added the support of timeout events in the workflow instance monitoring api. It was missing because the wrappedType attribute was not set in the WorkflowNode of a timeout event. This was causing a NP during the monitoring processing. 

**BDK upgrade**
For the same occasion, the BDK version has been upgraded to the latest 2.10.0. This version of BDK comes with the upgrade of spring-boot-dependencies where H2 database version was upgraded. This version of H2 is not compatible with Camunda, so the version has been strictly put in the build gradle to keep using h2 database 1.4.200.