### PR TITLE
Fix blast form replied event for start messages

### DIFF
--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/FormReplyIntegrationTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/FormReplyIntegrationTest.java
@@ -464,7 +464,7 @@ class FormReplyIntegrationTest extends IntegrationTest {
   }
 
   @Test
-  void formReplied_twoForms_sameFormId() throws Exception {
+  void formReplied_twoForms_sameFormId_sameWorkflow() throws Exception {
     Workflow workflow =
         SwadlParser.fromYaml(getClass().getResourceAsStream("/form/send-two-forms-same-id.swadl.yaml"));
 
@@ -496,5 +496,22 @@ class FormReplyIntegrationTest extends IntegrationTest {
     unfinished = unfinishedProcessById("send-two-forms-same-id");
     assertThat(finished).as("One finished executions as its form has been replied").hasSize(1);
     assertThat(unfinished).as("One execution is unfinished and waiting for its form to be replied").hasSize(1);
+  }
+
+  @Test
+  void formReplied_startingEvent() throws Exception {
+    final Workflow workflow =
+        SwadlParser.fromYaml(getClass().getResourceAsStream("/form/send-form-reply-starting-event.swadl.yaml"));
+
+    engine.deploy(workflow);
+
+    await().atMost(5, TimeUnit.SECONDS).ignoreExceptions().until(() -> {
+      engine.onEvent(form("MSG_ID", "FORM_ID", Collections.singletonMap("action", "approve")));
+      return true;
+    });
+
+    sleepToTimeout(1000);
+
+    assertThat(workflow).executed("sendFormStartingEvent", "assertScript");
   }
 }

--- a/workflow-bot-app/src/test/resources/form/send-form-reply-starting-event.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/form/send-form-reply-starting-event.swadl.yaml
@@ -1,0 +1,14 @@
+id: send-form-starting-event
+activities:
+  - execute-script:
+      id: sendFormStartingEvent
+      on:
+        form-replied:
+          form-id: FORM_ID
+      script: |
+        variables.formReplied = true
+
+  - execute-script:
+      id: assertScript
+      script: |
+        assert variables.formReplied == true


### PR DESCRIPTION
### Description
When no ongoing process is found for the formid and the form replied event messageId, we need to only execute startMessageOnly which is the only case where not finding a pending process is expected, otherwise no process should be executed. 
The exception thrown by Camunda is catched and logged as it is expected and should not make the workflow to fail.