### PR TITLE
Add inline template support for message activity

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -846,24 +846,33 @@ in [MessageML](https://docs.developers.symphony.com/building-bots-on-symphony/me
 Must contain at least one space. **In case the content is a form, the latter's id should be the same as the send-message
 activity one.**
 
-Content can
-be [MessageML](https://docs.developers.symphony.com/building-bots-on-symphony/messages/overview-of-messageml) with
+Content can be [MessageML](https://docs.developers.symphony.com/building-bots-on-symphony/messages/overview-of-messageml) with
 the `<messageML>` tags or can be simple text too (<messageML> are automatically added if needed).
 
-Content can either be set directly in the SWADL file as plain text (String) or it can be referenced from an external
-file (Object). When using an external file the content has to be defined as follows:
+Content can either be set directly in the SWADL file as plain text (String) or it can be a [Freemarker](https://freemarker.apache.org/) template. 
+
+Both inline template and external template file are supported.
+
+When using an inline template, the template content has to be defined as string to the `template` field:
 
 Key | Type | Required |
 ------------ | -------| --- |
 template | String | Yes |
 
-Both [Freemarker](https://freemarker.apache.org/) (.ftl) and mml.xml format are accepted as external files in the
-template field. By default, it will search for the file in the `./workflows` root folder.
-When [Freemarker](https://freemarker.apache.org/) is used, any workflow variable can be referenced in the external file,
-same format as it is for the any other activity in the SWADL file.
+When using an external file (.ftl), the content has to be defined as follows:
+
+Key | Type | Required |
+------------ | -------| --- |
+template-path | String | Yes 
+
+
+By default, it will search for the file in the `./workflows` root folder.
+
+When a template is used, any workflow variable can be referenced in it, same format as it is for the any other activity in the SWADL file.
 [Utility functions](#utility-functions) can also be used inside templates.
 
-Example using Freemarker:
+Example using Freemarker template:
+
 
 ```yaml
 id: pingPong
@@ -876,7 +885,23 @@ activities:
         message-received:
           content: /ping {message}
       content:
-        template: message-with-params.ftl
+        template: "<messageML>${variables.reply}: ${text(event.source.message.message)}</messageML>"
+```
+
+or
+
+```yaml
+id: pingPong
+variables:
+  reply: pong
+activities:
+  - send-message:
+      id: pingPong
+      on:
+        message-received:
+          content: /ping {message}
+      content:
+        template-path: message-with-params.ftl
 ```
 
 message-with-params.ftl

--- a/workflow-bot-app/build.gradle
+++ b/workflow-bot-app/build.gradle
@@ -12,11 +12,11 @@ javadoc {
 dependencies {
     implementation project(':workflow-language')
 
-    implementation platform('org.finos.symphony.bdk:symphony-bdk-bom:2.10.0') {
+    implementation platform('org.finos.symphony.bdk:symphony-bdk-bom:2.11.0') {
         exclude group: 'org.slf4j', module: 'slf4j-api'
     }
-    implementation platform('com.fasterxml.jackson:jackson-bom:2.13.4')
-    implementation platform('org.springframework.boot:spring-boot-dependencies:2.6.6')
+    implementation platform('com.fasterxml.jackson:jackson-bom:2.13.4.20221013')
+    implementation platform('org.springframework.boot:spring-boot-dependencies:2.7.5')
 
     implementation ('org.apache.httpcomponents.client5:httpclient5-fluent:5.1.3') {
         exclude group: 'org.slf4j', module: 'slf4j-api'
@@ -24,6 +24,8 @@ dependencies {
 
     implementation 'org.finos.symphony.bdk:symphony-bdk-core-spring-boot-starter'
     implementation 'org.finos.symphony.bdk.ext:symphony-group-extension'
+    implementation 'org.finos.symphony.bdk:symphony-bdk-template-freemarker'
+    implementation 'org.freemarker:freemarker'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/SendMessageExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/message/SendMessageExecutor.java
@@ -1,7 +1,5 @@
 package com.symphony.bdk.workflow.engine.executor.message;
 
-import static java.util.Collections.singletonList;
-
 import com.symphony.bdk.core.auth.AuthSession;
 import com.symphony.bdk.core.service.message.MessageService;
 import com.symphony.bdk.core.service.message.OboMessageService;
@@ -34,6 +32,8 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static java.util.Collections.singletonList;
 
 @Slf4j
 @Component
@@ -181,19 +181,30 @@ public class SendMessageExecutor extends OboExecutor<SendMessage, V4Message>
   }
 
   private static String extractContent(ActivityExecutorContext<SendMessage> execution) throws IOException {
-    if (execution.getActivity().getContent() != null) {
-      return execution.getActivity().getContent();
+    SendMessage activity = execution.getActivity();
+    if (activity.getContent() != null) {
+      return activity.getContent();
     } else {
-      String template = execution.getActivity().getTemplate();
-      File file = execution.getResourceFile(Path.of(template));
       Map<String, Object> templateVariables = new HashMap<>(execution.getVariables());
       // also bind our utility functions so they can be used inside templates
       templateVariables.put(UtilityFunctionsMapper.WDK_PREFIX, new UtilityFunctionsMapper());
-      return execution.bdk()
-          .messages()
-          .templates()
-          .newTemplateFromFile(file.getPath())
-          .process(templateVariables);
+
+      if (activity.getTemplatePath() != null) {
+        String templateFile = activity.getTemplatePath();
+        File file = execution.getResourceFile(Path.of(templateFile));
+        return execution.bdk()
+            .messages()
+            .templates()
+            .newTemplateFromFile(file.getPath())
+            .process(templateVariables);
+      } else {
+        String templateStr = activity.getTemplate();
+        return execution.bdk()
+            .messages()
+            .templates()
+            .newTemplateFromString(templateStr)
+            .process(templateVariables);
+      }
     }
   }
 

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/SendMessageIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/SendMessageIntegrationTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
 import java.io.ByteArrayInputStream;
@@ -143,10 +144,12 @@ class SendMessageIntegrationTest extends IntegrationTest {
     verify(messageService, never()).send(anyString(), any(Message.class));
   }
 
-  @Test
-  void sendMessageWithTemplateSuccessful() throws IOException, ProcessingException {
+  @ParameterizedTest
+  @ValueSource(strings = {"/message/send-message-with-freemarker.swadl.yaml",
+      "/message/send-message-with-inline-template.swadl.yaml"})
+  void sendMessageWithTemplateSuccessful(String swadl) throws IOException, ProcessingException {
     final Workflow workflow =
-        SwadlParser.fromYaml(getClass().getResourceAsStream("/message/send-message-with-freemarker.swadl.yaml"));
+        SwadlParser.fromYaml(getClass().getResourceAsStream(swadl));
 
     final V4Message message = message("MSG_ID");
     final TemplateEngine templateEngine = TemplateEngine.getDefaultImplementation();

--- a/workflow-bot-app/src/test/resources/message/send-message-with-inline-template.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/send-message-with-inline-template.swadl.yaml
@@ -5,7 +5,7 @@ activities:
   - send-message:
       id: sendMessageTemplateWithParams
       content:
-        template-path: /message/templates/message-freemarker.ftl
+        template: "Hello ${variables.val} ${text(variables.val)}!\n"
       to:
         stream-id: "123"
       on:

--- a/workflow-bot-app/src/test/resources/message/update-message-template.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/message/update-message-template.swadl.yaml
@@ -7,4 +7,4 @@ activities:
           content: /update
       message-id: MSG_ID
       content:
-        template: /message/templates/message.mml.xml
+        template-path: /message/templates/message.mml.xml

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/SendMessage.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/SendMessage.java
@@ -14,6 +14,7 @@ import javax.annotation.Nullable;
 public class SendMessage extends OboActivity {
 
   @Nullable private String template;
+  @Nullable private String templatePath;
   @Nullable private String content;
   @Nullable private To to;
   @Nullable private List<Attachment> attachments;
@@ -22,7 +23,9 @@ public class SendMessage extends OboActivity {
   @SuppressWarnings("unchecked")
   public void setContent(Object content) {
     if (content instanceof Map) {
-      setTemplate(((Map<String, String>) content).get("template"));
+      Map<String, String> map = (Map<String, String>) content;
+      setTemplate(map.get("template"));
+      setTemplatePath(map.get("template-path"));
     } else if (content instanceof String) {
       this.content = (String) content;
     }

--- a/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/UpdateMessage.java
+++ b/workflow-language/src/main/java/com/symphony/bdk/workflow/swadl/v1/activity/message/UpdateMessage.java
@@ -13,13 +13,16 @@ import javax.annotation.Nullable;
 public class UpdateMessage extends BaseActivity {
   private String messageId;
   @Nullable private String template;
+  @Nullable private String templatePath;
   @Nullable private String content;
   private Boolean silent = Boolean.TRUE;
 
   @SuppressWarnings("unchecked")
   public void setContent(Object content) {
     if (content instanceof Map) {
-      setTemplate(((Map<String, String>) content).get("template"));
+      Map<String, String> map = (Map<String, String>) content;
+      setTemplate(map.get("template"));
+      setTemplatePath(map.get("template-path"));
     } else if (content instanceof String) {
       this.content = (String) content;
     }

--- a/workflow-language/src/main/resources/swadl-schema-1.0.json
+++ b/workflow-language/src/main/resources/swadl-schema-1.0.json
@@ -3791,7 +3791,7 @@
         },
         "content-inner": {
             "description": "The content of the message in MessageML format. Must contain at least one space. In case the content is a form, this latter's id should be the same as the activity one.",
-            "anyOf": [
+            "oneOf": [
                 {
                     "enum": [
                         "${variables.VARIABLE_NAME}",
@@ -3806,10 +3806,19 @@
                     "properties": {
                         "template": {
                             "type": "string",
-                            "description": "External message template file.",
+                            "description": "Inline template message content in string.",
                             "minLength": 1
+                        },
+                        "template-path": {
+                          "type": "string",
+                          "description": "External message template file path.",
+                          "minLength": 1
                         }
-                    }
+                    },
+                    "oneOf": [
+                      {"required": ["template"]},
+                      {"required": ["template-path"]}
+                    ]
                 },
                 {
                     "type": "string",


### PR DESCRIPTION
Add inline template support, the field "template" now is holding the inline template string, the field "template-path" is used for the template file.

### Description
Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced a ticket in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
