### PR TITLE
Fix issue to support multi timer fired event

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaEngine.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/CamundaEngine.java
@@ -149,8 +149,8 @@ public class CamundaEngine implements WorkflowEngine<CamundaTranslatedWorkflowCo
       // Event coming from BDK DF is a sub type of V4Event since fix of https://github.com/finos/symphony-bdk-java/issues/741.
       // this change requires to read the super class to get the right processor mapping instead of the raw event type.
       // However many tests are still injecting the raw event type, so we do the check as below
-      Class<?> clazz = EventPayload.class.isAssignableFrom(event.getSource().getClass()) ?
-          event.getSource().getClass().getSuperclass() : event.getSource().getClass();
+      Class<?> clazz = EventPayload.class.isAssignableFrom(event.getSource().getClass())
+          ? event.getSource().getClass().getSuperclass() : event.getSource().getClass();
       ((RealTimeEventProcessor<T>) processorRegistry.get(clazz.getSimpleName())).process(event);
     } catch (Exception e) {
       log.error("This error happens when the incoming event has an invalid PresentationML message", e);

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/CamundaBpmnBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/CamundaBpmnBuilder.java
@@ -13,7 +13,7 @@ import com.symphony.bdk.workflow.engine.WorkflowNode;
 import com.symphony.bdk.workflow.engine.WorkflowNodeType;
 import com.symphony.bdk.workflow.engine.camunda.CamundaTranslatedWorkflowContext;
 import com.symphony.bdk.workflow.engine.camunda.WorkflowDirectedGraphService;
-import com.symphony.bdk.workflow.engine.camunda.bpmn.builder.WorkflowNodeBpmnBuilderFactory;
+import com.symphony.bdk.workflow.engine.camunda.bpmn.builder.WorkflowNodeBpmnBuilderRegistry;
 import com.symphony.bdk.workflow.engine.camunda.variable.VariablesListener;
 import com.symphony.bdk.workflow.swadl.v1.Workflow;
 
@@ -48,7 +48,7 @@ public class CamundaBpmnBuilder {
   public static final String FORK_GATEWAY = "_fork_gateway";
 
   private final RepositoryService repositoryService;
-  private final WorkflowNodeBpmnBuilderFactory builderFactory;
+  private final WorkflowNodeBpmnBuilderRegistry builderFactory;
   private final SessionService sessionService;
   private final WorkflowDirectedGraphService directedGraphService;
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/FormRepliedNodeBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/FormRepliedNodeBuilder.java
@@ -43,26 +43,31 @@ public class FormRepliedNodeBuilder extends AbstractNodeBpmnBuilder {
           .name(element.getEventId())
           .message(element.getId());
     } else {
-      // cache the sub process builder, the form reply might have a brother event,
-      // which is going to use this cached builder
-      SubProcessBuilder subProcess = builder.subProcess();
-      context.cacheSubProcess(subProcess);
-
-      timeoutFlow(element, subProcess);
-      // we add the form reply event sub process inside the subprocess
-      EventSubProcessBuilder subProcessBuilder = subProcess.camundaAsyncBefore().embeddedSubProcess().eventSubProcess();
-      // cache the sub process builder, so to terminate it later
-      context.cacheEventSubProcessToDone(subProcessBuilder);
-
-      return subProcessBuilder.startEvent()
-          .camundaExecutionListenerClass(ExecutionListener.EVENTNAME_START, FormVariableListener.class)
-          .camundaAsyncBefore()
-          // run multiple instances of the sub process (i.e. multiple replies) if it's true,
-          // otherwise execute only once, as exclusive
-          .interrupting(false)
-          .message(element.getId())
-          .name(element.getEventId());
+      return getSubProcessBuilder(element, builder, context);
     }
+  }
+
+  private StartEventBuilder getSubProcessBuilder(WorkflowNode element, AbstractFlowNodeBuilder<?, ?> builder,
+      BuildProcessContext context) {
+    // cache the sub process builder, the form reply might have a brother event,
+    // which is going to use this cached builder
+    SubProcessBuilder subProcess = builder.subProcess();
+    context.cacheSubProcess(subProcess);
+
+    timeoutFlow(element, subProcess);
+    // we add the form reply event sub process inside the subprocess
+    EventSubProcessBuilder subProcessBuilder = subProcess.camundaAsyncBefore().embeddedSubProcess().eventSubProcess();
+    // cache the sub process builder, so to terminate it later
+    context.cacheEventSubProcessToDone(subProcessBuilder);
+
+    return subProcessBuilder.startEvent()
+        .camundaExecutionListenerClass(ExecutionListener.EVENTNAME_START, FormVariableListener.class)
+        .camundaAsyncBefore()
+        // run multiple instances of the sub process (i.e. multiple replies) if it's true,
+        // otherwise execute only once, as exclusive
+        .interrupting(false)
+        .message(element.getId())
+        .name(element.getEventId());
   }
 
   private void timeoutFlow(WorkflowNode element, SubProcessBuilder subProcess) {

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/WorkflowNodeBpmnBuilderRegistry.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/WorkflowNodeBpmnBuilderRegistry.java
@@ -11,10 +11,10 @@ import java.util.List;
 import java.util.Map;
 
 @Component
-public class WorkflowNodeBpmnBuilderFactory {
+public class WorkflowNodeBpmnBuilderRegistry {
   private final Map<WorkflowNodeType, WorkflowNodeBpmnBuilder> factory;
 
-  public WorkflowNodeBpmnBuilderFactory(@Autowired List<WorkflowNodeBpmnBuilder> builders) {
+  public WorkflowNodeBpmnBuilderRegistry(@Autowired List<WorkflowNodeBpmnBuilder> builders) {
     factory = new EnumMap<>(WorkflowNodeType.class);
     builders.forEach(builder -> factory.put(builder.type(), builder));
   }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/event/EventVisitor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/event/EventVisitor.java
@@ -8,5 +8,14 @@ public interface EventVisitor {
 
   boolean predict(Event event);
 
+  /**
+   * Triple, left value is the optional custom defined event id, which might be null;
+   * middle is the event name; right is the event type
+   *
+   * @param event      current event, from which the triple info is extract
+   * @param workflowId id of workflow
+   * @param botName    bot display name
+   * @return info in triple
+   */
   Triple<String, String, Class<?>> getEventTripleInfo(Event event, String workflowId, String botName);
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/event/WorkflowEventType.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/event/WorkflowEventType.java
@@ -242,7 +242,9 @@ public enum WorkflowEventType implements EventVisitor {
     public Triple<String, String, Class<?>> getEventTripleInfo(Event event, String workflowId, String botName) {
       String name = this.getEventName();
       if (StringUtils.isNotEmpty(event.getTimerFired().getRepeat())) {
-        name = "timerFired_cycle";
+        name = "timerFired_cycle_" + event.getTimerFired().getRepeat();
+      } else {
+        name += "_" + event.getTimerFired().getAt();
       }
       return Triple.of(event.getTimerFired().getId(), name, TimerFiredEvent.class);
     }

--- a/workflow-bot-app/src/test/resources/event/timer/timer-multiple-at.swadl.yaml
+++ b/workflow-bot-app/src/test/resources/event/timer/timer-multiple-at.swadl.yaml
@@ -1,0 +1,18 @@
+id: timer-repeat-intermediate
+activities:
+  - send-message:
+      id: start
+      on:
+        timer-fired:
+          at: 2020-05-02T09:10:32
+      to:
+        stream-id: abc
+      content: start
+  - send-message:
+      id: next
+      on:
+        timer-fired:
+          at: 2023-05-02T15:32:32
+      to:
+        stream-id: abc
+      content: end

--- a/workflow-language/src/main/resources/swadl-schema-1.0.json
+++ b/workflow-language/src/main/resources/swadl-schema-1.0.json
@@ -1082,6 +1082,9 @@
                             },
                             {
                                 "$ref": "#/definitions/connection-accepted-event"
+                            },
+                            {
+                                "$ref": "#/definitions/timer-fired-event"
                             }
                         ]
                     }


### PR DESCRIPTION
A map is used to register the events and activities in the workflow graph, timer fired event uses a fixed string as id, in case there is several multi timers, the latest one overwrites the previous ones.

This commit fixed the issue by appending timer value to the event name, so they should be unique most of time, except if the timer value is the same (work around is to use all-of).

### Description
Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced a ticket in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
