### PR TITLE
Fix response code when trying to update a published workflow

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/exception/GlobalExceptionHandler.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/exception/GlobalExceptionHandler.java
@@ -2,16 +2,12 @@
 package com.symphony.bdk.workflow.exception;
 
 import com.symphony.bdk.workflow.api.v1.dto.ErrorResponse;
-
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import javax.persistence.OptimisticLockException;
@@ -55,6 +51,13 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     log.error("Illegal argument exception: [{}]", exception.getMessage());
     log.debug("", exception);
     return handle(exception.getMessage(), HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(UnsupportedOperationException.class)
+  public ResponseEntity<ErrorResponse> handle(UnsupportedOperationException exception) {
+    log.error("Unsupported operation exception: [{}]", exception.getMessage());
+    log.debug("", exception);
+    return handle(exception.getMessage(), HttpStatus.UNPROCESSABLE_ENTITY);
   }
 
   @ExceptionHandler(OptimisticLockException.class)

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/exception/GlobalExceptionHandlerTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/exception/GlobalExceptionHandlerTest.java
@@ -1,12 +1,11 @@
 package com.symphony.bdk.workflow.exception;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.symphony.bdk.workflow.api.v1.dto.ErrorResponse;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class GlobalExceptionHandlerTest {
 
@@ -29,6 +28,16 @@ class GlobalExceptionHandlerTest {
         globalExceptionHandler.handle(new IllegalArgumentException("Illegal argument exception's message"));
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    assertThat(response.getBody()).isEqualTo(expectedErrorResponse);
+  }
+
+  @Test
+  void testUnsupportedOperationException() {
+    ErrorResponse expectedErrorResponse = new ErrorResponse("Unsupported operation exception's message");
+    ResponseEntity<ErrorResponse> response = globalExceptionHandler.handle(
+            new UnsupportedOperationException("Unsupported operation exception's message"));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
     assertThat(response.getBody()).isEqualTo(expectedErrorResponse);
   }
 


### PR DESCRIPTION
### Description
The error message returned when trying to update a workflow that has an already published version was confusing at it says that the workflow does not exist. Ths has been fixed in this PR by firstly checking if the workflow exists, then returning a more detailed exception when a version is already published.