### PR TITLE
Add version awareness to the management api

### DIFF
--- a/allow-list.xml
+++ b/allow-list.xml
@@ -32,6 +32,13 @@
         <cve>CVE-2022-41854</cve>
     </suppress>
     <suppress>
+      <notes><![CDATA[
+          No fix available
+          ]]></notes>
+      <gav>org.yaml:snakeyaml:1.33</gav>
+      <cve>CVE-2022-1471</cve>
+    </suppress>
+    <suppress>
         <notes><![CDATA[
         Testing false positives by suppressing a CVE
         https://github.com/spring-projects/spring-framework/issues/24434 (Do not expose HttpInvoker)

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'io.codearte.nexus-staging' version '0.22.0'
-    id "org.owasp.dependencycheck" version "7.4.0"
+    id "org.owasp.dependencycheck" version "8.0.1"
 }
 
 group = 'org.finos.symphony.wdk'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.freefair.gradle:lombok-plugin:6.4.1'
+    implementation 'io.freefair.gradle:lombok-plugin:6.6.1'
     implementation 'com.github.spotbugs.snom:spotbugs-gradle-plugin:5.0.13'
 }

--- a/postman/Symphony Workflow Developer Kit (WDK) APIs.postman_collection.json
+++ b/postman/Symphony Workflow Developer Kit (WDK) APIs.postman_collection.json
@@ -1,8 +1,9 @@
 {
 	"info": {
-		"_postman_id": "bd3592e5-01f8-4a1e-8ede-8c0f8de5a133",
+		"_postman_id": "ee4b9acd-dcbc-43fd-b5b5-b302598a8298",
 		"name": "Symphony Workflow Developer Kit (WDK) APIs Copy",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "10221895"
 	},
 	"item": [
 		{
@@ -20,13 +21,24 @@
 							},
 							{
 								"key": "Content-Type",
-								"value": "text/plain",
+								"value": "multipart/form-data",
 								"type": "text"
 							}
 						],
 						"body": {
-							"mode": "raw",
-							"raw": ""
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "swadl",
+									"value": "",
+									"type": "text"
+								},
+								{
+									"key": "description",
+									"value": "",
+									"type": "text"
+								}
+							]
 						},
 						"url": {
 							"raw": "http://localhost:8080/wdk/v1/management/workflows",
@@ -57,13 +69,24 @@
 							},
 							{
 								"key": "Content-Type",
-								"value": "text/plain",
+								"value": "multipart/form-data",
 								"type": "text"
 							}
 						],
 						"body": {
-							"mode": "raw",
-							"raw": ""
+							"mode": "formdata",
+							"formdata": [
+								{
+									"key": "swadl",
+									"value": "",
+									"type": "text"
+								},
+								{
+									"key": "description",
+									"value": "",
+									"type": "text"
+								}
+							]
 						},
 						"url": {
 							"raw": "http://localhost:8080/wdk/v1/management/workflows",
@@ -115,8 +138,143 @@
 							"variable": [
 								{
 									"key": "workflowId",
-									"value": null,
+									"value": "",
 									"description": "workflow id defined in the swadl file"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get SWADL by ID",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-Management-Token",
+								"value": "",
+								"type": "text"
+							},
+							{
+								"key": "Content-Type",
+								"value": "text/plain",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "http://localhost:8080/wdk/v1/management/workflows/:workflowId",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"wdk",
+								"v1",
+								"management",
+								"workflows",
+								":workflowId"
+							],
+							"variable": [
+								{
+									"key": "workflowId",
+									"value": "",
+									"description": "workflow id defined in the swadl file"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get SWADL by ID and Version",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-Management-Token",
+								"value": "",
+								"type": "text"
+							},
+							{
+								"key": "Content-Type",
+								"value": "text/plain",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "http://localhost:8080/wdk/v1/management/workflows/:workflowId/versions/:version",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"wdk",
+								"v1",
+								"management",
+								"workflows",
+								":workflowId",
+								"versions",
+								":version"
+							],
+							"variable": [
+								{
+									"key": "workflowId",
+									"value": "",
+									"description": "workflow id defined in the swadl file"
+								},
+								{
+									"key": "version",
+									"value": ""
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete SWADL by ID and Version",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "X-Management-Token",
+								"value": "",
+								"type": "text"
+							},
+							{
+								"key": "Content-Type",
+								"value": "text/plain",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "http://localhost:8080/wdk/v1/management/workflows/:workflowId/versions/:version",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"wdk",
+								"v1",
+								"management",
+								"workflows",
+								":workflowId",
+								"versions",
+								":version"
+							],
+							"variable": [
+								{
+									"key": "workflowId",
+									"value": "",
+									"description": "workflow id defined in the swadl file"
+								},
+								{
+									"key": "version",
+									"value": null
 								}
 							]
 						}

--- a/workflow-bot-app/build.gradle
+++ b/workflow-bot-app/build.gradle
@@ -2,7 +2,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
     id 'workflow-bot.java-conventions'
-    id 'org.springframework.boot' version '2.7.6'
+    id 'org.springframework.boot' version '2.7.8'
 }
 
 javadoc {

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/api/v1/dto/SwadlView.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/api/v1/dto/SwadlView.java
@@ -1,0 +1,11 @@
+package com.symphony.bdk.workflow.api.v1.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SwadlView {
+  private String description;
+  private String swadl;
+}

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/api/v1/dto/VersionedWorkflowView.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/api/v1/dto/VersionedWorkflowView.java
@@ -1,0 +1,36 @@
+package com.symphony.bdk.workflow.api.v1.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class VersionedWorkflowView {
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private String id;
+
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private String workflowId;
+
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private Long version;
+
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private Boolean active;
+
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private Boolean published;
+
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private String deploymentId;
+
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private String lastUpdatedBy;
+
+  private String swadl;
+
+  private String description;
+}

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/management/WorkflowManagementService.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/management/WorkflowManagementService.java
@@ -1,5 +1,7 @@
 package com.symphony.bdk.workflow.management;
 
+import com.symphony.bdk.workflow.api.v1.dto.SwadlView;
+import com.symphony.bdk.workflow.api.v1.dto.VersionedWorkflowView;
 import com.symphony.bdk.workflow.configuration.ConditionalOnPropertyNotEmpty;
 import com.symphony.bdk.workflow.converter.ObjectConverter;
 import com.symphony.bdk.workflow.engine.WorkflowEngine;
@@ -17,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Optional;
 
 @Component
@@ -27,60 +30,75 @@ import java.util.Optional;
 public class WorkflowManagementService {
   private static final String WORKFLOW_NOT_EXIST_EXCEPTION_MSG = "Workflow %s does not exist.";
   private final WorkflowEngine<BpmnModelInstance> workflowEngine;
-  private final VersionedWorkflowRepository versioningRepository;
+  private final VersionedWorkflowRepository versionRepository;
   private final ObjectConverter objectConverter;
 
-  public void deploy(String content) {
-    Workflow workflow = objectConverter.convert(content, Workflow.class);
+  public void deploy(SwadlView swadlView) {
+    Workflow workflow = objectConverter.convert(swadlView.getSwadl(), Workflow.class);
     BpmnModelInstance modelInstance = workflowEngine.parseAndValidate(workflow);
+    Optional<VersionedWorkflow> notPublished = versionRepository.findByWorkflowIdAndPublishedFalse(workflow.getId());
+    notPublished.ifPresent(wf -> {
+      throw new IllegalArgumentException(
+          String.format("Version %s of workflow has not published yet.", wf.getVersion()));
+    });
     if (workflow.isToPublish()) {
-      publishWorkflow(content, workflow, modelInstance);
+      publishWorkflow(swadlView, workflow, modelInstance);
     } else {
-      VersionedWorkflow versionedWorkflow = toVersionedWorkflow(workflow, content, Optional.empty());
-      versioningRepository.save(versionedWorkflow);
+      VersionedWorkflow versionedWorkflow = toVersionedWorkflow(workflow, swadlView, Optional.empty());
+      versionRepository.save(versionedWorkflow);
     }
   }
 
-  private void publishWorkflow(String content, Workflow workflow, BpmnModelInstance modelInstance) {
+  private void publishWorkflow(SwadlView swadlView, Workflow workflow, BpmnModelInstance modelInstance) {
     String deploy = workflowEngine.deploy(workflow, modelInstance);
-    VersionedWorkflow versionedWorkflow = toVersionedWorkflow(workflow, content, Optional.of(deploy));
-    Optional<VersionedWorkflow> activeVersion =
-        versioningRepository.findByWorkflowIdAndActiveTrue(workflow.getId());
+    VersionedWorkflow versionedWorkflow = toVersionedWorkflow(workflow, swadlView, Optional.of(deploy));
+    Optional<VersionedWorkflow> activeVersion = versionRepository.findByWorkflowIdAndActiveTrue(workflow.getId());
     if (activeVersion.isPresent()) {
       VersionedWorkflow activeWorkflow = activeVersion.get();
       activeWorkflow.setActive(null);
-      versioningRepository.saveAndFlush(activeWorkflow);
+      versionRepository.saveAndFlush(activeWorkflow);
     }
-    versioningRepository.save(versionedWorkflow);
+    versionRepository.save(versionedWorkflow);
   }
 
-  private VersionedWorkflow toVersionedWorkflow(Workflow workflow, String content, Optional<String> deploymentId) {
+  private VersionedWorkflow toVersionedWorkflow(Workflow workflow, SwadlView swadlView, Optional<String> deploymentId) {
     VersionedWorkflow versionedWorkflow = new VersionedWorkflow();
     versionedWorkflow.setWorkflowId(workflow.getId());
     versionedWorkflow.setVersion(ChronoUnit.MICROS.between(Instant.EPOCH, Instant.now()));
     versionedWorkflow.setDeploymentId(deploymentId.orElse(null));
-    versionedWorkflow.setSwadl(content);
+    versionedWorkflow.setSwadl(swadlView.getSwadl());
+    versionedWorkflow.setDescription(swadlView.getDescription());
     versionedWorkflow.setPublished(workflow.isToPublish());
     versionedWorkflow.setActive(deploymentId.isPresent() ? true : null);
     versionedWorkflow.setDeploymentId(deploymentId.orElse(null));
     return versionedWorkflow;
   }
 
-  public void update(String content) {
-    Workflow workflow = objectConverter.convert(content, Workflow.class);
-    Optional<VersionedWorkflow> activeVersion =
-        versioningRepository.findFirstByWorkflowIdOrderByVersionDesc(workflow.getId());
-    VersionedWorkflow versionedWorkflow = validateUpdateOperation(workflow, activeVersion);
+  public void update(SwadlView swadlView) {
+    Workflow workflow = objectConverter.convert(swadlView.getSwadl(), Workflow.class);
+    Optional<VersionedWorkflow> unpublished = versionRepository.findByWorkflowIdAndPublishedFalse(workflow.getId());
+    VersionedWorkflow versionedWorkflow = validateUpdateOperation(workflow, unpublished);
     BpmnModelInstance modelInstance = workflowEngine.parseAndValidate(workflow);
     versionedWorkflow.setVersion(ChronoUnit.MICROS.between(Instant.EPOCH, Instant.now()));
-    versionedWorkflow.setSwadl(content);
+    versionedWorkflow.setSwadl(swadlView.getSwadl());
+    versionedWorkflow.setDescription(swadlView.getDescription());
     versionedWorkflow.setPublished(workflow.isToPublish());
     if (workflow.isToPublish()) {
       String deploy = workflowEngine.deploy(workflow, modelInstance);
       versionedWorkflow.setDeploymentId(deploy);
       versionedWorkflow.setActive(true);
     }
-    versioningRepository.save(versionedWorkflow);
+    versionRepository.save(versionedWorkflow);
+  }
+
+  public List<VersionedWorkflowView> get(String id) {
+    List<VersionedWorkflow> workflows = versionRepository.findByWorkflowId(id);
+    return objectConverter.convertCollection(workflows, VersionedWorkflowView.class);
+  }
+
+  public Optional<VersionedWorkflowView> get(String id, Long version) {
+    Optional<VersionedWorkflow> versionedWorkflow = versionRepository.findByWorkflowIdAndVersion(id, version);
+    return versionedWorkflow.map(w -> objectConverter.convert(w, VersionedWorkflowView.class));
   }
 
   private VersionedWorkflow validateUpdateOperation(Workflow workflow, Optional<VersionedWorkflow> activeVersion) {
@@ -94,38 +112,43 @@ public class WorkflowManagementService {
     return versionedWorkflow;
   }
 
-  public void delete(String id) {
-    boolean exist = versioningRepository.existsByWorkflowId(id);
-    if (!exist) {
-      throw new NotFoundException(String.format(WORKFLOW_NOT_EXIST_EXCEPTION_MSG, id));
-    }
-    workflowEngine.undeploy(id);
-    versioningRepository.deleteByWorkflowId(id);
+  public void delete(String id, Optional<Long> version) {
+    version.ifPresentOrElse(ver -> {
+      Optional<VersionedWorkflow> workflow = versionRepository.findByWorkflowIdAndVersion(id, ver);
+      workflow.ifPresent(w -> {
+        versionRepository.deleteByWorkflowIdAndVersion(id, ver);
+        if (w.getActive()) {
+          workflowEngine.undeploy(w.getWorkflowId());
+        }
+      });
+    }, () -> {
+      versionRepository.deleteByWorkflowId(id);
+      workflowEngine.undeploy(id);
+    });
   }
 
-  public void setActiveVersion(String workflowId, String version) {
-    Optional<VersionedWorkflow> deployedWorkflowOptional =
-        versioningRepository.findByWorkflowIdAndVersion(workflowId, Long.valueOf(version));
-    if (deployedWorkflowOptional.isEmpty()) {
+  public void setActiveVersion(String workflowId, Long version) {
+    Optional<VersionedWorkflow> optionalDeployed = versionRepository.findByWorkflowIdAndVersion(workflowId, version);
+    if (optionalDeployed.isEmpty()) {
       throw new NotFoundException(String.format("Version %s of the workflow %s does not exist.", version, workflowId));
     }
 
-    VersionedWorkflow deployedWorkflow = deployedWorkflowOptional.get();
+    VersionedWorkflow deployedWorkflow = optionalDeployed.get();
     if (!deployedWorkflow.getPublished()) {
       throw new IllegalArgumentException(
           String.format("Version %s of the workflow %s is in draft mode.", version, workflowId));
     }
 
-    Optional<VersionedWorkflow> activeVersion = versioningRepository.findByWorkflowIdAndActiveTrue(workflowId);
+    Optional<VersionedWorkflow> activeVersion = versionRepository.findByWorkflowIdAndActiveTrue(workflowId);
     activeVersion.ifPresent(versionedWorkflow -> {
       versionedWorkflow.setActive(null);
-      versioningRepository.saveAndFlush(versionedWorkflow);
+      versionRepository.saveAndFlush(versionedWorkflow);
     });
 
     Workflow workflowToDeploy = objectConverter.convert(deployedWorkflow.getSwadl(), Workflow.class);
     String deploymentId = workflowEngine.deploy(workflowToDeploy);
     deployedWorkflow.setDeploymentId(deploymentId);
     deployedWorkflow.setActive(true);
-    versioningRepository.save(deployedWorkflow);
+    versionRepository.save(deployedWorkflow);
   }
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/management/converter/VersionedWorkflowConverter.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/management/converter/VersionedWorkflowConverter.java
@@ -1,0 +1,26 @@
+package com.symphony.bdk.workflow.management.converter;
+
+import com.symphony.bdk.workflow.api.v1.dto.VersionedWorkflowView;
+import com.symphony.bdk.workflow.converter.Converter;
+import com.symphony.bdk.workflow.versioning.model.VersionedWorkflow;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class VersionedWorkflowConverter implements Converter<VersionedWorkflow, VersionedWorkflowView> {
+
+  @Override
+  public VersionedWorkflowView apply(VersionedWorkflow versionedWorkflow) {
+    return VersionedWorkflowView.builder()
+        .id(versionedWorkflow.getId())
+        .workflowId(versionedWorkflow.getWorkflowId())
+        .version(versionedWorkflow.getVersion())
+        .active(versionedWorkflow.getActive())
+        .published(versionedWorkflow.getPublished())
+        .deploymentId(versionedWorkflow.getDeploymentId())
+        .swadl(versionedWorkflow.getSwadl())
+        .description(versionedWorkflow.getDescription())
+        .lastUpdatedBy(versionedWorkflow.getUserId())
+        .build();
+  }
+}

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/versioning/repository/VersionedWorkflowRepository.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/versioning/repository/VersionedWorkflowRepository.java
@@ -4,9 +4,6 @@ import com.symphony.bdk.workflow.configuration.ConditionalOnPropertyNotEmpty;
 import com.symphony.bdk.workflow.versioning.model.VersionedWorkflow;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -21,11 +18,9 @@ public interface VersionedWorkflowRepository extends JpaRepository<VersionedWork
 
   Optional<VersionedWorkflow> findByWorkflowIdAndActiveTrue(String workflowId);
 
-  Optional<VersionedWorkflow> findFirstByWorkflowIdOrderByVersionDesc(String workflowId);
+  Optional<VersionedWorkflow> findByWorkflowIdAndPublishedFalse(String workflowId);
 
-  @Modifying
-  @Query("DELETE FROM VersionedWorkflow f WHERE f.workflowId=:workflowId")
-  void deleteByWorkflowId(@Param("workflowId") String workflowId);
+  void deleteByWorkflowId(String workflowId);
 
-  boolean existsByWorkflowId(String workflowId);
+  void deleteByWorkflowIdAndVersion(String id, Long version);
 }

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/api/v1/controller/WorkflowsMgtApiControllerTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/api/v1/controller/WorkflowsMgtApiControllerTest.java
@@ -1,5 +1,7 @@
 package com.symphony.bdk.workflow.api.v1.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -8,9 +10,13 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.symphony.bdk.workflow.api.v1.WorkflowsMgtApi;
+import com.symphony.bdk.workflow.api.v1.dto.SwadlView;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+
+import java.util.Optional;
 
 class WorkflowsMgtApiControllerTest extends ApiTest {
 
@@ -18,48 +24,50 @@ class WorkflowsMgtApiControllerTest extends ApiTest {
 
   @Test
   void test_managementRequests_deploy() throws Exception {
-    doNothing().when(workflowManagementService).deploy(anyString());
+    doNothing().when(workflowManagementService).deploy(any(SwadlView.class));
 
     mockMvc.perform(request(HttpMethod.POST, URL)
             .header(WorkflowsMgtApi.X_MANAGEMENT_TOKEN_KEY, "myToken")
-            .contentType("text/plain")
-            .content("swadl content"))
+            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+            .param("swadl", "content")
+            .param("description", "description"))
         .andExpect(status().isNoContent());
 
-    verify(workflowManagementService).deploy(anyString());
+    verify(workflowManagementService).deploy(any(SwadlView.class));
   }
 
   @Test
   void test_managementRequests_update() throws Exception {
-    doNothing().when(workflowManagementService).update(anyString());
+    doNothing().when(workflowManagementService).update(any(SwadlView.class));
 
     mockMvc.perform(request(HttpMethod.PUT, URL)
             .header(WorkflowsMgtApi.X_MANAGEMENT_TOKEN_KEY, "myToken")
-            .contentType("text/plain")
-            .content("swadl content"))
+            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+            .param("swadl", "content")
+            .param("description", "description"))
         .andExpect(status().isNoContent());
 
-    verify(workflowManagementService).update(anyString());
+    verify(workflowManagementService).update(any(SwadlView.class));
   }
 
   @Test
   void test_managementRequests_delete() throws Exception {
-    doNothing().when(workflowManagementService).deploy(anyString());
+    doNothing().when(workflowManagementService).delete(anyString(), any(Optional.class));
 
     mockMvc.perform(request(HttpMethod.DELETE, URL + "id")
             .header(WorkflowsMgtApi.X_MANAGEMENT_TOKEN_KEY, "myToken")
-            .contentType("text/plain")
-            .content("swadl content"))
+            .contentType("text/plain"))
         .andExpect(status().isNoContent());
 
-    verify(workflowManagementService).delete(anyString());
+    verify(workflowManagementService).delete(anyString(), any(Optional.class));
   }
 
   @Test
   void test_missingToken_badRequest() throws Exception {
     mockMvc.perform(request(HttpMethod.POST, URL)
-            .contentType("text/plain")
-            .content("content"))
+            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+            .param("swadl", "content")
+            .param("description", "description"))
         .andExpect(status().isBadRequest());
   }
 
@@ -88,14 +96,14 @@ class WorkflowsMgtApiControllerTest extends ApiTest {
 
   @Test
   void test_setActiveVersion_returnOk() throws Exception {
-    doNothing().when(workflowManagementService).setActiveVersion(anyString(), anyString());
+    doNothing().when(workflowManagementService).setActiveVersion(anyString(), anyLong());
 
-    mockMvc.perform(request(HttpMethod.POST, URL + "/wfId/versions/v1")
+    mockMvc.perform(request(HttpMethod.POST, URL + "/wfId/versions/1674651222294886")
             .header(WorkflowsMgtApi.X_MANAGEMENT_TOKEN_KEY, "myToken")
             .contentType("text/plain"))
         .andExpect(status().isNoContent());
 
-    verify(workflowManagementService).setActiveVersion(eq("wfId"), eq("v1"));
+    verify(workflowManagementService).setActiveVersion(eq("wfId"), eq(1674651222294886L));
 
   }
 }

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/management/WorkflowManagementServiceTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/management/WorkflowManagementServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -14,6 +13,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.symphony.bdk.workflow.api.v1.dto.SwadlView;
 import com.symphony.bdk.workflow.converter.ObjectConverter;
 import com.symphony.bdk.workflow.engine.WorkflowEngine;
 import com.symphony.bdk.workflow.exception.NotFoundException;
@@ -32,14 +32,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 public class WorkflowManagementServiceTest {
 
   @Mock
-  VersionedWorkflowRepository versioningService;
+  VersionedWorkflowRepository versionRepository;
 
   @Mock
   ObjectConverter conveter;
@@ -61,9 +60,11 @@ public class WorkflowManagementServiceTest {
       + "      content: content";
 
   Workflow workflow;
+  SwadlView swadlView;
 
   public WorkflowManagementServiceTest() throws IOException, ProcessingException {
     workflow = SwadlParser.fromYaml(swadl);
+    swadlView = SwadlView.builder().swadl(swadl).description("desc").build();
   }
 
   @Test
@@ -73,16 +74,16 @@ public class WorkflowManagementServiceTest {
     when(camundaEngine.parseAndValidate(any(Workflow.class))).thenReturn(instance);
     when(camundaEngine.deploy(any(Workflow.class), any(BpmnModelInstance.class))).thenReturn("id");
     VersionedWorkflow activeVersion = new VersionedWorkflow();
-    when(versioningService.save(any())).thenReturn(activeVersion);
-    when(versioningService.saveAndFlush(any())).thenReturn(activeVersion);
-    when(versioningService.findByWorkflowIdAndActiveTrue(eq("test"))).thenReturn(Optional.of(activeVersion));
+    when(versionRepository.save(any())).thenReturn(activeVersion);
+    when(versionRepository.saveAndFlush(any())).thenReturn(activeVersion);
+    when(versionRepository.findByWorkflowIdAndActiveTrue(eq("test"))).thenReturn(Optional.of(activeVersion));
 
-    workflowManagementService.deploy(swadl);
+    workflowManagementService.deploy(swadlView);
 
     assertThat(activeVersion.getActive()).isFalse();
     verify(camundaEngine).deploy(any(Workflow.class), any(BpmnModelInstance.class));
-    verify(versioningService).save(any());
-    verify(versioningService).saveAndFlush(any());
+    verify(versionRepository).save(any());
+    verify(versionRepository).saveAndFlush(any());
   }
 
   @Test
@@ -91,32 +92,31 @@ public class WorkflowManagementServiceTest {
     BpmnModelInstance instance = mock(BpmnModelInstance.class);
     when(camundaEngine.parseAndValidate(any(Workflow.class))).thenReturn(instance);
     when(camundaEngine.deploy(any(Workflow.class), any(BpmnModelInstance.class))).thenReturn("id");
-    when(versioningService.save(any(VersionedWorkflow.class))).thenReturn(null);
-    when(versioningService.findByWorkflowIdAndActiveTrue(eq("test"))).thenReturn(Optional.empty());
+    when(versionRepository.save(any(VersionedWorkflow.class))).thenReturn(null);
+    when(versionRepository.findByWorkflowIdAndActiveTrue(eq("test"))).thenReturn(Optional.empty());
 
-    workflowManagementService.deploy(swadl);
+    workflowManagementService.deploy(swadlView);
 
     verify(camundaEngine).deploy(any(Workflow.class), any(BpmnModelInstance.class));
-    verify(versioningService).save(any(VersionedWorkflow.class));
+    verify(versionRepository).save(any(VersionedWorkflow.class));
   }
 
   @Test
   void testUpdate_latestNoPublishedVersion_publishSucceed() {
     when(conveter.convert(anyString(), eq(Workflow.class))).thenReturn(workflow);
-    VersionedWorkflow latestNoPublishedVersion = new VersionedWorkflow();
-    latestNoPublishedVersion.setPublished(false);
-    when(versioningService.findFirstByWorkflowIdOrderByVersionDesc(anyString())).thenReturn(
-        Optional.of(latestNoPublishedVersion));
+    VersionedWorkflow noPublishedVersion = new VersionedWorkflow();
+    noPublishedVersion.setPublished(false);
+    when(versionRepository.findByWorkflowIdAndPublishedFalse(anyString())).thenReturn(Optional.of(noPublishedVersion));
     BpmnModelInstance instance = mock(BpmnModelInstance.class);
     when(camundaEngine.parseAndValidate(any(Workflow.class))).thenReturn(instance);
     when(camundaEngine.deploy(any(Workflow.class), any(BpmnModelInstance.class))).thenReturn("id");
-    when(versioningService.save(any(VersionedWorkflow.class))).thenReturn(latestNoPublishedVersion);
+    when(versionRepository.save(any(VersionedWorkflow.class))).thenReturn(noPublishedVersion);
 
-    workflowManagementService.update(swadl);
+    workflowManagementService.update(swadlView);
 
-    assertThat(latestNoPublishedVersion.getDeploymentId()).isEqualTo("id");
-    assertThat(latestNoPublishedVersion.getActive()).isTrue();
-    assertThat(latestNoPublishedVersion.getPublished()).isTrue();
+    assertThat(noPublishedVersion.getDeploymentId()).isEqualTo("id");
+    assertThat(noPublishedVersion.getActive()).isTrue();
+    assertThat(noPublishedVersion.getPublished()).isTrue();
     verify(camundaEngine).deploy(any(Workflow.class), any(BpmnModelInstance.class));
   }
 
@@ -126,47 +126,53 @@ public class WorkflowManagementServiceTest {
     properties.setPublish(false);
     workflow.setProperties(properties);
     when(conveter.convert(anyString(), eq(Workflow.class))).thenReturn(workflow);
-    VersionedWorkflow latestNoPublishedVersion = new VersionedWorkflow();
-    latestNoPublishedVersion.setPublished(false);
-    latestNoPublishedVersion.setActive(false);
-    when(versioningService.findFirstByWorkflowIdOrderByVersionDesc(anyString())).thenReturn(
-        Optional.of(latestNoPublishedVersion));
+    VersionedWorkflow noPublishedVersion = new VersionedWorkflow();
+    noPublishedVersion.setPublished(false);
+    noPublishedVersion.setActive(false);
+    when(versionRepository.findByWorkflowIdAndPublishedFalse(anyString())).thenReturn(Optional.of(noPublishedVersion));
     BpmnModelInstance instance = mock(BpmnModelInstance.class);
     when(camundaEngine.parseAndValidate(any(Workflow.class))).thenReturn(instance);
-    when(versioningService.save(any(VersionedWorkflow.class))).thenReturn(latestNoPublishedVersion);
+    when(versionRepository.save(any(VersionedWorkflow.class))).thenReturn(noPublishedVersion);
 
-    workflowManagementService.update(swadl);
+    workflowManagementService.update(swadlView);
 
-    assertThat(latestNoPublishedVersion.getActive()).isFalse();
-    assertThat(latestNoPublishedVersion.getPublished()).isFalse();
+    assertThat(noPublishedVersion.getActive()).isFalse();
+    assertThat(noPublishedVersion.getPublished()).isFalse();
     verify(camundaEngine, never()).deploy(any(Workflow.class), any(BpmnModelInstance.class));
   }
 
   @Test
   void testUpdate_noActiveVersion_notFoundException() {
     when(conveter.convert(anyString(), eq(Workflow.class))).thenReturn(workflow);
-    when(versioningService.findFirstByWorkflowIdOrderByVersionDesc(anyString())).thenReturn(Optional.empty());
+    when(versionRepository.findByWorkflowIdAndPublishedFalse(anyString())).thenReturn(Optional.empty());
 
-    assertThatThrownBy(() -> workflowManagementService.update(swadl)).isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(() -> workflowManagementService.update(swadlView)).isInstanceOf(NotFoundException.class);
   }
 
   @Test
   void testDelete_existingVersion_succeed() {
+    VersionedWorkflow workflow = new VersionedWorkflow();
+    workflow.setActive(true);
+    workflow.setWorkflowId("id");
     doNothing().when(camundaEngine).undeploy(anyString());
-    doNothing().when(versioningService).deleteByWorkflowId(anyString());
-    when(versioningService.existsByWorkflowId(anyString())).thenReturn(true);
+    doNothing().when(versionRepository).deleteByWorkflowIdAndVersion(anyString(), anyLong());
+    when(versionRepository.findByWorkflowIdAndVersion(anyString(), anyLong())).thenReturn(Optional.of(workflow));
 
-    workflowManagementService.delete("id");
+    workflowManagementService.delete("id", Optional.of(1674651222294886L));
 
     verify(camundaEngine).undeploy(anyString());
-    verify(versioningService).deleteByWorkflowId(anyString());
+    verify(versionRepository).deleteByWorkflowIdAndVersion(anyString(), anyLong());
   }
 
   @Test
-  void testDelete_noExistingWorkflow_notFoundException() {
-    when(versioningService.existsByWorkflowId(anyString())).thenReturn(false);
+  void testDelete_withoutVersion_succeed() {
+    doNothing().when(camundaEngine).undeploy(anyString());
+    doNothing().when(versionRepository).deleteByWorkflowId(anyString());
 
-    assertThatThrownBy(() -> workflowManagementService.delete("id")).isInstanceOf(NotFoundException.class);
+    workflowManagementService.delete("id", Optional.empty());
+
+    verify(camundaEngine).undeploy(anyString());
+    verify(versionRepository).deleteByWorkflowId(anyString());
   }
 
   @Test
@@ -179,19 +185,19 @@ public class WorkflowManagementServiceTest {
     VersionedWorkflow activeWorkflow = new VersionedWorkflow();
     activeWorkflow.setActive(true);
 
-    when(versioningService.findByWorkflowIdAndVersion(anyString(), anyLong())).thenReturn(
+    when(versionRepository.findByWorkflowIdAndVersion(anyString(), anyLong())).thenReturn(
         Optional.of(versionedWorkflow));
-    when(versioningService.findByWorkflowIdAndActiveTrue(anyString())).thenReturn(Optional.of(activeWorkflow));
+    when(versionRepository.findByWorkflowIdAndActiveTrue(anyString())).thenReturn(Optional.of(activeWorkflow));
     when(conveter.convert(anyString(), eq(Workflow.class))).thenReturn(workflow);
     String deploymentId = "ABC";
     when(camundaEngine.deploy(any())).thenReturn(deploymentId);
-    when(versioningService.save(any())).thenReturn(versionedWorkflow);
-    when(versioningService.saveAndFlush(any())).thenReturn(activeWorkflow);
+    when(versionRepository.save(any())).thenReturn(versionedWorkflow);
+    when(versionRepository.saveAndFlush(any())).thenReturn(activeWorkflow);
 
-    workflowManagementService.setActiveVersion(workflowId, "1234");
+    workflowManagementService.setActiveVersion(workflowId, 1674651222294886L);
 
     verify(camundaEngine).deploy(any());
-    verify(versioningService).save(any());
+    verify(versionRepository).save(any());
     assertThat(activeWorkflow.getActive()).isFalse();
     assertThat(versionedWorkflow.getActive()).isTrue();
     assertThat(versionedWorkflow.getDeploymentId()).isEqualTo(deploymentId);
@@ -200,10 +206,10 @@ public class WorkflowManagementServiceTest {
   @Test
   void testSetActiveVersion_workflowNotFound() {
     assertThatExceptionOfType(NotFoundException.class).isThrownBy(() -> {
-      workflowManagementService.setActiveVersion("notFoundWorkflowId", "1234");
+      workflowManagementService.setActiveVersion("notFoundWorkflowId", 1674651222294886L);
     }).satisfies(
         e -> assertThat(e.getMessage())
-            .isEqualTo("Version 1234 of the workflow notFoundWorkflowId does not exist."));
+            .isEqualTo("Version 1674651222294886 of the workflow notFoundWorkflowId does not exist."));
   }
 
   @Test
@@ -212,12 +218,12 @@ public class WorkflowManagementServiceTest {
     versionedWorkflow.setWorkflowId("inactiveWorkflow");
     versionedWorkflow.setSwadl(swadl);
     versionedWorkflow.setPublished(false);
-    when(versioningService.findByWorkflowIdAndVersion(anyString(), anyLong())).thenReturn(
+    when(versionRepository.findByWorkflowIdAndVersion(anyString(), anyLong())).thenReturn(
         Optional.of(versionedWorkflow));
     assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {
-      workflowManagementService.setActiveVersion("inactiveWorkflow", "1234");
+      workflowManagementService.setActiveVersion("inactiveWorkflow", 1674651222294886L);
     }).satisfies(
         e -> assertThat(e.getMessage())
-            .isEqualTo("Version 1234 of the workflow inactiveWorkflow is in draft mode."));
+            .isEqualTo("Version 1674651222294886 of the workflow inactiveWorkflow is in draft mode."));
   }
 }

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/management/converter/VersionedWorkflowConverterTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/management/converter/VersionedWorkflowConverterTest.java
@@ -1,0 +1,35 @@
+package com.symphony.bdk.workflow.management.converter;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.symphony.bdk.workflow.api.v1.dto.VersionedWorkflowView;
+import com.symphony.bdk.workflow.versioning.model.VersionedWorkflow;
+
+import org.junit.jupiter.api.Test;
+
+class VersionedWorkflowConverterTest {
+
+  @Test
+  void apply() {
+    VersionedWorkflow versionedWorkflow = new VersionedWorkflow();
+    versionedWorkflow.setVersion(1234L);
+    versionedWorkflow.setWorkflowId("workflow");
+    versionedWorkflow.setId("id");
+    versionedWorkflow.setSwadl("swadl");
+    versionedWorkflow.setPublished(true);
+    versionedWorkflow.setActive(true);
+    versionedWorkflow.setDescription("description");
+    versionedWorkflow.setDeploymentId("deployment");
+    versionedWorkflow.setUserId("user");
+    VersionedWorkflowConverter converter = new VersionedWorkflowConverter();
+    VersionedWorkflowView workflowView = converter.apply(versionedWorkflow);
+    assertThat(workflowView.getWorkflowId()).isEqualTo("workflow");
+    assertThat(workflowView.getVersion()).isEqualTo(1234L);
+    assertThat(workflowView.getId()).isEqualTo("id");
+    assertThat(workflowView.getPublished()).isTrue();
+    assertThat(workflowView.getActive()).isTrue();
+    assertThat(workflowView.getDeploymentId()).isEqualTo("deployment");
+    assertThat(workflowView.getDescription()).isEqualTo("description");
+    assertThat(workflowView.getLastUpdatedBy()).isEqualTo("user");
+  }
+}

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/versioning/repository/VersionedWorkflowRepositoryTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/versioning/repository/VersionedWorkflowRepositoryTest.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 
 @DataJpaTest(properties = {"wdk.properties.management-token=token"})
 @Import({WorkflowDataSourceConfiguration.class})
-public class VersioningWorkflowRepositoryTest {
+public class VersionedWorkflowRepositoryTest {
   @Autowired
   VersionedWorkflowRepository versionedWorkflowRepository;
   VersionedWorkflow versionedWorkflow1;
@@ -107,21 +107,10 @@ public class VersioningWorkflowRepositoryTest {
 
   @Test
   void findFirstByWorkflowIdOrderByVersionDesc() {
-    Optional<VersionedWorkflow> workflow = versionedWorkflowRepository.findFirstByWorkflowIdOrderByVersionDesc("id1");
+    Optional<VersionedWorkflow> workflow = versionedWorkflowRepository.findByWorkflowIdAndPublishedFalse("id1");
     assertThat(workflow).isPresent();
     assertThat(workflow.get().getWorkflowId()).isEqualTo("id1");
     assertThat(workflow.get().getVersion()).isEqualTo(V3);
   }
 
-  @Test
-  void testDeleteAllByWorkflowId() {
-    boolean exist = versionedWorkflowRepository.existsByWorkflowId("id1");
-    assertThat(exist).isTrue();
-
-    versionedWorkflowRepository.deleteByWorkflowId("id1");
-    List<VersionedWorkflow> all = versionedWorkflowRepository.findAll();
-
-    assertThat(all).hasSize(1);
-    assertThat(all.get(0)).isEqualTo(versionedWorkflow4);
-  }
 }


### PR DESCRIPTION
This is a follow up work on version control feature, add version awareness to the management api, so a specific version of workflow can be retrieved, redeployed and deleted.

### Description
Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced a ticket in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
