### PR TITLE
Fix exception message missing bug

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/api/v1/dto/SecretView.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/api/v1/dto/SecretView.java
@@ -1,13 +1,17 @@
 package com.symphony.bdk.workflow.api.v1.dto;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+@ApiModel
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class SecretView {
   private String key;
+  @ApiModelProperty(name = "secret", dataType = "java.lang.String", required = true)
   private char[] secret;
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/event/V4MessageSentEventProcessor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/event/V4MessageSentEventProcessor.java
@@ -59,6 +59,7 @@ public class V4MessageSentEventProcessor extends AbstractRealTimeEventProcessor<
             args.put(EVENT_NAME_KEY, signal.getEventName());
             ((EventHolder) variables.get(ActivityExecutorContext.EVENT)).setArgs(args);
 
+            log.debug("Send a signal named {} upon the received message", signal.getEventName());
             runtimeService.createSignalEvent(signal.getEventName())
                 .setVariables(variables)
                 .send();

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/logs/LogsStreamingAppender.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/logs/LogsStreamingAppender.java
@@ -1,15 +1,12 @@
 package com.symphony.bdk.workflow.logs;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.classic.spi.StackTraceElementProxy;
+import ch.qos.logback.classic.spi.ThrowableProxyUtil;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.stereotype.Component;
-
-import java.util.Arrays;
-import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -24,10 +21,8 @@ public class LogsStreamingAppender extends UnsynchronizedAppenderBase<ILoggingEv
     messageBuilder.append(eventObject.getFormattedMessage());
 
     if (eventObject.getThrowableProxy() != null) {
-      messageBuilder.append("\n")
-              .append(Arrays.stream(eventObject.getThrowableProxy().getStackTraceElementProxyArray())
-                      .map(StackTraceElementProxy::getSTEAsString)
-                      .collect(Collectors.joining("\n")));
+      messageBuilder.append("\n");
+      messageBuilder.append(ThrowableProxyUtil.asString(eventObject.getThrowableProxy()));
     }
 
     String formattedMessage = messageBuilder.toString().replaceAll("(\\r|\\n|\\r\\n)+", "\t");

--- a/workflow-bot-app/src/main/resources/application.yaml
+++ b/workflow-bot-app/src/main/resources/application.yaml
@@ -75,8 +75,7 @@ server:
 
 logging:
   pattern:
-    file: "%d{yyyy-MM-dd'T'HH:mm:ss,SSS}Z %-5level [%t] %C{-15}: %m proc.id=%mdc{X-PROCESS-ID} act.id=%mdc{X-ACTIVITY-ID} %n%xEx"
-    console: "%d{yyyy-MM-dd'T'HH:mm:ss,SSS}Z %-5level [%t] %C{-15}: %m proc.id=%mdc{X-PROCESS-ID} act.id=%mdc{X-ACTIVITY-ID} %n%xEx"
+    console: "%d{yyyy-MM-dd'T'HH:mm:ss,SSS}Z %-5level [%t] %C{-15}: %m %n%xEx"
   level:
     com.symphony: DEBUG
     # Troubleshoot Camunda by setting lower log level

--- a/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/logs/LogsStreamingAppenderTest.java
+++ b/workflow-bot-app/src/test/java/com/symphony/bdk/workflow/logs/LogsStreamingAppenderTest.java
@@ -37,13 +37,14 @@ class LogsStreamingAppenderTest {
 
     StackTraceElement stackTraceElement = new StackTraceElement("class", "method", "filename", 1);
     Throwable throwable = new Throwable();
-    throwable.setStackTrace(new StackTraceElement[]{stackTraceElement});
+    throwable.setStackTrace(new StackTraceElement[] {stackTraceElement});
     ThrowableProxy throwableProxy = new ThrowableProxy(throwable);
     when(event.getThrowableProxy()).thenReturn(throwableProxy);
 
     doNothing().when(service).broadcast(anyLong(), anyString(), anyString(), anyString());
     appender.append(event);
-    verify(service).broadcast(anyLong(), anyString(), eq("www"), eq("log message\tat class.method(filename:1)"));
+    verify(service).broadcast(anyLong(), anyString(), eq("www"),
+        eq("log message\tjava.lang.Throwable: null\t\tat class.method(filename:1)\t"));
   }
 
   @Test


### PR DESCRIPTION
The exception message was missing in the log appender. This commit fix the bug by using the Logback ThrowableProxyUtil to parse the stacktrace into string, so all info about the exception is in the final string.

### Description
Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced a ticket in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
