### PR TITLE
Disable org.camunda.bpm log to avoid Camunda stacktrace

### DIFF
--- a/workflow-bot-app/src/main/resources/application-local.yaml
+++ b/workflow-bot-app/src/main/resources/application-local.yaml
@@ -23,4 +23,3 @@ logging:
     org.camunda.bpm.engine.script: DEBUG
     org.camunda.bpm: OFF
     com.symphony.bdk.workflow.engine.camunda.bpmn.CamundaBpmnBuilder: DEBUG
-    root: OFF

--- a/workflow-bot-app/src/main/resources/application-local.yaml
+++ b/workflow-bot-app/src/main/resources/application-local.yaml
@@ -15,7 +15,7 @@ bdk:
 
 logging:
   level:
-    org.camunda.bpm.engine.bpmn.parser: WARN
+    org.camunda.bpm.engine.bpmn.parser: DEBUG
     org.camunda.bpm.engine.bpmn.behavior: DEBUG
     org.camunda.bpm.engine.dmn: DEBUG
     org.camunda.bpm.engine.pvm: DEBUG

--- a/workflow-bot-app/src/main/resources/application-local.yaml
+++ b/workflow-bot-app/src/main/resources/application-local.yaml
@@ -15,10 +15,12 @@ bdk:
 
 logging:
   level:
-    org.camunda.bpm.engine.bpmn.parser: DEBUG
+    org.camunda.bpm.engine.bpmn.parser: WARN
     org.camunda.bpm.engine.bpmn.behavior: DEBUG
     org.camunda.bpm.engine.dmn: DEBUG
     org.camunda.bpm.engine.pvm: DEBUG
     org.camunda.bpm.dmn.feel: DEBUG
     org.camunda.bpm.engine.script: DEBUG
+    org.camunda.bpm: OFF
     com.symphony.bdk.workflow.engine.camunda.bpmn.CamundaBpmnBuilder: DEBUG
+    root: OFF

--- a/workflow-bot-app/src/main/resources/application.yaml
+++ b/workflow-bot-app/src/main/resources/application.yaml
@@ -80,7 +80,13 @@ logging:
   level:
     com.symphony: DEBUG
     # Troubleshoot Camunda by setting lower log level
-    org.camunda: WARN
+    org.camunda.bpm.engine.bpmn.parser: WARN
+    org.camunda.bpm.engine.bpmn.behavior: WARN
+    org.camunda.bpm.engine.dmn: WARN
+    org.camunda.bpm.engine.pvm: WARN
+    org.camunda.bpm.dmn.feel: WARN
+    org.camunda.bpm.engine.script: WARN
+    org.camunda.bpm: OFF
     # Audit trail can be disabled with WARN level
     #audit-trail: WARN
     # Disable BPMN image generation


### PR DESCRIPTION
### Description
When an activity execution starts, the NodeBuilder stores its swadl as String in order to allow CamundaExecutor to read it and build the activity to be executed. The insert query is not executed on the fly but only after the execution ends, as a batch. When the activity swadl exceeds 4000 char, the insert query batch fails as the variable is of type String requiring a max of 4000 chars. This exception cannot be caught in WDK as it is executed by a Camunda scheduled job. The exception does not make the workflow to fail but only logs the stacktrace. As the variable only used by the CamundaExecutor, and it is not fetched after the activity execution, we decided to only hide it from the console by setting the log level of org.camunda.bpm to OFF.