### PR TITLE
Add API profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ RUN apk add --no-cache --virtual .build-deps curl binutils \
 COPY --from=builder custom/jre /custom/jre
 COPY --from=builder wdk.jar wdk.jar
 
-ENTRYPOINT ["custom/jre/bin/java", "-Dspring.config.additional-location=./symphony/", "-Dloader.path=./symphony/libs", "-jar", "wdk.jar", "--spring.profiles.active=${PROFILE:default}"]
+ENTRYPOINT ["custom/jre/bin/java", "-Dspring.config.additional-location=./symphony/", "-Dloader.path=./symphony/libs", "-jar", "wdk.jar", "--spring.profiles.active=${PROFILE:api}"]

--- a/docs/deployment-with-docker.md
+++ b/docs/deployment-with-docker.md
@@ -69,11 +69,11 @@ For example, if `PROFILE=prod` is used, then `application-prod.yml` will be used
 
 `PROFILE` environment variable is optional with default value `default`.
 ```shell
-docker run -v $(pwd)/symphony:/symphony -e PROFILE=prod -p 8080:8080 finos/symphony-wdk:latest 
+docker run -v $(pwd)/symphony:/symphony -e -p 8080:8080 finos/symphony-wdk:latest 
 ```
 If you want to mount the persistence database in a separate volume, `./data` for example, then create the folder in the same level as `./symphony`, update the `jdbc-url` property accordingly `jdbc:h2:file:./data/wdk_workflow;DB_CLOSE_DELAY=-1;AUTO_SERVER=TRUE` and run:
 ```shell
-docker run -v $(pwd)/symphony:/symphony -v $(pwd)/data:/data -e PROFILE=prod -p 8080:8080 finos/symphony-wdk:latest 
+docker run -v $(pwd)/symphony:/symphony -v $(pwd)/data:/data -e -p 8080:8080 finos/symphony-wdk:latest 
 ```
 
 ---

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,7 +6,8 @@ The [Getting started](./getting-started.md) guide explains how the Symphony Gene
 project with configuration files.
 
 By default, the WDK does not persist state except in memory, so restarting the bot means all running
-workflow's state is lost. In order to have a persistent database, you need to change Camunda specific configuration (see [Persistent database part](./deployment.md#camunda-specific-configuration)).
+workflow's state is lost. In order to have a persistent database, you need to change Camunda specific configuration (
+see [Persistent database part](./deployment.md#camunda-specific-configuration)).
 
 _Running multiple instances of the bot for high availability is not yet supported._
 
@@ -18,18 +19,22 @@ from the framework applies here.
 
 ### Workflow bot specific configuration
 
-`wdk.workflows.path`: The path to the folder containing SWADL files to load on startup and to watch for changes. Defaults
+`wdk.workflows.path`: The path to the folder containing SWADL files to load on startup and to watch for changes.
+Defaults
 to _./workflows_, relative to the working directory when starting the bot.
 
-`wdk.properties.monitoring-token`: The token to authenticate requests to the [monitoring api](#monitoring). Defaults to an empty
+`wdk.properties.monitoring-token`: The token to authenticate requests to the [monitoring api](#monitoring). Defaults to
+an empty
 String. It can be set as an environment variable in the run configuration. Not setting the monitoring-token and keeping
 its default value disables the monitoring api.
 
-`wdk.properties.management-token`: The token to authenticate requests to the [management api](#management). Defaults to an empty
+`wdk.properties.management-token`: The token to authenticate requests to the [management api](#management). Defaults to
+an empty
 String. It can be set as an environment variable in the run configuration. Not setting the management-token and keeping
 its default value disables the management api.
 
-`wdk.properties.schedule.pool-size`: The size of threads to keep in the pool for scheduled jobs. Default to 20. It can be set
+`wdk.properties.schedule.pool-size`: The size of threads to keep in the pool for scheduled jobs. Default to 20. It can
+be set
 as an environment variable in the run configuration.
 
 ### BDK specific configuration
@@ -45,24 +50,32 @@ The BDK configuration is under the `bdk` key.
 
 As Camunda is used internally to run workflows, properties for the Camunda Engine can be configured too. The available
 properties are listed
-in [Camunda's documentation](https://docs.camunda.org/manual/latest/user-guide/spring-boot-integration/configuration/#camunda-engine-properties).
+in [Camunda's documentation](https://docs.camunda.org/manual/latest/user-guide/spring-boot-integration/configuration/#camunda-engine-properties)
+.
 
 #### Job execution
+
 We are mainly interested in the `camunda.bpm.job-execution` properties to configure the background process running
 workflows, for instance the wait time to detect new events to process. It is configured with a low value by default to
 ensure the bot is reactive.
 
 #### Retry on activity/task errors
+
 Camunda is configured to retry on activity/task errors. Part of the error handling is done via the BDK that already
 support retrying on failed API calls and then error handling can also be done when writing workflows with
 the [activity-failed event](./reference.md#activity-failed).
 
 #### Persistent database
-In order to use a persistent database, you need to change `spring.datasource.url` to `jdbc:h2:file:./data/wdk_database;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE`.
 
-In this case, a local disk file will be used to store data. It can also be changed to any database supported by Camunda (see [Camunda Database Configuration documentation](https://docs.camunda.org/manual/7.15/user-guide/process-engine/database/database-configuration/)).
+In order to use a persistent database, you need to change `spring.datasource.camunda.jdbc-url`
+to `jdbc:h2:file:./data/wdk_database;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE`.
 
-In case JDBC driver is missing, you might need to add it to the bot classpath in folder _/lib_ . 
+In this case, a local disk file will be used to store data. It can also be changed to any database supported by
+Camunda (
+see [Camunda Database Configuration documentation](https://docs.camunda.org/manual/7.15/user-guide/process-engine/database/database-configuration/))
+.
+
+In case JDBC driver is missing, you might need to add it to the bot classpath in folder _/lib_ .
 
 ### Spring Boot specific configuration
 
@@ -84,6 +97,24 @@ retrieve metrics.
 
 - `management.endpoints.web.exposure` can be used to control which endpoints to expose
 
+### Spring profiles
+
+All configurations mentioned so far can be defined directly under default profile in the `application.yaml`. However the
+application
+still comes with two main profiles by default, `default` and `api`, in order to have a quick setup to start the
+application according to
+their needs.
+
+`default` profile disables the management api and set the `wdk.workflows.path` to its default value _./workflows_, while
+`api` profile, on the other side, disables the `wdk.workflows.path`, but enables the management
+api, [shared data utility function](./reference.md#utility-functions), which requires a secondary data source.
+
+To run the application in a particular profile, start the app as shown below
+
+```shell
+java -jar workflow-bot-app.jar --spring.profiles.active=api
+```
+
 ## Monitoring
 
 By default, metrics are available on port 8081 under the `/actuator` path.
@@ -102,13 +133,14 @@ including:
 - workflow.process.completed
 - workflow.process.running
 
-More metrics are exposed by the WDK public api under /wdk. See [http://localhost:8080/wdk/swagger-ui/](http://localhost:8080/wdk/swagger-ui/#)
+More metrics are exposed by the WDK public api under /wdk.
+See [http://localhost:8080/wdk/swagger-ui/](http://localhost:8080/wdk/swagger-ui/#)
 
 ## Management
 
-Users can deploy, update and delete a workflow through WDK management API under `/manangement/workflows` path.
+Users can deploy, update and delete a workflow through WDK management API under `/workflows` path.
 
-Note: 
+Note:
 
 - the API requests require the management token in the header [X-Management-Token](#workflow-bot-specific-configuration)
 - remember to use [publish property](./reference.md#properties) in order to create a workflow without deploying.

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaEngineConfiguration.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaEngineConfiguration.java
@@ -18,6 +18,7 @@ import org.camunda.bpm.spring.boot.starter.configuration.Ordering;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 
+import java.util.Optional;
 import javax.script.Bindings;
 import javax.script.ScriptEngine;
 
@@ -29,7 +30,7 @@ public class CamundaEngineConfiguration implements ProcessEnginePlugin {
 
   private final BdkGateway bdkGateway;
 
-  private final SharedDataStore sharedDataStore;
+  private final Optional<SharedDataStore> sharedDataStore;
 
   @Override
   public void preInit(ProcessEngineConfigurationImpl processEngineConfiguration) {
@@ -60,8 +61,9 @@ public class CamundaEngineConfiguration implements ProcessEnginePlugin {
 
   @Override
   public void postInit(ProcessEngineConfigurationImpl processEngineConfiguration) {
-    processEngineConfiguration.getBeans().put(
-        UtilityFunctionsMapper.WDK_PREFIX, new UtilityFunctionsMapper(this.bdkGateway.session(), this.sharedDataStore));
+    processEngineConfiguration.getBeans()
+        .put(UtilityFunctionsMapper.WDK_PREFIX,
+            new UtilityFunctionsMapper(this.bdkGateway.session(), this.sharedDataStore.orElse(null)));
     handleScriptExceptionsAsBpmnErrors(processEngineConfiguration);
   }
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaExecutor.java
@@ -42,6 +42,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Slf4j
 @Component
@@ -73,12 +74,12 @@ public class CamundaExecutor implements JavaDelegate {
   }
 
   private final BdkGateway bdk;
-  private final SharedDataStore sharedDataStore;
+  private final Optional<SharedDataStore> sharedDataStore;
   private final AuditTrailLogAction auditTrailLogger;
   private final ResourceProvider resourceLoader;
   private final ApplicationContext applicationContext;
 
-  public CamundaExecutor(BdkGateway bdk, SharedDataStore sharedDataStore, AuditTrailLogAction auditTrailLogger,
+  public CamundaExecutor(BdkGateway bdk, Optional<SharedDataStore> sharedDataStore, AuditTrailLogAction auditTrailLogger,
       @Qualifier("workflowResourcesProvider") ResourceProvider resourceLoader, ApplicationContext applicationContext) {
     this.bdk = bdk;
     this.sharedDataStore = sharedDataStore;
@@ -118,7 +119,7 @@ public class CamundaExecutor implements JavaDelegate {
       setMdc(execution);
       auditTrailLogger.execute(execution, activity.getClass().getSimpleName());
       executor.execute(
-          new CamundaActivityExecutorContext(execution, activity, event, resourceLoader, bdk, sharedDataStore));
+          new CamundaActivityExecutorContext(execution, activity, event, resourceLoader, bdk, sharedDataStore.orElse(null)));
     } catch (Exception e) {
       log.error(String.format("Activity from workflow %s failed", execution.getProcessDefinitionId()), e);
       logErrorVariables(execution, activity, e);

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/UtilityFunctionsMapper.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/UtilityFunctionsMapper.java
@@ -15,7 +15,6 @@ import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.camunda.bpm.engine.impl.javax.el.FunctionMapper;
 import org.camunda.bpm.engine.impl.util.ReflectUtil;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.lang.reflect.Method;
 import java.util.Collections;
@@ -39,7 +38,6 @@ public class UtilityFunctionsMapper extends FunctionMapper {
     UtilityFunctionsMapper.sharedDataStore = sharedDataStore;
   }
 
-  @Autowired
   public UtilityFunctionsMapper(SessionService sessionService, SharedDataStore sharedDataStore) {
     setStaticSessionService(sessionService);
     setSharedStateService(sharedDataStore);
@@ -74,10 +72,12 @@ public class UtilityFunctionsMapper extends FunctionMapper {
     FUNCTION_MAP.put(CASHTAGS, ReflectUtil.getMethod(UtilityFunctionsMapper.class, CASHTAGS, Object.class));
     FUNCTION_MAP.put(EMOJIS, ReflectUtil.getMethod(UtilityFunctionsMapper.class, ESCAPE, Object.class));
     FUNCTION_MAP.put(SESSION, ReflectUtil.getMethod(UtilityFunctionsMapper.class, SESSION));
-    FUNCTION_MAP.put(READSHARED,
-        ReflectUtil.getMethod(UtilityFunctionsMapper.class, READSHARED, String.class, String.class));
-    FUNCTION_MAP.put(WRITESHARED,
-        ReflectUtil.getMethod(UtilityFunctionsMapper.class, WRITESHARED, String.class, String.class, Object.class));
+    if (sharedDataStore != null) {
+      FUNCTION_MAP.put(READSHARED,
+          ReflectUtil.getMethod(UtilityFunctionsMapper.class, READSHARED, String.class, String.class));
+      FUNCTION_MAP.put(WRITESHARED,
+          ReflectUtil.getMethod(UtilityFunctionsMapper.class, WRITESHARED, String.class, String.class, Object.class));
+    }
   }
 
   @Override

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/shared/DefaultSharedDataStore.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/shared/DefaultSharedDataStore.java
@@ -1,5 +1,6 @@
 package com.symphony.bdk.workflow.shared;
 
+import com.symphony.bdk.workflow.configuration.ConditionalOnPropertyNotEmpty;
 import com.symphony.bdk.workflow.engine.executor.SharedDataStore;
 
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
+@ConditionalOnPropertyNotEmpty("wdk.properties.management-token")
 @Transactional(propagation = Propagation.REQUIRES_NEW)
 public class DefaultSharedDataStore implements SharedDataStore {
   private final SharedDataRepository repository;

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/shared/SharedDataRepository.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/shared/SharedDataRepository.java
@@ -1,11 +1,14 @@
 package com.symphony.bdk.workflow.shared;
 
+import com.symphony.bdk.workflow.configuration.ConditionalOnPropertyNotEmpty;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
+@ConditionalOnPropertyNotEmpty("wdk.properties.management-token")
 public interface SharedDataRepository extends JpaRepository<SharedData, String> {
   Optional<SharedData> findByNamespace(String namespace);
 }

--- a/workflow-bot-app/src/main/resources/application-api.yaml
+++ b/workflow-bot-app/src/main/resources/application-api.yaml
@@ -1,0 +1,15 @@
+# WDK configuration
+wdk:
+  workflows:
+    path:
+  properties:
+    management-token: ${wdk.management.token:token} # The default value is an empty String
+
+# Spring boot configuration
+spring:
+  datasource:
+    wdk:
+      username: sa
+      password: sa
+      driver-class-name: org.h2.Driver
+      jdbc-url: jdbc:h2:mem:wdk_workflow;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE

--- a/workflow-bot-app/src/main/resources/application-local.yaml
+++ b/workflow-bot-app/src/main/resources/application-local.yaml
@@ -1,7 +1,5 @@
 # WDK configuration
 wdk:
-  workflows:
-    path: ./workflows
   properties:
     monitoring-token: token # The default value is an empty String
 

--- a/workflow-bot-app/src/main/resources/application.yaml
+++ b/workflow-bot-app/src/main/resources/application.yaml
@@ -1,10 +1,9 @@
 # WDK configuration
 wdk:
   workflows:
-    path:
+    path: ./workflows
   properties:
     monitoring-token: ${wdk.monitoring.token:} # The default value is an empty String
-    management-token: ${wdk.management.token:} # The default value is an empty String
     schedule:
       pool-size: ${wdk.pool.size:20}
 
@@ -40,11 +39,6 @@ camunda:
 # Spring boot configuration
 spring:
   datasource:
-    wdk:
-      username: sa
-      password: sa
-      driver-class-name: org.h2.Driver
-      jdbc-url: jdbc:h2:mem:wdk_workflow;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     camunda:
       username: sa
       password: sa


### PR DESCRIPTION
Add a new spring profile, called "api", so that the default profile stick with disk swadl deploy mode, and "api" profile is to enable managment api mode.

These profiles are meant to help wdk clients have a quick application setup according to their needs, after all, all configurations can be directly defined into the default profile.

### Description
Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced a ticket in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
