### PR TITLE
[CICD] - Fixed Docker image push job in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,13 @@ jobs:
           printf "$GPG_KEY_BASE64" | base64 --decode > ~/.gnupg/secring.gpg
           ./gradlew -PmavenRepoUsername=${{ secrets.MAVEN_USERNAME }} -PmavenRepoPassword=${{ secrets.MAVEN_PASSWORD }} -Psigning.keyId=${{ secrets.GPG_KEY_ID }} -Psigning.secretKeyRingFile=${{ github.workspace }}/secring.gpg -Psigning.password=${{ secrets.GPG_KEY_PASSPHRASE }} publish closeAndReleaseRepository
 
+      - name: Upload fatJar artifact
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          path: workflow-bot-app/build/libs/**
+          if-no-files-found: error
+          retention-days: 1
+
   build-and-push-image:
     name: "Push Docker Image"
     needs: build
@@ -49,6 +56,14 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Upload fatJar artifact
+        uses: actions/download-artifact@v3
+        with:
+          path: .
+
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:11-slim-buster AS builder
-COPY workflow-bot-app/build/libs/*.jar wdk.jar
+COPY artifact/*.jar wdk.jar
 
 # Create custom JRE
 RUN mkdir custom


### PR DESCRIPTION
#226 
The docker image push job depends on the release job but it needs to checkout the repository when it starts which makes it lose the fatJar procuded by the previous job. In this commit, we added actions to the release job to download the fatJar as an artifact and download it in the next job to create the docker image.