### PR TITLE
Fix activity variable size limit bug

### DIFF
--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/AbstractNodeBpmnBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/AbstractNodeBpmnBuilder.java
@@ -6,7 +6,6 @@ import static com.symphony.bdk.workflow.engine.camunda.bpmn.CamundaBpmnBuilder.E
 import com.symphony.bdk.workflow.engine.WorkflowNode;
 import com.symphony.bdk.workflow.engine.camunda.bpmn.BuildProcessContext;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.camunda.bpm.model.bpmn.builder.AbstractFlowNodeBuilder;
 import org.camunda.bpm.model.bpmn.builder.AbstractGatewayBuilder;
 import org.camunda.bpm.model.bpmn.builder.SubProcessBuilder;
@@ -15,7 +14,7 @@ public abstract class AbstractNodeBpmnBuilder implements WorkflowNodeBpmnBuilder
 
   @Override
   public AbstractFlowNodeBuilder<?, ?> connect(WorkflowNode element, String parentId,
-      AbstractFlowNodeBuilder<?, ?> builder, BuildProcessContext context) throws JsonProcessingException {
+      AbstractFlowNodeBuilder<?, ?> builder, BuildProcessContext context) {
     String nodeId = element.getId();
     if (context.isAlreadyBuilt(nodeId)) {
       if (element.isConditional()) {
@@ -63,5 +62,5 @@ public abstract class AbstractNodeBpmnBuilder implements WorkflowNodeBpmnBuilder
   }
 
   protected abstract AbstractFlowNodeBuilder<?, ?> build(WorkflowNode element, String parentId,
-      AbstractFlowNodeBuilder<?, ?> builder, BuildProcessContext context) throws JsonProcessingException;
+      AbstractFlowNodeBuilder<?, ?> builder, BuildProcessContext context);
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/ActivityExpiredNodeBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/ActivityExpiredNodeBuilder.java
@@ -5,7 +5,6 @@ import com.symphony.bdk.workflow.engine.WorkflowNodeType;
 import com.symphony.bdk.workflow.engine.camunda.bpmn.BuildProcessContext;
 import com.symphony.bdk.workflow.swadl.v1.EventWithTimeout;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.camunda.bpm.model.bpmn.builder.AbstractCatchEventBuilder;
 import org.camunda.bpm.model.bpmn.builder.AbstractFlowNodeBuilder;
 import org.camunda.bpm.model.bpmn.builder.AbstractGatewayBuilder;
@@ -17,7 +16,7 @@ public class ActivityExpiredNodeBuilder extends ActivityNodeBuilder {
 
   @Override
   public AbstractFlowNodeBuilder<?, ?> build(WorkflowNode element, String parentId,
-      AbstractFlowNodeBuilder<?, ?> builder, BuildProcessContext context) throws JsonProcessingException {
+      AbstractFlowNodeBuilder<?, ?> builder, BuildProcessContext context) {
     if (hasNoExclusiveFormReplyParent(element, context)) {
       if (context.hasTimeoutSubProcess()) {
         builder = context.removeLastSubProcessTimeoutBuilder();

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/ActivityFailedNodeBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/ActivityFailedNodeBuilder.java
@@ -4,7 +4,6 @@ import com.symphony.bdk.workflow.engine.WorkflowNode;
 import com.symphony.bdk.workflow.engine.WorkflowNodeType;
 import com.symphony.bdk.workflow.engine.camunda.bpmn.BuildProcessContext;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.camunda.bpm.model.bpmn.builder.AbstractActivityBuilder;
 import org.camunda.bpm.model.bpmn.builder.AbstractFlowNodeBuilder;
 import org.springframework.stereotype.Component;
@@ -14,17 +13,13 @@ public class ActivityFailedNodeBuilder extends ActivityNodeBuilder {
 
   @Override
   protected void connectToExistingNode(String nodeId, AbstractFlowNodeBuilder<?, ?> builder) {
-    ((AbstractActivityBuilder<?, ?>) builder).boundaryEvent()
-        .name("error_" + nodeId)
-        .error().connectTo(nodeId);
+    ((AbstractActivityBuilder<?, ?>) builder).boundaryEvent().name("error_" + nodeId).error().connectTo(nodeId);
   }
 
   @Override
   public AbstractFlowNodeBuilder<?, ?> build(WorkflowNode element, String parentId,
-      AbstractFlowNodeBuilder<?, ?> builder, BuildProcessContext context) throws JsonProcessingException {
-    builder = ((AbstractActivityBuilder<?, ?>) builder).boundaryEvent()
-        .name("error_" + element.getId())
-        .error();
+      AbstractFlowNodeBuilder<?, ?> builder, BuildProcessContext context) {
+    builder = ((AbstractActivityBuilder<?, ?>) builder).boundaryEvent().name("error_" + element.getId()).error();
     return addTask(builder, element.getActivity());
   }
 

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/ActivityNodeBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/ActivityNodeBuilder.java
@@ -9,7 +9,6 @@ import com.symphony.bdk.workflow.swadl.ActivityRegistry;
 import com.symphony.bdk.workflow.swadl.v1.activity.BaseActivity;
 import com.symphony.bdk.workflow.swadl.v1.activity.ExecuteScript;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.camunda.bpm.engine.delegate.ExecutionListener;
 import org.camunda.bpm.model.bpmn.builder.AbstractFlowNodeBuilder;
 import org.springframework.stereotype.Component;
@@ -19,7 +18,7 @@ public class ActivityNodeBuilder extends AbstractNodeBpmnBuilder {
 
   @Override
   public AbstractFlowNodeBuilder<?, ?> build(WorkflowNode element, String parentId,
-      AbstractFlowNodeBuilder<?, ?> builder, BuildProcessContext context) throws JsonProcessingException {
+      AbstractFlowNodeBuilder<?, ?> builder, BuildProcessContext context) {
     return addTask(builder, element.getActivity());
   }
 
@@ -28,8 +27,7 @@ public class ActivityNodeBuilder extends AbstractNodeBpmnBuilder {
     return WorkflowNodeType.ACTIVITY;
   }
 
-  protected AbstractFlowNodeBuilder<?, ?> addTask(AbstractFlowNodeBuilder<?, ?> eventBuilder, BaseActivity activity)
-      throws JsonProcessingException {
+  protected AbstractFlowNodeBuilder<?, ?> addTask(AbstractFlowNodeBuilder<?, ?> eventBuilder, BaseActivity activity) {
     // hardcoded so we can rely on Camunda's script task instead of a service task
     if (activity instanceof ExecuteScript) {
       return addScriptTask(eventBuilder, (ExecuteScript) activity);
@@ -48,8 +46,7 @@ public class ActivityNodeBuilder extends AbstractNodeBpmnBuilder {
         .camundaExecutionListenerClass(ExecutionListener.EVENTNAME_START, ScriptTaskAuditListener.class);
   }
 
-  private AbstractFlowNodeBuilder<?, ?> addServiceTask(AbstractFlowNodeBuilder<?, ?> builder, BaseActivity activity)
-      throws JsonProcessingException {
+  private AbstractFlowNodeBuilder<?, ?> addServiceTask(AbstractFlowNodeBuilder<?, ?> builder, BaseActivity activity) {
     return builder.serviceTask()
         .id(activity.getId())
         .name(activity.getId())
@@ -57,6 +54,6 @@ public class ActivityNodeBuilder extends AbstractNodeBpmnBuilder {
         .camundaClass(CamundaExecutor.class)
         .camundaInputParameter(CamundaExecutor.EXECUTOR,
             ActivityRegistry.getActivityExecutors().get(activity.getClass()).getName())
-        .camundaInputParameter(CamundaExecutor.ACTIVITY, CamundaExecutor.OBJECT_MAPPER.writeValueAsString(activity));
+        .camundaInputParameter(CamundaExecutor.ACTIVITY, activity.getId());
   }
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/JoinActivityNodeBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/JoinActivityNodeBuilder.java
@@ -5,7 +5,6 @@ import com.symphony.bdk.workflow.engine.WorkflowNodeType;
 import com.symphony.bdk.workflow.engine.camunda.bpmn.BuildProcessContext;
 import com.symphony.bdk.workflow.engine.camunda.variable.FormVariableListener;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.camunda.bpm.engine.delegate.ExecutionListener;
 import org.camunda.bpm.model.bpmn.builder.AbstractFlowNodeBuilder;
 import org.springframework.stereotype.Component;
@@ -14,7 +13,7 @@ import org.springframework.stereotype.Component;
 public class JoinActivityNodeBuilder extends AbstractNodeBpmnBuilder {
   @Override
   protected AbstractFlowNodeBuilder<?, ?> build(WorkflowNode element, String parentId,
-      AbstractFlowNodeBuilder<?, ?> builder, BuildProcessContext context) throws JsonProcessingException {
+      AbstractFlowNodeBuilder<?, ?> builder, BuildProcessContext context) {
     return builder.parallelGateway(element.getId())
         .camundaExecutionListenerClass(ExecutionListener.EVENTNAME_START, FormVariableListener.class);
   }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/WorkflowNodeBpmnBuilder.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/camunda/bpmn/builder/WorkflowNodeBpmnBuilder.java
@@ -4,7 +4,6 @@ import com.symphony.bdk.workflow.engine.WorkflowNode;
 import com.symphony.bdk.workflow.engine.WorkflowNodeType;
 import com.symphony.bdk.workflow.engine.camunda.bpmn.BuildProcessContext;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.camunda.bpm.model.bpmn.builder.AbstractFlowNodeBuilder;
 
 public interface WorkflowNodeBpmnBuilder {
@@ -12,7 +11,7 @@ public interface WorkflowNodeBpmnBuilder {
   String DEFAULT_FORM_REPLIED_EVENT_TIMEOUT = "PT24H";
 
   AbstractFlowNodeBuilder<?, ?> connect(WorkflowNode element, String parentId, AbstractFlowNodeBuilder<?, ?> builder,
-      BuildProcessContext context) throws JsonProcessingException;
+      BuildProcessContext context);
 
   WorkflowNodeType type();
 }

--- a/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/ExecuteRequestExecutor.java
+++ b/workflow-bot-app/src/main/java/com/symphony/bdk/workflow/engine/executor/request/ExecuteRequestExecutor.java
@@ -1,7 +1,5 @@
 package com.symphony.bdk.workflow.engine.executor.request;
 
-import static com.symphony.bdk.workflow.engine.camunda.CamundaExecutor.OBJECT_MAPPER;
-
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutor;
 import com.symphony.bdk.workflow.engine.executor.ActivityExecutorContext;
 import com.symphony.bdk.workflow.engine.executor.request.client.HttpClient;
@@ -45,12 +43,10 @@ public class ExecuteRequestExecutor implements ActivityExecutor<ExecuteRequest> 
             headersToString(activity.getHeaders()));
 
     log.info("Received response {}", response.getCode());
-    String valueAsString = OBJECT_MAPPER.writeValueAsString(response.getContent());
 
     Map<String, Object> outputs = new HashMap<>();
     outputs.put(OUTPUT_STATUS_KEY, response.getCode());
-    outputs.put(OUTPUT_BODY_KEY,
-        valueAsString.length() > 1000 ? valueAsString.substring(0, 1000) : response.getContent());
+    outputs.put(OUTPUT_BODY_KEY, response.getContent());
     execution.setOutputVariables(outputs);
   }
 


### PR DESCRIPTION
The activity json string input variable might be too big to be stored in DB (4000 characters limit), e.g. the activity json string contains a variable being resolved at runtime with a more than 4000 characters string value, when camunda persists this new activity json string as variable in DB, it fails with an exception.

This commit fixed this issue by definiting the input activity string in a map instead of string, the map object is stored in bytearray table as BLOB type without limit.

### Description
Please put here the intent of your pull request.

### Dependencies
List the other pull requests that should be merged before/along this one.

### Checklist
- [ ] Referenced a ticket in the PR title or description
- [ ] Filled properly the description and dependencies, if any
- [ ] Unit/Integration tests updated or added
- [ ] Javadoc added or updated
- [ ] Updated the documentation in [docs folder](../docs)
