### PR TITLE
Fix event listener method signature bug

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/event/DatafeedEventToWorkflowEvent.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/event/DatafeedEventToWorkflowEvent.java
@@ -37,82 +37,82 @@ public class DatafeedEventToWorkflowEvent {
   }
 
   @EventListener
-  public void onMessageSent(RealTimeEvent<V4MessageSent> event) {
+  public void onMessageSent(RealTimeEvent<? extends V4MessageSent> event) {
     workflowEngine.onEvent(event);
   }
 
   @EventListener
-  public void onSymphonyElementsAction(RealTimeEvent<V4SymphonyElementsAction> event) {
+  public void onSymphonyElementsAction(RealTimeEvent<? extends V4SymphonyElementsAction> event) {
     workflowEngine.onEvent(event);
   }
 
   @EventListener
-  public void onConnectionRequested(RealTimeEvent<V4ConnectionRequested> event) {
+  public void onConnectionRequested(RealTimeEvent<? extends V4ConnectionRequested> event) {
     workflowEngine.onEvent(event);
   }
 
   @EventListener
-  public void onConnectionAccepted(RealTimeEvent<V4ConnectionAccepted> event) {
+  public void onConnectionAccepted(RealTimeEvent<? extends V4ConnectionAccepted> event) {
     workflowEngine.onEvent(event);
   }
 
   @EventListener
-  public void onMessageSuppressed(RealTimeEvent<V4MessageSuppressed> event) {
+  public void onMessageSuppressed(RealTimeEvent<? extends V4MessageSuppressed> event) {
     workflowEngine.onEvent(event);
   }
 
   @EventListener
-  public void onSharedPost(RealTimeEvent<V4SharedPost> event) {
+  public void onSharedPost(RealTimeEvent<? extends V4SharedPost> event) {
     workflowEngine.onEvent(event);
   }
 
   @EventListener
-  public void onInstantMessageCreated(RealTimeEvent<V4InstantMessageCreated> event) {
+  public void onInstantMessageCreated(RealTimeEvent<? extends V4InstantMessageCreated> event) {
     workflowEngine.onEvent(event);
   }
 
   @EventListener
-  public void onRoomCreated(RealTimeEvent<V4RoomCreated> event) {
+  public void onRoomCreated(RealTimeEvent<? extends V4RoomCreated> event) {
     workflowEngine.onEvent(event);
   }
 
   @EventListener
-  public void onRoomUpdated(RealTimeEvent<V4RoomUpdated> event) {
+  public void onRoomUpdated(RealTimeEvent<? extends V4RoomUpdated> event) {
     workflowEngine.onEvent(event);
   }
 
   @EventListener
-  public void onRoomDeactivated(RealTimeEvent<V4RoomDeactivated> event) {
+  public void onRoomDeactivated(RealTimeEvent<? extends V4RoomDeactivated> event) {
     workflowEngine.onEvent(event);
   }
 
   @EventListener
-  public void onRoomReactivated(RealTimeEvent<V4RoomReactivated> event) {
+  public void onRoomReactivated(RealTimeEvent<? extends V4RoomReactivated> event) {
     workflowEngine.onEvent(event);
   }
 
   @EventListener
-  public void onUserRequestedToJoinRoom(RealTimeEvent<V4UserRequestedToJoinRoom> event) {
+  public void onUserRequestedToJoinRoom(RealTimeEvent<? extends V4UserRequestedToJoinRoom> event) {
     workflowEngine.onEvent(event);
   }
 
   @EventListener
-  public void onUserJoinedRoom(RealTimeEvent<V4UserJoinedRoom> event) {
+  public void onUserJoinedRoom(RealTimeEvent<? extends V4UserJoinedRoom> event) {
     workflowEngine.onEvent(event);
   }
 
   @EventListener
-  public void onUserLeftRoom(RealTimeEvent<V4UserLeftRoom> event) {
+  public void onUserLeftRoom(RealTimeEvent<? extends V4UserLeftRoom> event) {
     workflowEngine.onEvent(event);
   }
 
   @EventListener
-  public void onRoomMemberPromotedToOwner(RealTimeEvent<V4RoomMemberPromotedToOwner> event) {
+  public void onRoomMemberPromotedToOwner(RealTimeEvent<? extends V4RoomMemberPromotedToOwner> event) {
     workflowEngine.onEvent(event);
   }
 
   @EventListener
-  public void onRoomMemberDemotedFromOwner(RealTimeEvent<V4RoomMemberDemotedFromOwner> event) {
+  public void onRoomMemberDemotedFromOwner(RealTimeEvent<? extends V4RoomMemberDemotedFromOwner> event) {
     workflowEngine.onEvent(event);
   }
 }


### PR DESCRIPTION
Since BDK 2.13.0, the RealTimeEvent object is actually a sub type of the original V4 event type, therefore change the Spring event listener method signature to include the sub type of the event.

It is also a good practice to include the sub type to have maximum extensibility in the code.

### Description
Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced a ticket in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
