### PR TITLE
Add exceptions stack trace to the log streaming appender.

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/logs/LogsStreamingAppender.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/logs/LogsStreamingAppender.java
@@ -20,19 +20,19 @@ public class LogsStreamingAppender extends UnsynchronizedAppenderBase<ILoggingEv
 
   @Override
   protected void append(ILoggingEvent eventObject) {
-    StringBuilder formattedMessage = new StringBuilder();
-    formattedMessage.append(eventObject.getFormattedMessage());
+    StringBuilder messageBuilder = new StringBuilder();
+    messageBuilder.append(eventObject.getFormattedMessage());
 
     if (eventObject.getThrowableProxy() != null) {
-      formattedMessage.append("\n")
+      messageBuilder.append("\n")
               .append(Arrays.stream(eventObject.getThrowableProxy().getStackTraceElementProxyArray())
                       .map(StackTraceElementProxy::getSTEAsString)
                       .collect(Collectors.joining("\n")));
     }
 
-
+    String formattedMessage = messageBuilder.toString().replaceAll("(\\r|\\n|\\r\\n)+", "\t");
     service.broadcast(eventObject.getTimeStamp(), eventObject.getLevel().toString(), eventObject.getLoggerName(),
-            formattedMessage.toString());
+        formattedMessage);
   }
 
   @Override

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/logs/LogsStreamingAppender.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/logs/LogsStreamingAppender.java
@@ -1,11 +1,15 @@
 package com.symphony.bdk.workflow.logs;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.StackTraceElementProxy;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -16,8 +20,19 @@ public class LogsStreamingAppender extends UnsynchronizedAppenderBase<ILoggingEv
 
   @Override
   protected void append(ILoggingEvent eventObject) {
+    StringBuilder formattedMessage = new StringBuilder();
+    formattedMessage.append(eventObject.getFormattedMessage());
+
+    if (eventObject.getThrowableProxy() != null) {
+      formattedMessage.append("\n")
+              .append(Arrays.stream(eventObject.getThrowableProxy().getStackTraceElementProxyArray())
+                      .map(StackTraceElementProxy::getSTEAsString)
+                      .collect(Collectors.joining("\n")));
+    }
+
+
     service.broadcast(eventObject.getTimeStamp(), eventObject.getLevel().toString(), eventObject.getLoggerName(),
-        eventObject.getFormattedMessage());
+            formattedMessage.toString());
   }
 
   @Override

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/logs/LogsStreamingAppenderTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/logs/LogsStreamingAppenderTest.java
@@ -1,5 +1,14 @@
 package com.symphony.bdk.workflow.logs;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.ThrowableProxy;
@@ -10,15 +19,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class LogsStreamingAppenderTest {
@@ -33,7 +33,7 @@ class LogsStreamingAppenderTest {
     when(event.getTimeStamp()).thenReturn(Instant.now().toEpochMilli());
     when(event.getLoggerName()).thenReturn("www");
     when(event.getLevel()).thenReturn(Level.DEBUG);
-    when(event.getFormattedMessage()).thenReturn("log message");
+    when(event.getFormattedMessage()).thenReturn("log message\n");
 
     StackTraceElement stackTraceElement = new StackTraceElement("class", "method", "filename", 1);
     Throwable throwable = new Throwable();
@@ -43,7 +43,7 @@ class LogsStreamingAppenderTest {
 
     doNothing().when(service).broadcast(anyLong(), anyString(), anyString(), anyString());
     appender.append(event);
-    verify(service).broadcast(anyLong(), anyString(), eq("www"), eq("log message\nat class.method(filename:1)"));
+    verify(service).broadcast(anyLong(), anyString(), eq("www"), eq("log message\tat class.method(filename:1)"));
   }
 
   @Test

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/logs/LogsStreamingAppenderTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/logs/LogsStreamingAppenderTest.java
@@ -1,15 +1,8 @@
 package com.symphony.bdk.workflow.logs;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.ThrowableProxy;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -17,6 +10,15 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class LogsStreamingAppenderTest {
@@ -26,7 +28,26 @@ class LogsStreamingAppenderTest {
   LogsStreamingAppender appender;
 
   @Test
-  void append_eventBroadcast() {
+  void append_eventBroadcast_withStackTrace() {
+    ILoggingEvent event = mock(ILoggingEvent.class);
+    when(event.getTimeStamp()).thenReturn(Instant.now().toEpochMilli());
+    when(event.getLoggerName()).thenReturn("www");
+    when(event.getLevel()).thenReturn(Level.DEBUG);
+    when(event.getFormattedMessage()).thenReturn("log message");
+
+    StackTraceElement stackTraceElement = new StackTraceElement("class", "method", "filename", 1);
+    Throwable throwable = new Throwable();
+    throwable.setStackTrace(new StackTraceElement[]{stackTraceElement});
+    ThrowableProxy throwableProxy = new ThrowableProxy(throwable);
+    when(event.getThrowableProxy()).thenReturn(throwableProxy);
+
+    doNothing().when(service).broadcast(anyLong(), anyString(), anyString(), anyString());
+    appender.append(event);
+    verify(service).broadcast(anyLong(), anyString(), eq("www"), eq("log message\nat class.method(filename:1)"));
+  }
+
+  @Test
+  void append_eventBroadcast_noStackTrace() {
     ILoggingEvent event = mock(ILoggingEvent.class);
     when(event.getTimeStamp()).thenReturn(Instant.now().toEpochMilli());
     when(event.getLoggerName()).thenReturn("www");
@@ -34,7 +55,7 @@ class LogsStreamingAppenderTest {
     when(event.getFormattedMessage()).thenReturn("log message");
     doNothing().when(service).broadcast(anyLong(), anyString(), anyString(), anyString());
     appender.append(event);
-    verify(service).broadcast(anyLong(), anyString(), anyString(), anyString());
+    verify(service).broadcast(anyLong(), anyString(), eq("www"), eq("log message"));
   }
 
   @Test


### PR DESCRIPTION
### Description
The log streaming appender was only adding exceptions formatted message. As the stacktrace can help troubleshooting, we added the stacktrace lines to the streamed payload.

<img width="1666" alt="Capture d’écran 2023-04-14 à 10 31 24" src="https://user-images.githubusercontent.com/52406574/231989810-867b3738-4ec6-41f3-b4b5-fa3c03d89b12.png">
