### PR TITLE
Compress the swadl string to save storage

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/versioning/BigStringCompressor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/versioning/BigStringCompressor.java
@@ -1,0 +1,53 @@
+package com.symphony.bdk.workflow.versioning;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter
+public class BigStringCompressor implements AttributeConverter<String, byte[]> {
+  @Override
+  public byte[] convertToDatabaseColumn(String attribute) {
+    try {
+      return compress(attribute);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static byte[] compress(String attribute) throws IOException {
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    GZIPOutputStream gzipOutputStream = new GZIPOutputStream(outputStream);
+    gzipOutputStream.write(attribute.getBytes(StandardCharsets.UTF_8));
+    gzipOutputStream.close();
+    return outputStream.toByteArray();
+  }
+
+  @Override
+  public String convertToEntityAttribute(byte[] dbData) {
+    try {
+      return decompress(dbData);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static String decompress(byte[] dbData) throws IOException {
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(dbData);
+    GZIPInputStream gzipInputStream = new GZIPInputStream(inputStream);
+    byte[] buffer = new byte[100];
+    int length;
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    while ((length = gzipInputStream.read(buffer)) > 0) {
+      outputStream.write(buffer, 0, length);
+    }
+    gzipInputStream.close();
+    outputStream.close();
+    return outputStream.toString(StandardCharsets.UTF_8);
+  }
+}

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/versioning/model/VersionedWorkflow.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/versioning/model/VersionedWorkflow.java
@@ -1,11 +1,14 @@
 package com.symphony.bdk.workflow.versioning.model;
 
+import com.symphony.bdk.workflow.versioning.BigStringCompressor;
+
 import lombok.Data;
 import lombok.Generated;
 import org.hibernate.annotations.GenericGenerator;
 
 import java.util.Optional;
 import javax.persistence.Column;
+import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -38,6 +41,7 @@ public class VersionedWorkflow {
   private Long etag;
   @Lob
   @Column(name = "SWADL", length = Integer.MAX_VALUE, nullable = false)
+  @Convert(converter = BigStringCompressor.class)
   private String swadl;
   @Column(name = "DEPLOY_ID", length = 64)
   private String deploymentId;

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/swadl/CompressionTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/swadl/CompressionTest.java
@@ -1,0 +1,41 @@
+package com.symphony.bdk.workflow.swadl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.symphony.bdk.workflow.versioning.BigStringCompressor;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+public class CompressionTest {
+
+  @Test
+  void compressString() throws IOException {
+    String inputString = "id: my-workflow\n"
+        + "\n"
+        + "activities:\n"
+        + "  - send-message:\n"
+        + "      id: counter\n"
+        + "      on:\n"
+        + "        message-received:\n"
+        + "          content: /count\n"
+        + "      content: \"version1\"\n"
+        + "  - execute-script:\n"
+        + "      id: vars\n"
+        + "      script: |\n"
+        + "        counter = wdk.readShared('test', 'counter')\n"
+        + "        counter++\n"
+        + "        wdk.writeShared('test', 'counter', counter)\n"
+        + "  - send-message:\n"
+        + "      id: send_counter\n"
+        + "      content: ${readShared('test', 'counter')}\n";
+
+    BigStringCompressor compressor = new BigStringCompressor();
+    byte[] converted = compressor.convertToDatabaseColumn(inputString);
+    assertThat(converted.length).isLessThan(inputString.length());
+
+    String attribute = compressor.convertToEntityAttribute(converted);
+    assertThat(attribute).isEqualTo(inputString);
+  }
+}


### PR DESCRIPTION
Add Spring Jpa attribute converter to compress and decompress the swadl attribute string, in order to save storage.

### Description
Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced a ticket in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
