### PR TITLE
Support blast form replies

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/event/AbstractRealTimeEventProcessor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/event/AbstractRealTimeEventProcessor.java
@@ -24,11 +24,11 @@ public abstract class AbstractRealTimeEventProcessor<T> implements RealTimeEvent
   public void process(RealTimeEvent<T> event) throws Exception {
     Map<String, Object> processVariables = new HashMap<>();
     processVariables.put(ActivityExecutorContext.EVENT,
-        new EventHolder<>(event.getInitiator(), event.getSource(), new HashMap<>()));
+            new EventHolder<>(event.getInitiator(), event.getSource(), new HashMap<>()));
 
     if (event.getInitiator() != null
-        && event.getInitiator().getUser() != null
-        && event.getInitiator().getUser().getUserId() != null) {
+            && event.getInitiator().getUser() != null
+            && event.getInitiator().getUser().getUserId() != null) {
       Long userId = event.getInitiator().getUser().getUserId();
       processVariables.put(ActivityExecutorContext.INITIATOR, userId);
       log.debug("Dispatching event {} from user {}", event.getSource().getClass().getSimpleName(), userId);

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/event/V4ElementActionEventProcessor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/event/V4ElementActionEventProcessor.java
@@ -1,7 +1,5 @@
 package com.symphony.bdk.workflow.event;
 
-import static java.util.Collections.singletonMap;
-
 import com.symphony.bdk.gen.api.model.V4SymphonyElementsAction;
 import com.symphony.bdk.workflow.engine.camunda.variable.FormVariableListener;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
@@ -9,10 +7,16 @@ import com.symphony.bdk.workflow.engine.executor.EventHolder;
 import com.symphony.bdk.workflow.engine.executor.message.SendMessageExecutor;
 
 import lombok.extern.slf4j.Slf4j;
+
 import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.runtime.VariableInstance;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.singletonMap;
 
 @Service
 @Slf4j
@@ -24,8 +28,7 @@ public class V4ElementActionEventProcessor extends AbstractRealTimeEventProcesso
 
   @Override
   @SuppressWarnings({"unchecked", "rawtypes"})
-  protected void processEventSource(V4SymphonyElementsAction eventSource, Map<String, Object> variables)
-      throws Exception {
+  protected void processEventSource(V4SymphonyElementsAction eventSource, Map<String, Object> variables) {
     // we expect the activity id to be the same as the form id to work
     // correlation across processes is based on the message id that was created to send the form
     String formId = eventSource.getFormId();
@@ -34,10 +37,38 @@ public class V4ElementActionEventProcessor extends AbstractRealTimeEventProcesso
     variables.put(FormVariableListener.FORM_VARIABLES, singletonMap(formId, formReplies));
     ((EventHolder) variables.get(ActivityExecutorContext.EVENT)).getArgs().put(EVENT_NAME_KEY, eventName + formId);
 
-    runtimeService.createMessageCorrelation(eventName + formId)
-        .processInstanceVariableEquals(String.format("%s.%s.%s", formId, ActivityExecutorContext.OUTPUTS,
-            SendMessageExecutor.OUTPUT_MESSAGE_ID_KEY), eventSource.getFormMessageId())
-        .setVariables(variables)
-        .correlateAll();
+    String processId = getProcessToExecute(formId, eventSource.getFormMessageId());
+
+    if (processId != null) {
+      runtimeService.createMessageCorrelation(eventName + formId)
+              .processInstanceId(processId)
+              .setVariables(variables)
+              .correlateAll();
+    }
+  }
+
+
+  /**
+   * This method returns the process to be executed when a form has been actioned.
+   * Given 2 forms with the same formId have been sent in 2 different processes, when one of them is actioned,
+   * we want to resume only the process in which context this form has been sent, hence the filter done with the formId
+   * and messageId, since both forms have the same formId but different messageIds.
+   *
+   * @param formId on which the action is applied.
+   * @param messageId of the form.
+   * @return process instance id to be resumed.
+   */
+  private String getProcessToExecute(String formId, String messageId) {
+    List<String> collect = runtimeService.createVariableInstanceQuery().list().stream()
+            .filter(a -> a.getName().equals(String.format("%s.%s.%s", formId, ActivityExecutorContext.OUTPUTS,
+                    SendMessageExecutor.OUTPUT_MESSAGE_IDS_KEY)) && ((List) a.getValue()).contains(messageId))
+            .map(VariableInstance::getProcessInstanceId)
+            .collect(Collectors.toList());
+
+    if (!collect.isEmpty()) {
+      return collect.get(0);
+    } else {
+      return null;
+    }
   }
 }

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/IntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/IntegrationTest.java
@@ -403,6 +403,19 @@ public abstract class IntegrationTest {
     }
   }
 
+  protected Optional<String> lastProcess(Workflow workflow) {
+    List<HistoricProcessInstance> processes = historyService.createHistoricProcessInstanceQuery()
+            .processDefinitionName(workflow.getId())
+            .orderByProcessInstanceStartTime().desc()
+            .list();
+    if (processes.isEmpty()) {
+      return Optional.empty();
+    } else {
+      return Optional.ofNullable(processes.get(0))
+              .map(HistoricProcessInstance::getId);
+    }
+  }
+
   public static List<String> finishedProcessById(String workflowId) {
     return historyService.createHistoricProcessInstanceQuery()
             .processDefinitionKey(workflowId)
@@ -421,19 +434,6 @@ public abstract class IntegrationTest {
             .stream()
             .map(HistoricProcessInstance::getId)
             .collect(Collectors.toList());
-  }
-
-  protected Optional<String> lastProcess(Workflow workflow) {
-    List<HistoricProcessInstance> processes = historyService.createHistoricProcessInstanceQuery()
-        .processDefinitionName(workflow.getId())
-        .orderByProcessInstanceStartTime().desc()
-        .list();
-    if (processes.isEmpty()) {
-      return Optional.empty();
-    } else {
-      return Optional.ofNullable(processes.get(0))
-          .map(HistoricProcessInstance::getId);
-    }
   }
 
   public static void assertExecuted(Workflow workflow) {

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/RequestReceivedEventIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/RequestReceivedEventIntegrationTest.java
@@ -1,5 +1,19 @@
 package com.symphony.bdk.workflow;
 
+import com.github.fge.jsonschema.core.exceptions.ProcessingException;
+import com.symphony.bdk.core.service.message.model.Message;
+import com.symphony.bdk.workflow.engine.ExecutionParameters;
+import com.symphony.bdk.workflow.exception.NotFoundException;
+import com.symphony.bdk.workflow.exception.UnauthorizedException;
+import com.symphony.bdk.workflow.swadl.SwadlParser;
+import com.symphony.bdk.workflow.swadl.v1.Workflow;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
 import static com.symphony.bdk.workflow.custom.assertion.Assertions.assertThat;
 import static com.symphony.bdk.workflow.custom.assertion.WorkflowAssert.content;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -12,21 +26,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import com.symphony.bdk.core.service.message.model.Message;
-import com.symphony.bdk.workflow.engine.ExecutionParameters;
-import com.symphony.bdk.workflow.exception.NotFoundException;
-import com.symphony.bdk.workflow.exception.UnauthorizedException;
-import com.symphony.bdk.workflow.swadl.SwadlParser;
-import com.symphony.bdk.workflow.swadl.v1.Workflow;
-
-import com.github.fge.jsonschema.core.exceptions.ProcessingException;
-import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 class RequestReceivedEventIntegrationTest extends IntegrationTest {
 
@@ -58,7 +57,8 @@ class RequestReceivedEventIntegrationTest extends IntegrationTest {
   }
 
   @Test
-  void onRequestReceived_inOneOf_formRepliedSubsequentActivity() throws IOException, ProcessingException {
+  void onRequestReceived_inOneOf_formRepliedSubsequentActivity() throws IOException, ProcessingException,
+          InterruptedException {
     final Workflow workflow = SwadlParser.fromYaml(
         getClass().getResourceAsStream("/event/request-received-in-one-of-with-form-replied-activity.swadl.yaml"));
 
@@ -69,6 +69,7 @@ class RequestReceivedEventIntegrationTest extends IntegrationTest {
     engine.execute("request-received-in-one-of-with-form-replied-activity",
         new ExecutionParameters(Map.of(), "myToken"));
 
+    sleepToTimeout(1000);
     await().atMost(5, TimeUnit.SECONDS).ignoreExceptions().until(() -> {
       engine.onEvent(form("msgId", "formActivity", Collections.singletonMap("action", "one")));
       return true;

--- a/workflow-bot-app/src/test/resources/form/send-blast-form-reply.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/form/send-blast-form-reply.swadl.yaml
@@ -1,0 +1,26 @@
+id: send-blast-form-reply
+activities:
+  - send-message:
+      id: sendBlastForm
+      on:
+        message-received:
+          content: "/blast-form"
+      to:
+        stream-ids:
+          - "123"
+          - "456"
+      content: |
+        <messageML>
+         <form id="sendBlastForm">
+           <button name="approve" type="action">Approve</button>
+           <button name="reject" type="action">Reject</button>
+         </form>
+        </messageML>
+
+  - execute-script:
+      id: script
+      on:
+        form-replied:
+          form-id: sendBlastForm
+      script: |
+        assert true

--- a/workflow-bot-app/src/test/resources/form/send-two-forms-same-id.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/form/send-two-forms-same-id.swadl.yaml
@@ -1,0 +1,24 @@
+id: send-two-forms-same-id
+activities:
+  - send-message:
+      id: sendFormSameIds
+      on:
+        message-received:
+          content: "/two-forms-same-id"
+      to:
+        stream-id: "123"
+      content: |
+        <messageML>
+         <form id="sendFormSameIds">
+           <button name="approve" type="action">Approve</button>
+           <button name="reject" type="action">Reject</button>
+         </form>
+        </messageML>
+
+  - execute-script:
+      id: script
+      on:
+        form-replied:
+          form-id: sendFormSameIds
+      script: |
+        assert true


### PR DESCRIPTION
### Description
In this PR, we added the support of blast form replies.
Having an activity to be executed on a form reply event, if this form has been sent in a blast way, then the activity triggers only when the first form is replied and not the other blast ones.

When a blast message is sent, we only store the first messageId in outputs. This is stored as a variable of the ongoing process instances. 
In the form reply event processing class, we only execute ongoing processes that have a variable msgId equals to the message id of the form that has been actioned. So when the messageId is not the one that is stored in the variable, the process is not executed. 

The fix consists of introducing a new output variable msgIds to the SendMessageExecutor where we store the list of message ids in case of a blast, and the only message id in case it is not a blast. In the form reply event processing class, we fetch for a process id where the variables msgIds list contains the message id of the form that has been actioned and we execute it by its process id. In case no process is found, which can be the case when the on:form-reply event is the starting event of the workflow, then we do not apply this filter which will start a new process execution. 