### PR TITLE
#211 Fix Get rooms wrong criteria

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/GetRoomsExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/room/GetRoomsExecutor.java
@@ -34,7 +34,7 @@ public class GetRoomsExecutor extends OboExecutor<GetRooms, V3RoomSearchResults>
       rooms = this.searchRoomsNoPagination(execution);
     } else {
       throw new IllegalArgumentException(
-          String.format("Skip and limit should both be set to get rooms in activity %s", getRooms.getId()));
+          String.format("Skip and limit should both be set in activity %s to get rooms", getRooms.getId()));
     }
 
     execution.setOutputVariable(OUTPUTS_ROOMS_KEY, rooms);
@@ -53,10 +53,10 @@ public class GetRoomsExecutor extends OboExecutor<GetRooms, V3RoomSearchResults>
       criteria.setCreator(new UserId().id(Long.parseLong(getRooms.getCreatorId())));
     }
     if (getRooms.getOwnerId() != null) {
-      criteria.setOwner(new UserId().id(Long.parseLong(getRooms.getCreatorId())));
+      criteria.setOwner(new UserId().id(Long.parseLong(getRooms.getOwnerId())));
     }
     if (getRooms.getMemberId() != null) {
-      criteria.setMember(new UserId().id(Long.parseLong(getRooms.getCreatorId())));
+      criteria.setMember(new UserId().id(Long.parseLong(getRooms.getMemberId())));
     }
     return criteria;
   }

--- a/workflow-bot-app/src/test/resources/room/get-rooms-bad-pagination-no-limit.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/get-rooms-bad-pagination-no-limit.swadl.yaml
@@ -1,10 +1,10 @@
-id: get-rooms
+id: get-rooms-bad-pagination-no-limit
 activities:
   - get-rooms:
       id: act1
       on:
         message-received:
-          content: /get-rooms
+          content: /get-rooms-bad-pagination
       active: true
       labels:
         - test
@@ -14,7 +14,10 @@ activities:
       creator-id: 123
       owner-id: 456
       member-id: 789
+      skip: 10
+      #limit not set
+
   - execute-script:
-      id: script
+      id: scriptShouldNotBeExecuted
       script: |
-        assert act1.outputs.rooms != null
+        assert false

--- a/workflow-bot-app/src/test/resources/room/get-rooms-bad-pagination-no-skip.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/get-rooms-bad-pagination-no-skip.swadl.yaml
@@ -1,10 +1,10 @@
-id: get-rooms
+id: get-rooms-bad-pagination-no-skip
 activities:
   - get-rooms:
       id: act1
       on:
         message-received:
-          content: /get-rooms
+          content: /get-rooms-bad-pagination
       active: true
       labels:
         - test
@@ -14,7 +14,10 @@ activities:
       creator-id: 123
       owner-id: 456
       member-id: 789
+      limit: 10
+      #skip not set
+
   - execute-script:
-      id: script
+      id: scriptShouldNotBeExecuted
       script: |
-        assert act1.outputs.rooms != null
+        assert false

--- a/workflow-bot-app/src/test/resources/room/obo/get-rooms-obo-bad-pagination-no-limit.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/get-rooms-obo-bad-pagination-no-limit.swadl.yaml
@@ -1,0 +1,22 @@
+id: get-rooms-on-behalf-of-user-bad-pagination-no-limit
+activities:
+  - get-rooms:
+      id: getRoomsOboValidUserid
+      on:
+        message-received:
+          content: "/get-rooms-obo-bad-pagination"
+      active: true
+      labels:
+        - test
+        - test1
+      query: test
+      sort-order: BASIC
+      obo:
+        user-id: 12345
+      skip: 10
+      #limit not set
+
+  - execute-script:
+      id: scriptShouldNotBeExecuted
+      script: |
+        assert false

--- a/workflow-bot-app/src/test/resources/room/obo/get-rooms-obo-bad-pagination-no-skip.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/room/obo/get-rooms-obo-bad-pagination-no-skip.swadl.yaml
@@ -1,0 +1,22 @@
+id: get-rooms-on-behalf-of-user-bad-pagination-no-skip
+activities:
+  - get-rooms:
+      id: getRoomsOboValidUserid
+      on:
+        message-received:
+          content: "/get-rooms-obo-bad-pagination"
+      active: true
+      labels:
+        - test
+        - test1
+      query: test
+      sort-order: BASIC
+      obo:
+        user-id: 12345
+      limit: 10
+      #skip not set
+
+  - execute-script:
+      id: scriptShouldNotBeExecuted
+      script: |
+        assert false


### PR DESCRIPTION
### Description
In get rooms executor, the criteria were wrong where an owner or member id is set because the creator id was used rather. This has been fixed in this PR, more tests are added to improve the coverage and avoid such issues in the future
Closes #211